### PR TITLE
Add admin LTI user stats and listing endpoint

### DIFF
--- a/backend/app/progress_store.py
+++ b/backend/app/progress_store.py
@@ -78,6 +78,11 @@ class ProgressStore:
             # return a deep copy that callers can modify safely
             return json.loads(json.dumps(bucket))
 
+    def list_identities(self) -> list[str]:
+        with self._lock:
+            identities = self._data.get("identities", {})
+            return list(identities.keys())
+
     def update_activity(self, identity: str, activity_id: str, completed: bool) -> ActivityRecord:
         with self._lock:
             bucket = self._identity_bucket(identity)

--- a/backend/tests/test_admin_lti_users.py
+++ b/backend/tests/test_admin_lti_users.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from backend.app.admin_store import AdminStore, AdminStoreError, AdminUser
+from backend.app.main import (
+    _require_admin_store,
+    _require_admin_user,
+    app,
+    get_progress_store,
+)
+from backend.app.progress_store import ProgressStore
+
+
+def test_record_lti_user_login_updates(tmp_path) -> None:
+    store = AdminStore(path=tmp_path / "admin.json")
+    first_login = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    second_login = datetime(2024, 1, 2, 8, 30, tzinfo=timezone.utc)
+
+    stat = store.record_lti_user_login(
+        "https://platform.example",
+        "learner-1",
+        name="Learner One",
+        email="learner1@example.com",
+        login_at=first_login,
+    )
+
+    assert stat.login_count == 1
+    assert stat.last_login_at.endswith("Z")
+    assert stat.first_login_at == stat.last_login_at
+
+    stat_updated = store.record_lti_user_login(
+        "https://platform.example",
+        "learner-1",
+        email="learner.one+alt@example.com",
+        login_at=second_login,
+    )
+
+    assert stat_updated.login_count == 2
+    assert stat_updated.email == "learner.one+alt@example.com"
+    assert stat_updated.first_login_at == stat.first_login_at
+    assert stat_updated.last_login_at.endswith("Z")
+
+    persisted = store.get_lti_user_stat("https://platform.example", "learner-1")
+    assert persisted is not None
+    assert persisted.login_count == 2
+
+    # defensive: ensure error raised on missing identifiers
+    try:
+        store.record_lti_user_login("", "")
+    except AdminStoreError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected AdminStoreError when identifiers are missing")
+
+
+def test_admin_list_lti_users_endpoint(tmp_path) -> None:
+    admin_store = AdminStore(path=tmp_path / "admin.json")
+    progress_store = ProgressStore(path=tmp_path / "progress.json")
+
+    login_time = datetime(2024, 3, 15, 9, 45, tzinfo=timezone.utc)
+    admin_store.record_lti_user_login(
+        "https://lti.example",
+        "student-42",
+        name="Student Example",
+        email="student@example.com",
+        login_at=login_time,
+    )
+
+    identity = "lti::https://lti.example::student-42"
+    progress_store.update_activity(identity, "mission-1", completed=True)
+    progress_store.update_activity(identity, "mission-2", completed=False)
+
+    dummy_admin = AdminUser(
+        username="tester",
+        password_hash="hash",
+        password_salt="salt",
+    )
+
+    app.dependency_overrides[_require_admin_user] = lambda: dummy_admin
+    app.dependency_overrides[_require_admin_store] = lambda: admin_store
+    app.dependency_overrides[get_progress_store] = lambda: progress_store
+
+    with TestClient(app) as client:
+        response = client.get("/api/admin/lti-users", params={"includeDetails": "true"})
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["page"] == 1
+    assert payload["pageSize"] == 50
+    assert payload["totalPages"] == 1
+
+    assert payload["items"], "Expected at least one user entry"
+    user = payload["items"][0]
+    assert user["issuer"] == "https://lti.example"
+    assert user["subject"] == "student-42"
+    assert user["displayName"] == "Student Example"
+    assert user["email"] == "student@example.com"
+    assert user["loginCount"] == 1
+    assert user["completedActivities"] == 1
+    assert user["completedActivityIds"] == ["mission-1"]
+    assert user.get("profileMissing") is False
+    assert user.get("completedActivitiesDetail")
+    assert user["completedActivitiesDetail"][0]["activityId"] == "mission-1"


### PR DESCRIPTION
## Summary
- persist LTI user metrics in the admin store and normalize issuer handling
- collect completion data from the progress store and expose `/api/admin/lti-users`
- increment stats on each LTI launch and cover the flow with backend tests

## Testing
- PYTHONPATH=. pytest backend/tests -q


------
https://chatgpt.com/codex/tasks/task_e_68cd1debfcc48322a624d5e368859c93