### PR TITLE
Protect workshop flow and enforce inputs

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -59,9 +59,13 @@ function Layout({ currentStep, children }: LayoutProps): JSX.Element {
                 ? "bg-white text-[color:var(--brand-black)]"
                 : "bg-white/70 text-[color:var(--brand-charcoal)]/80 hover:bg-white";
               return (
-                <Link key={step.number} to={step.path} className={`${baseClasses} ${stateClasses}`}>
+                <div
+                  key={step.number}
+                  className={`${baseClasses} ${stateClasses}`}
+                  aria-current={isActive ? "step" : undefined}
+                >
                   Étape {step.number} · {step.label}
-                </Link>
+                </div>
               );
             })}
           </nav>

--- a/frontend/src/pages/StepOne.tsx
+++ b/frontend/src/pages/StepOne.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import InfoCard from "../components/InfoCard";
@@ -8,12 +8,24 @@ interface StepOneProps {
   onSourceTextChange: (value: string) => void;
 }
 
+const WORD_THRESHOLD = 120;
+
 function StepOne({ sourceText, onSourceTextChange }: StepOneProps): JSX.Element {
   const navigate = useNavigate();
 
   const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     onSourceTextChange(event.target.value);
   };
+
+  const wordCount = useMemo(() => {
+    const trimmed = sourceText.trim();
+    if (!trimmed) {
+      return 0;
+    }
+    return trimmed.split(/\s+/).length;
+  }, [sourceText]);
+
+  const canProceed = wordCount >= WORD_THRESHOLD;
 
   return (
     <div className="space-y-12">
@@ -39,13 +51,21 @@ function StepOne({ sourceText, onSourceTextChange }: StepOneProps): JSX.Element 
             className="min-h-[220px] w-full rounded-3xl border border-white/70 bg-white/80 p-5 text-sm leading-relaxed shadow-inner focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
           />
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <p className="text-xs text-[color:var(--brand-charcoal)]">
-              Astuce : notez vos objectifs d’apprentissage dans le texte. Les modèles s’y référeront pour cadrer leurs réponses.
-            </p>
+            <div className="space-y-1 text-xs text-[color:var(--brand-charcoal)]">
+              <p>
+                Astuce : notez vos objectifs d’apprentissage dans le texte. Les modèles s’y référeront pour cadrer leurs réponses.
+              </p>
+              <p className={!canProceed ? "text-[color:var(--brand-red)]" : "text-[color:var(--brand-charcoal)]/80"}>
+                {canProceed
+                  ? "Seuil atteint : vous pouvez lancer la comparaison."
+                  : `Ajoutez encore ${Math.max(WORD_THRESHOLD - wordCount, 0)} mot(s) pour atteindre le minimum requis (${wordCount}/${WORD_THRESHOLD}).`}
+              </p>
+            </div>
             <button
               type="button"
-            onClick={() => navigate("/atelier/etape-2")}
-              className="cta-button cta-button--primary"
+              onClick={() => navigate("/atelier/etape-2")}
+              className="cta-button cta-button--primary disabled:cursor-not-allowed disabled:bg-slate-300"
+              disabled={!canProceed}
             >
               Passer à l’étape 2
             </button>

--- a/frontend/src/pages/StepThree.tsx
+++ b/frontend/src/pages/StepThree.tsx
@@ -154,16 +154,17 @@ function StepThree({
     if (!finalSummary.trim() || activityProgressMarked) {
       return;
     }
-    const markProgress = async () => {
+    const markProgressAndNavigate = async () => {
       try {
         await updateActivityProgress({ activityId: "atelier", completed: true });
-        setActivityProgressMarked(true);
       } catch (error) {
         console.error("Unable to persist atelier progress", error);
       }
+      setActivityProgressMarked(true);
+      navigate("/activites", { state: { completed: "atelier" } });
     };
-    void markProgress();
-  }, [finalSummary, activityProgressMarked]);
+    void markProgressAndNavigate();
+  }, [finalSummary, activityProgressMarked, navigate]);
 
   return (
     <div className="space-y-12">

--- a/frontend/src/pages/StepTwo.tsx
+++ b/frontend/src/pages/StepTwo.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, SetStateAction, useMemo, useState } from "react";
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import InfoCard from "../components/InfoCard";
@@ -34,6 +34,14 @@ function StepTwo({
   const [errorB, setErrorB] = useState<string | null>(null);
 
   const disabled = useMemo(() => !sourceText.trim(), [sourceText]);
+
+  useEffect(() => {
+    if (!sourceText.trim()) {
+      navigate("/atelier/etape-1", { replace: true });
+    }
+  }, [navigate, sourceText]);
+
+  const canProceedToStepThree = Boolean(summaryA.trim() && summaryB.trim());
 
   const handleConfigChange = (
     side: "A" | "B",
@@ -261,7 +269,7 @@ function StepTwo({
           type="button"
           onClick={() => navigate("/atelier/etape-3")}
           className="cta-button cta-button--light disabled:cursor-not-allowed disabled:bg-slate-300"
-          disabled={!summaryA.trim() || !summaryB.trim()}
+          disabled={!canProceedToStepThree}
         >
           Passer à l’étape 3
         </button>

--- a/frontend/src/pages/WorkshopRoutes.tsx
+++ b/frontend/src/pages/WorkshopRoutes.tsx
@@ -50,6 +50,9 @@ function WorkshopRoutes({
     return 1;
   }, [location.pathname]);
 
+  const isSourceEmpty = !sourceText.trim();
+  const summariesMissing = !summaryA.trim() || !summaryB.trim();
+
   return (
     <Layout currentStep={stepIndex}>
       <Routes>
@@ -66,33 +69,43 @@ function WorkshopRoutes({
         <Route
           path="etape-2"
           element={
-            <StepTwo
-              sourceText={sourceText}
-              configA={configA}
-              configB={configB}
-              setConfigA={setConfigA}
-              setConfigB={setConfigB}
-              summaryA={summaryA}
-              summaryB={summaryB}
-              setSummaryA={setSummaryA}
-              setSummaryB={setSummaryB}
-            />
+            isSourceEmpty ? (
+              <Navigate to="etape-1" replace />
+            ) : (
+              <StepTwo
+                sourceText={sourceText}
+                configA={configA}
+                configB={configB}
+                setConfigA={setConfigA}
+                setConfigB={setConfigB}
+                summaryA={summaryA}
+                summaryB={summaryB}
+                setSummaryA={setSummaryA}
+                setSummaryB={setSummaryB}
+              />
+            )
           }
         />
         <Route
           path="etape-3"
           element={
-            <StepThree
-              sourceText={sourceText}
-              summaryA={summaryA}
-              summaryB={summaryB}
-              flashcardsA={flashcardsA}
-              flashcardsB={flashcardsB}
-              setFlashcardsA={setFlashcardsA}
-              setFlashcardsB={setFlashcardsB}
-              configA={configA}
-              configB={configB}
-            />
+            isSourceEmpty ? (
+              <Navigate to="etape-1" replace />
+            ) : summariesMissing ? (
+              <Navigate to="etape-2" replace />
+            ) : (
+              <StepThree
+                sourceText={sourceText}
+                summaryA={summaryA}
+                summaryB={summaryB}
+                flashcardsA={flashcardsA}
+                flashcardsB={flashcardsB}
+                setFlashcardsA={setFlashcardsA}
+                setFlashcardsB={setFlashcardsB}
+                configA={configA}
+                configB={configB}
+              />
+            )
           }
         />
         <Route path="*" element={<Navigate to="etape-1" replace />} />


### PR DESCRIPTION
## Summary
- block direct navigation to steps 2 and 3 when prerequisites (source text and summaries) are missing and make the step indicator non-clickable
- require a minimum source word count before continuing and guide users with contextual messaging in step 1
- guard later steps against missing context and redirect to the activities list once the final synthesis is produced

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd20f197d48322a00300ff614b3a4a