### PR TITLE
Refactor activity routing into shared configuration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,70 +1,16 @@
-import { useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import ActivitySelector from "./pages/ActivitySelector";
-import PromptDojo from "./pages/PromptDojo";
-import ClarityPath from "./pages/ClarityPath";
-import ClarteDabord from "./pages/ClarteDabord";
-import WorkshopRoutes from "./pages/WorkshopRoutes";
-import type { ModelConfig } from "./config";
-import { MODEL_OPTIONS } from "./config";
-
-export interface Flashcard {
-  question: string;
-  reponse: string;
-}
-
-const DEFAULT_TEXT = `L'automatisation est particulièrement utile pour structurer des notes de cours, créer des rappels et générer des résumés ciblés. Les étudiantes et étudiants qui savent dialoguer avec l'IA peuvent obtenir des analyses précises, du survol rapide jusqu'à des synthèses détaillées. Comprendre comment ajuster les paramètres du modèle aide à mieux contrôler la production, à gagner du temps et à repérer les limites de l'outil.`;
-
-const DEFAULT_CONFIG_A: ModelConfig = {
-  model: MODEL_OPTIONS[0].value,
-  verbosity: "medium",
-  thinking: "minimal",
-};
-
-const DEFAULT_CONFIG_B: ModelConfig = {
-  model: MODEL_OPTIONS[1].value,
-  verbosity: "high",
-  thinking: "high",
-};
+import { ACTIVITY_DEFINITIONS } from "./config/activities";
 
 function App(): JSX.Element {
-  const [sourceText, setSourceText] = useState(DEFAULT_TEXT);
-  const [configA, setConfigA] = useState<ModelConfig>(DEFAULT_CONFIG_A);
-  const [configB, setConfigB] = useState<ModelConfig>(DEFAULT_CONFIG_B);
-  const [summaryA, setSummaryA] = useState("");
-  const [summaryB, setSummaryB] = useState("");
-  const [flashcardsA, setFlashcardsA] = useState<Flashcard[]>([]);
-  const [flashcardsB, setFlashcardsB] = useState<Flashcard[]>([]);
-
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/activites" replace />} />
       <Route path="/activites" element={<ActivitySelector />} />
-      <Route path="/prompt-dojo" element={<PromptDojo />} />
-      <Route path="/parcours-clarte" element={<ClarityPath />} />
-      <Route path="/clarte-dabord" element={<ClarteDabord />} />
-      <Route
-        path="/atelier/*"
-        element={
-          <WorkshopRoutes
-            sourceText={sourceText}
-            setSourceText={setSourceText}
-            configA={configA}
-            configB={configB}
-            setConfigA={setConfigA}
-            setConfigB={setConfigB}
-            summaryA={summaryA}
-            summaryB={summaryB}
-            setSummaryA={setSummaryA}
-            setSummaryB={setSummaryB}
-            flashcardsA={flashcardsA}
-            flashcardsB={flashcardsB}
-            setFlashcardsA={setFlashcardsA}
-            setFlashcardsB={setFlashcardsB}
-          />
-        }
-      />
+      {ACTIVITY_DEFINITIONS.map((definition) => (
+        <Route key={definition.id} path={definition.path} element={definition.element} />
+      ))}
       <Route path="*" element={<Navigate to="/activites" replace />} />
     </Routes>
   );

--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -1,0 +1,88 @@
+import ClarityPath from "../pages/ClarityPath";
+import ClarteDabord from "../pages/ClarteDabord";
+import PromptDojo from "../pages/PromptDojo";
+import WorkshopExperience from "../pages/WorkshopExperience";
+
+export interface ActivityDefinition {
+  id: string;
+  title: string;
+  description: string;
+  highlights: string[];
+  cta: {
+    label: string;
+    to: string;
+  };
+  path: string;
+  element: JSX.Element;
+}
+
+export const ACTIVITY_DEFINITIONS: ActivityDefinition[] = [
+  {
+    id: "atelier",
+    title: "Atelier comparatif IA",
+    description:
+      "Objectif : cadrer ta demande, comparer deux configurations IA et capitaliser sur les essais.",
+    highlights: [
+      "Définir le contexte et les attentes",
+      "Tester modèle, verbosité et raisonnement",
+      "Assembler une synthèse réutilisable",
+    ],
+    cta: {
+      label: "Lancer l’atelier",
+      to: "/atelier/etape-1",
+    },
+    path: "/atelier/*",
+    element: <WorkshopExperience />,
+  },
+  {
+    id: "prompt-dojo",
+    title: "Prompt Dojo — Mission débutant",
+    description:
+      "Objectif : t’entraîner à affiner une consigne en suivant des défis progressifs.",
+    highlights: [
+      "Défis à difficulté graduelle",
+      "Retour immédiat sur la qualité du prompt",
+      "Construction d’une version finale personnalisée",
+    ],
+    cta: {
+      label: "Entrer dans le dojo",
+      to: "/prompt-dojo",
+    },
+    path: "/prompt-dojo",
+    element: <PromptDojo />,
+  },
+  {
+    id: "clarity",
+    title: "Parcours de la clarté",
+    description:
+      "Objectif : expérimenter la précision des consignes sur un parcours 10×10.",
+    highlights: [
+      "Plan d’action IA généré avant l’animation",
+      "Visualisation pas à pas avec obstacles",
+      "Analyse des tentatives et du surcoût",
+    ],
+    cta: {
+      label: "Tester la clarté",
+      to: "/parcours-clarte",
+    },
+    path: "/parcours-clarte",
+    element: <ClarityPath />,
+  },
+  {
+    id: "clarte-dabord",
+    title: "Clarté d’abord !",
+    description:
+      "Objectif : mesurer l’impact d’un brief incomplet et révéler la checklist idéale.",
+    highlights: [
+      "Deux missions thématiques en trois manches",
+      "Champs guidés avec validations pédagogiques",
+      "Révélation finale et export JSON du menu",
+    ],
+    cta: {
+      label: "Lancer Clarté d’abord !",
+      to: "/clarte-dabord",
+    },
+    path: "/clarte-dabord",
+    element: <ClarteDabord />,
+  },
+];

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -3,61 +3,10 @@ import { Link } from "react-router-dom";
 
 import logoPrincipal from "../assets/logo_principal.svg";
 import { getProgress, type ProgressResponse } from "../api";
-
-const ACTIVITIES = [
-  {
-    id: "atelier",
-    title: "Atelier comparatif IA",
-    description:
-      "Objectif : cadrer ta demande, comparer deux configurations IA et capitaliser sur les essais.",
-    highlights: [
-      "Définir le contexte et les attentes",
-      "Tester modèle, verbosité et raisonnement",
-      "Assembler une synthèse réutilisable",
-    ],
-    cta: "Lancer l’atelier",
-    to: "/atelier/etape-1",
-  },
-  {
-    id: "prompt-dojo",
-    title: "Prompt Dojo — Mission débutant",
-    description:
-      "Objectif : t’entraîner à affiner une consigne en suivant des défis progressifs.",
-    highlights: [
-      "Défis à difficulté graduelle",
-      "Retour immédiat sur la qualité du prompt",
-      "Construction d’une version finale personnalisée",
-    ],
-    cta: "Entrer dans le dojo",
-    to: "/prompt-dojo",
-  },
-  {
-    id: "clarity",
-    title: "Parcours de la clarté",
-    description:
-      "Objectif : expérimenter la précision des consignes sur un parcours 10×10.",
-    highlights: [
-      "Plan d’action IA généré avant l’animation",
-      "Visualisation pas à pas avec obstacles",
-      "Analyse des tentatives et du surcoût",
-    ],
-    cta: "Tester la clarté",
-    to: "/parcours-clarte",
-  },
-  {
-    id: "clarte-dabord",
-    title: "Clarté d’abord !",
-    description:
-      "Objectif : mesurer l’impact d’un brief incomplet et révéler la checklist idéale.",
-    highlights: [
-      "Deux missions thématiques en trois manches",
-      "Champs guidés avec validations pédagogiques",
-      "Révélation finale et export JSON du menu",
-    ],
-    cta: "Lancer Clarté d’abord !",
-    to: "/clarte-dabord",
-  },
-];
+import {
+  ACTIVITY_DEFINITIONS,
+  type ActivityDefinition,
+} from "../config/activities";
 
 function ActivitySelector(): JSX.Element {
   const [completedMap, setCompletedMap] = useState<Record<string, boolean>>({});
@@ -114,7 +63,7 @@ function ActivitySelector(): JSX.Element {
         </header>
 
         <div className="grid gap-6 md:grid-cols-2 animate-section-delayed">
-          {ACTIVITIES.map((activity) => (
+          {ACTIVITY_DEFINITIONS.map((activity: ActivityDefinition) => (
             <article
               key={activity.id}
               className="group relative flex h-full flex-col gap-6 rounded-3xl border border-white/60 bg-white/90 p-8 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg"
@@ -144,10 +93,10 @@ function ActivitySelector(): JSX.Element {
               </ul>
               <div className="mt-auto">
                 <Link
-                  to={activity.to}
+                  to={activity.cta.to}
                   className="cta-button cta-button--primary inline-flex items-center gap-2"
                 >
-                  {activity.cta}
+                  {activity.cta.label}
                   <span className="inline-block text-lg transition group-hover:translate-x-1">→</span>
                 </Link>
               </div>

--- a/frontend/src/pages/WorkshopExperience.tsx
+++ b/frontend/src/pages/WorkshopExperience.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+import { MODEL_OPTIONS, type ModelConfig } from "../config";
+import type { Flashcard } from "../types/flashcards";
+import WorkshopRoutes from "./WorkshopRoutes";
+
+const DEFAULT_TEXT = `L'automatisation est particulièrement utile pour structurer des notes de cours, créer des rappels et générer des résumés ciblés. Les étudiantes et étudiants qui savent dialoguer avec l'IA peuvent obtenir des analyses précises, du survol rapide jusqu'à des synthèses détaillées. Comprendre comment ajuster les paramètres du modèle aide à mieux contrôler la production, à gagner du temps et à repérer les limites de l'outil.`;
+
+const DEFAULT_CONFIG_A: ModelConfig = {
+  model: MODEL_OPTIONS[0].value,
+  verbosity: "medium",
+  thinking: "minimal",
+};
+
+const DEFAULT_CONFIG_B: ModelConfig = {
+  model: MODEL_OPTIONS[1].value,
+  verbosity: "high",
+  thinking: "high",
+};
+
+function WorkshopExperience(): JSX.Element {
+  const [sourceText, setSourceText] = useState(DEFAULT_TEXT);
+  const [configA, setConfigA] = useState<ModelConfig>(DEFAULT_CONFIG_A);
+  const [configB, setConfigB] = useState<ModelConfig>(DEFAULT_CONFIG_B);
+  const [summaryA, setSummaryA] = useState("");
+  const [summaryB, setSummaryB] = useState("");
+  const [flashcardsA, setFlashcardsA] = useState<Flashcard[]>([]);
+  const [flashcardsB, setFlashcardsB] = useState<Flashcard[]>([]);
+
+  return (
+    <WorkshopRoutes
+      sourceText={sourceText}
+      setSourceText={setSourceText}
+      configA={configA}
+      configB={configB}
+      setConfigA={setConfigA}
+      setConfigB={setConfigB}
+      summaryA={summaryA}
+      summaryB={summaryB}
+      setSummaryA={setSummaryA}
+      setSummaryB={setSummaryB}
+      flashcardsA={flashcardsA}
+      flashcardsB={flashcardsB}
+      setFlashcardsA={setFlashcardsA}
+      setFlashcardsB={setFlashcardsB}
+    />
+  );
+}
+
+export default WorkshopExperience;

--- a/frontend/src/pages/WorkshopRoutes.tsx
+++ b/frontend/src/pages/WorkshopRoutes.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, useMemo } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import Layout from "../components/Layout";
-import type { Flashcard } from "../App";
+import type { Flashcard } from "../types/flashcards";
 import type { ModelConfig } from "../config";
 import StepOne from "./StepOne";
 import StepThree from "./StepThree";

--- a/frontend/src/types/flashcards.ts
+++ b/frontend/src/types/flashcards.ts
@@ -1,0 +1,4 @@
+export interface Flashcard {
+  question: string;
+  reponse: string;
+}


### PR DESCRIPTION
## Summary
- add a shared activity catalog describing cards and route elements
- introduce a dedicated WorkshopExperience wrapper so the workshop keeps its own state while sharing the same configuration shape as other activities
- update the activity selector to consume the catalog and share CTA metadata
- extract the flashcard type for reuse across modules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9dda6e988322b1f2ee486cd68e38