### PR TITLE
Enforce stage validation and finalize Clarté d'abord flow

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -60,6 +60,7 @@ export type FieldSpec =
 export interface MissionStage {
   prompt: string;
   fields: FieldSpec[];
+  allowEmpty?: boolean;
 }
 
 export interface Mission {

--- a/frontend/src/components/FinalReveal.tsx
+++ b/frontend/src/components/FinalReveal.tsx
@@ -8,9 +8,11 @@ interface FinalRevealProps {
   onReplay: () => void;
   onBack: () => void;
   onNextMission?: () => void;
+  onFinish?: () => void | Promise<void>;
 }
-function FinalReveal({ mission, records, onReplay, onBack, onNextMission }: FinalRevealProps): JSX.Element {
+function FinalReveal({ mission, records, onReplay, onBack, onNextMission, onFinish }: FinalRevealProps): JSX.Element {
   const [showDebrief, setShowDebrief] = useState(true);
+  const [isFinishing, setIsFinishing] = useState(false);
   const checklistLines = useMemo(() => mission.revelation.split("\\n"), [mission.revelation]);
 
   return (
@@ -43,40 +45,57 @@ function FinalReveal({ mission, records, onReplay, onBack, onNextMission }: Fina
               <div className="mt-4 flex flex-wrap justify-end gap-3">
                 <button
                   type="button"
-                  className="cta-button cta-button--primary"
+                  className="cta-button cta-button--primary disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={() => setShowDebrief(false)}
+                  disabled={isFinishing}
                 >
                   Fermer le débrief
                 </button>
                 <button
                   type="button"
-                  className="cta-button cta-button--light"
+                  className="cta-button cta-button--light disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={() => {
                     setShowDebrief(false);
                     onReplay();
                   }}
+                  disabled={isFinishing}
                 >
                   Rejouer cette mission
                 </button>
                 {onNextMission ? (
                   <button
                     type="button"
-                    className="cta-button cta-button--light"
+                    className="cta-button cta-button--light disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => {
                       setShowDebrief(false);
                       onNextMission();
                     }}
+                    disabled={isFinishing}
                   >
                     Mission suivante
                   </button>
                 ) : null}
                 <button
                   type="button"
-                  className="cta-button cta-button--light"
-                  onClick={() => {
-                    setShowDebrief(false);
-                    onBack();
+                  className="cta-button cta-button--light disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={async () => {
+                    if (isFinishing) {
+                      return;
+                    }
+                    setIsFinishing(true);
+                    try {
+                      if (onFinish) {
+                        await onFinish();
+                      }
+                    } catch (error) {
+                      console.error("Unable to finalize mission", error);
+                    } finally {
+                      setShowDebrief(false);
+                      onBack();
+                      setIsFinishing(false);
+                    }
                   }}
+                  disabled={isFinishing}
                 >
                   Retour à l’accueil
                 </button>


### PR DESCRIPTION
## Summary
- add an optional `allowEmpty` flag to missions and enforce field validation when stages are mandatory, showing inline errors and disabling navigation when incomplete
- update the final reveal overlay to support a finish callback that prevents duplicate clicks and triggers completion logic
- redirect Clarté d'abord to the activities page after marking the activity complete once the user finishes a mission

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd211d15c4832288afdbe514da0338