### PR TITLE
feat: add admin administration portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 
 .env
 /lti-keys
+node_modules/
+frontend/node_modules/
+dist/
+frontend/dist/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,27 @@ import { Navigate, Route, Routes } from "react-router-dom";
 
 import ActivitySelector from "./pages/ActivitySelector";
 import { ACTIVITY_DEFINITIONS } from "./config/activities";
+import { AdminGuard } from "./pages/admin/AdminGuard";
+import { AdminLayout } from "./pages/admin/AdminLayout";
+import { AdminLocalUsersPage } from "./pages/admin/AdminLocalUsersPage";
+import { AdminLoginPage } from "./pages/admin/AdminLoginPage";
+import { AdminLtiUsersPage } from "./pages/admin/AdminLtiUsersPage";
+import { AdminPlatformsPage } from "./pages/admin/AdminPlatformsPage";
 
 function App(): JSX.Element {
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/activites" replace />} />
       <Route path="/activites" element={<ActivitySelector />} />
+      <Route path="/admin/login" element={<AdminLoginPage />} />
+      <Route element={<AdminGuard />}>
+        <Route path="/admin" element={<AdminLayout />}>
+          <Route index element={<Navigate to="platforms" replace />} />
+          <Route path="platforms" element={<AdminPlatformsPage />} />
+          <Route path="lti-users" element={<AdminLtiUsersPage />} />
+          <Route path="local-users" element={<AdminLocalUsersPage />} />
+        </Route>
+      </Route>
       {ACTIVITY_DEFINITIONS.map((definition) => (
         <Route key={definition.id} path={definition.path} element={definition.element} />
       ))}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -148,8 +148,322 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
     throw new Error(text || `Erreur serveur (${response.status}).`);
   }
 
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType || !contentType.includes("application/json")) {
+    const text = await response.text();
+    if (!text) {
+      throw new Error("Réponse JSON attendue.");
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      throw new Error("Réponse JSON invalide.");
+    }
+  }
+
   return (await response.json()) as T;
 }
+
+function withAdminCredentials(init: RequestInit = {}, token?: string | null): RequestInit {
+  const headers: HeadersInit = {
+    ...(init.headers ?? {}),
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return {
+    ...init,
+    headers,
+    credentials: "include",
+  };
+}
+
+export interface AdminUser {
+  username: string;
+  roles: string[];
+  isActive: boolean;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  fromEnv?: boolean;
+}
+
+export interface AdminSession {
+  token: string | null;
+  expiresAt?: string | null;
+  user: AdminUser;
+}
+
+export interface AdminLoginPayload {
+  username: string;
+  password: string;
+  remember?: boolean;
+}
+
+export interface AdminAuthResponse {
+  token: string;
+  expiresAt?: string;
+  user: AdminUser;
+}
+
+export interface AdminMeResponse {
+  user: AdminUser;
+  expiresAt?: string;
+}
+
+export interface AdminPlatform {
+  issuer: string;
+  clientId: string;
+  authorizationEndpoint: string | null;
+  tokenEndpoint: string | null;
+  jwksUri: string | null;
+  deploymentId: string | null;
+  deploymentIds: string[];
+  audience: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  readOnly?: boolean;
+}
+
+export interface AdminPlatformPayload {
+  issuer: string;
+  clientId: string;
+  authorizationEndpoint?: string | null;
+  tokenEndpoint?: string | null;
+  jwksUri?: string | null;
+  deploymentId?: string | null;
+  deploymentIds?: string[] | null;
+  audience?: string | null;
+}
+
+export interface AdminPlatformListResponse {
+  platforms: AdminPlatform[];
+}
+
+export interface AdminPlatformResponse {
+  platform: AdminPlatform;
+}
+
+export type AdminPlatformSaveMode = "create" | "replace" | "patch";
+
+export interface AdminLtiUser {
+  issuer: string;
+  subject: string;
+  displayName: string;
+  email?: string | null;
+  loginCount: number;
+  firstLoginAt?: string | null;
+  lastLoginAt?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  completedActivities: number;
+  completedActivityIds: string[];
+  hasProgress: boolean;
+  profileMissing?: boolean;
+  progressIdentity?: string;
+  completedActivitiesDetail?: Array<{
+    activityId: string;
+    completedAt?: string | null;
+    updatedAt?: string | null;
+  }>;
+}
+
+export interface PaginatedResponse<T> {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  items: T[];
+}
+
+export interface AdminLtiUsersQuery {
+  page?: number;
+  pageSize?: number;
+  issuer?: string;
+  subject?: string;
+  search?: string;
+  includeDetails?: boolean;
+}
+
+export interface AdminLocalUser extends AdminUser {}
+
+export interface AdminLocalUsersResponse {
+  users: AdminLocalUser[];
+}
+
+export interface AdminLocalUserCreatePayload {
+  username: string;
+  password: string;
+  roles?: string[];
+  isActive?: boolean;
+}
+
+export interface AdminLocalUserUpdatePayload {
+  roles?: string[];
+  isActive?: boolean;
+}
+
+export interface AdminLocalUserPasswordResetPayload {
+  password: string;
+}
+
+export interface AdminLocalUserResponse {
+  user: AdminLocalUser;
+}
+
+export const admin = {
+  auth: {
+    login: async (payload: AdminLoginPayload): Promise<AdminAuthResponse> =>
+      fetchJson<AdminAuthResponse>(`${API_BASE_URL}/admin/auth/login`,
+        withAdminCredentials(
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          },
+        )
+      ),
+    logout: async (token?: string | null): Promise<void> => {
+      await fetchJson<void>(
+        `${API_BASE_URL}/admin/auth/logout`,
+        withAdminCredentials(
+          {
+            method: "POST",
+          },
+          token
+        )
+      );
+    },
+    me: async (token?: string | null): Promise<AdminMeResponse> =>
+      fetchJson<AdminMeResponse>(
+        `${API_BASE_URL}/admin/auth/me`,
+        withAdminCredentials({}, token)
+      ),
+  },
+  platforms: {
+    list: async (token?: string | null): Promise<AdminPlatformListResponse> =>
+      fetchJson<AdminPlatformListResponse>(
+        `${API_BASE_URL}/admin/lti-platforms`,
+        withAdminCredentials({}, token)
+      ),
+    save: async (
+      payload: AdminPlatformPayload,
+      options: { mode?: AdminPlatformSaveMode; token?: string | null } = {}
+    ): Promise<AdminPlatformResponse> => {
+      const mode = options.mode ?? "replace";
+      const method = mode === "create" ? "POST" : mode === "patch" ? "PATCH" : "PUT";
+      return fetchJson<AdminPlatformResponse>(
+        `${API_BASE_URL}/admin/lti-platforms`,
+        withAdminCredentials(
+          {
+            method,
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          },
+          options.token
+        )
+      );
+    },
+    remove: async (issuer: string, clientId: string, token?: string | null): Promise<void> => {
+      const params = new URLSearchParams({ issuer, clientId });
+      await fetchJson<void>(
+        `${API_BASE_URL}/admin/lti-platforms?${params.toString()}`,
+        withAdminCredentials(
+          {
+            method: "DELETE",
+          },
+          token
+        )
+      );
+    },
+  },
+  ltiUsers: {
+    list: async (
+      query: AdminLtiUsersQuery = {},
+      token?: string | null
+    ): Promise<PaginatedResponse<AdminLtiUser>> => {
+      const params = new URLSearchParams();
+      if (query.page) params.set("page", String(query.page));
+      if (query.pageSize) params.set("pageSize", String(query.pageSize));
+      if (query.issuer) params.set("issuer", query.issuer);
+      if (query.subject) params.set("subject", query.subject);
+      if (query.search) params.set("search", query.search);
+      if (query.includeDetails) params.set("includeDetails", "true");
+      const querySuffix = params.toString();
+      const url = querySuffix
+        ? `${API_BASE_URL}/admin/lti-users?${querySuffix}`
+        : `${API_BASE_URL}/admin/lti-users`;
+      return fetchJson<PaginatedResponse<AdminLtiUser>>(url, withAdminCredentials({}, token));
+    },
+  },
+  localUsers: {
+    list: async (token?: string | null): Promise<AdminLocalUsersResponse> =>
+      fetchJson<AdminLocalUsersResponse>(
+        `${API_BASE_URL}/admin/users`,
+        withAdminCredentials({}, token)
+      ),
+    create: async (
+      payload: AdminLocalUserCreatePayload,
+      token?: string | null
+    ): Promise<AdminLocalUserResponse> =>
+      fetchJson<AdminLocalUserResponse>(
+        `${API_BASE_URL}/admin/users`,
+        withAdminCredentials(
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          },
+          token
+        )
+      ),
+    update: async (
+      username: string,
+      payload: AdminLocalUserUpdatePayload,
+      token?: string | null
+    ): Promise<AdminLocalUserResponse> =>
+      fetchJson<AdminLocalUserResponse>(
+        `${API_BASE_URL}/admin/users/${encodeURIComponent(username)}`,
+        withAdminCredentials(
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          },
+          token
+        )
+      ),
+    resetPassword: async (
+      username: string,
+      payload: AdminLocalUserPasswordResetPayload,
+      token?: string | null
+    ): Promise<AdminLocalUserResponse> =>
+      fetchJson<AdminLocalUserResponse>(
+        `${API_BASE_URL}/admin/users/${encodeURIComponent(username)}/reset-password`,
+        withAdminCredentials(
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          },
+          token
+        )
+      ),
+  },
+};
 
 export async function getMissions(): Promise<Mission[]> {
   return fetchJson<Mission[]>(`${API_BASE_URL}/missions`);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
+import { useAdminAuth } from "../providers/AdminAuthProvider";
 
 import logoPrincipal from "../assets/logo_principal.svg";
 
@@ -15,6 +16,9 @@ const STEPS = [
 ];
 
 function Layout({ currentStep, children }: LayoutProps): JSX.Element {
+  const { status: adminStatus } = useAdminAuth();
+  const isAdminAuthenticated = adminStatus === "authenticated";
+
   return (
     <div className="landing-gradient min-h-screen px-6 pb-16 pt-10 text-[color:var(--brand-black)]">
       <div className="mx-auto flex max-w-6xl flex-col gap-12">
@@ -26,9 +30,19 @@ function Layout({ currentStep, children }: LayoutProps): JSX.Element {
                 Atelier comparatif IA
               </span>
             </Link>
-            <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-              Trois étapes guidées
-            </span>
+            <div className="flex flex-col items-center gap-2 md:flex-row md:items-center">
+              <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
+                Trois étapes guidées
+              </span>
+              {isAdminAuthenticated ? (
+                <Link
+                  to="/admin"
+                  className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+                >
+                  Administration
+                </Link>
+              ) : null}
+            </div>
           </div>
           <div className="grid gap-6 md:grid-cols-[3fr_2fr] md:items-start">
             <div className="space-y-3">

--- a/frontend/src/components/admin/AdminModal.tsx
+++ b/frontend/src/components/admin/AdminModal.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+
+interface AdminModalProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  onClose: () => void;
+  children: ReactNode;
+  footer?: ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+const SIZE_CLASS: Record<NonNullable<AdminModalProps["size"]>, string> = {
+  sm: "max-w-md",
+  md: "max-w-2xl",
+  lg: "max-w-4xl",
+};
+
+export function AdminModal({
+  open,
+  title,
+  description,
+  onClose,
+  children,
+  footer,
+  size = "md",
+}: AdminModalProps): JSX.Element | null {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8">
+      <div
+        className={`w-full ${SIZE_CLASS[size]} rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl backdrop-blur`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="admin-modal-title"
+      >
+        <div className="flex items-start justify-between gap-6">
+          <div>
+            <h2 id="admin-modal-title" className="text-xl font-semibold text-[color:var(--brand-black)]">
+              {title}
+            </h2>
+            {description ? (
+              <p className="mt-1 text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90">{description}</p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-transparent p-2 text-lg text-[color:var(--brand-charcoal)]/80 transition hover:bg-[color:var(--brand-charcoal)]/10"
+            aria-label="Fermer la fenêtre"
+          >
+            ×
+          </button>
+        </div>
+        <div className="mt-6 space-y-4 text-[color:var(--brand-charcoal)]">{children}</div>
+        {footer ? (
+          <div className="mt-6 flex flex-col gap-3 border-t border-[color:var(--brand-charcoal)]/10 pt-4 text-right md:flex-row md:justify-end">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminSkeleton.tsx
+++ b/frontend/src/components/admin/AdminSkeleton.tsx
@@ -1,0 +1,20 @@
+interface AdminSkeletonProps {
+  lines?: number;
+  rounded?: boolean;
+}
+
+export function AdminSkeleton({ lines = 3, rounded = true }: AdminSkeletonProps): JSX.Element {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: lines }).map((_, index) => (
+        <div
+          // eslint-disable-next-line react/no-array-index-key -- skeleton items do not require stable keys
+          key={index}
+          className={`h-4 w-full animate-pulse bg-[color:var(--brand-charcoal)]/10 ${
+            rounded ? "rounded-full" : ""
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,15 +3,15 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
-import AuthGate from "./components/AuthGate";
+import { AdminAuthProvider } from "./providers/AdminAuthProvider";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthGate>
+      <AdminAuthProvider>
         <App />
-      </AuthGate>
+      </AdminAuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -8,6 +8,7 @@ import {
   type ActivityDefinition,
 } from "../config/activities";
 import { useLTI } from "../hooks/useLTI";
+import { useAdminAuth } from "../providers/AdminAuthProvider";
 
 function ActivitySelector(): JSX.Element {
   const [completedMap, setCompletedMap] = useState<Record<string, boolean>>({});
@@ -15,6 +16,7 @@ function ActivitySelector(): JSX.Element {
   const location = useLocation();
   const navigate = useNavigate();
   const { context, isLTISession, loading: ltiLoading } = useLTI();
+  const { status: adminStatus } = useAdminAuth();
   const displayName =
     context?.user?.name?.trim() ||
     context?.user?.email?.trim() ||
@@ -22,6 +24,7 @@ function ActivitySelector(): JSX.Element {
     "";
   const shouldShowWelcome = isLTISession && !ltiLoading && displayName.length > 0;
   const completedId = (location.state as { completed?: string } | null)?.completed;
+  const isAdminAuthenticated = adminStatus === "authenticated";
 
   useEffect(() => {
     if (!completedId) {
@@ -137,9 +140,19 @@ function ActivitySelector(): JSX.Element {
                 Choisis ton activité
               </span>
             </Link>
-            <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-              Objectifs pédagogiques
-            </span>
+            <div className="flex flex-col items-center gap-2 md:flex-row md:items-center">
+              <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
+                Objectifs pédagogiques
+              </span>
+              {isAdminAuthenticated ? (
+                <Link
+                  to="/admin"
+                  className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+                >
+                  Administration
+                </Link>
+              ) : null}
+            </div>
           </div>
           <div className="space-y-3 text-center md:text-left">
             <h1 className="text-3xl font-semibold md:text-4xl">

--- a/frontend/src/pages/admin/AdminGuard.tsx
+++ b/frontend/src/pages/admin/AdminGuard.tsx
@@ -1,0 +1,41 @@
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+
+import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+export function AdminGuard(): JSX.Element {
+  const { status, isProcessing } = useAdminAuth();
+  const location = useLocation();
+
+  if (status === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[color:var(--brand-sand)]/40">
+        <div className="w-full max-w-md rounded-3xl border border-white/60 bg-white/90 p-8 shadow-xl backdrop-blur">
+          <p className="text-sm font-medium text-[color:var(--brand-charcoal)]/80">Chargement de l’espace administrateur…</p>
+          <div className="mt-4">
+            <AdminSkeleton lines={4} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (status !== "authenticated") {
+    return (
+      <Navigate
+        to="/admin/login"
+        replace
+        state={{ from: `${location.pathname}${location.search}` }}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[color:var(--brand-sand)]/40">
+      {isProcessing ? (
+        <div className="fixed inset-x-0 top-0 z-40 h-1 bg-gradient-to-r from-[color:var(--brand-red)] via-transparent to-[color:var(--brand-red)] animate-pulse" />
+      ) : null}
+      <Outlet />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+import { Link, NavLink, Outlet } from "react-router-dom";
+
+import logoPrincipal from "../../assets/logo_principal.svg";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+const NAV_LINKS = [
+  { to: "/admin/platforms", label: "Plateformes LTI" },
+  { to: "/admin/lti-users", label: "Utilisateurs LTI" },
+  { to: "/admin/local-users", label: "Comptes internes" },
+];
+
+export function AdminLayout(): JSX.Element {
+  const { user, logout, isProcessing, expiresAt } = useAdminAuth();
+  const expirationDisplay = useMemo(() => {
+    if (!expiresAt) {
+      return null;
+    }
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return parsed.toLocaleString();
+  }, [expiresAt]);
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-10 px-6 py-10 text-[color:var(--brand-black)]">
+      <header className="space-y-6 rounded-3xl border border-white/60 bg-white/95 p-8 shadow-lg backdrop-blur">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-4 text-sm text-[color:var(--brand-charcoal)]/90 sm:text-base">
+            <div className="flex items-center gap-4">
+              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-10 w-auto sm:h-12" />
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-[color:var(--brand-charcoal)]/60">
+                  Espace administrateur
+                </p>
+                <h1 className="text-2xl font-semibold text-[color:var(--brand-black)] sm:text-3xl">Formation IA</h1>
+              </div>
+            </div>
+            <p>
+              Gérez les plateformes LTI, les comptes locaux et consultez l’activité des utilisateurs connectés.
+            </p>
+            <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+              {user ? <span>Connecté en tant que {user.username}</span> : null}
+              {expirationDisplay ? <span>Expiration : {expirationDisplay}</span> : null}
+            </div>
+          </div>
+          <div className="flex flex-col items-stretch gap-3 text-sm sm:flex-row sm:items-center">
+            <Link
+              to="/activites"
+              className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+            >
+              ← Retour aux activités
+            </Link>
+            <button
+              type="button"
+              onClick={() => {
+                void logout();
+              }}
+              disabled={isProcessing}
+              className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-400"
+            >
+              Se déconnecter
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+        <aside className="space-y-4 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-md backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+            Navigation
+          </p>
+          <nav className="flex flex-col gap-2 text-sm">
+            {NAV_LINKS.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `rounded-full px-4 py-2 font-medium transition ${
+                    isActive
+                      ? "bg-[color:var(--brand-red)] text-white shadow"
+                      : "bg-white/70 text-[color:var(--brand-charcoal)] hover:bg-white"
+                  }`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+          <div className="rounded-2xl bg-[color:var(--brand-sand)]/80 p-4 text-xs text-[color:var(--brand-charcoal)]/80">
+            <p className="font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Conseil</p>
+            <p className="mt-2 leading-relaxed">
+              Les mises à jour sont sauvegardées immédiatement. Rafraîchis la page si les informations semblent périmées.
+            </p>
+          </div>
+        </aside>
+        <section className="rounded-3xl border border-white/60 bg-white/95 p-6 shadow-lg backdrop-blur">
+          <Outlet />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminLocalUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminLocalUsersPage.tsx
@@ -1,0 +1,439 @@
+import { FormEvent, useCallback, useEffect, useState } from "react";
+
+import {
+  admin,
+  type AdminLocalUser,
+  type AdminLocalUserCreatePayload,
+  type AdminLocalUserUpdatePayload,
+} from "../../api";
+import { AdminModal } from "../../components/admin/AdminModal";
+import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+interface LocalUserFormState {
+  username: string;
+  password: string;
+  roles: string;
+  isActive: boolean;
+}
+
+function createFormState(user?: AdminLocalUser | null): LocalUserFormState {
+  return {
+    username: user?.username ?? "",
+    password: "",
+    roles: (user?.roles ?? ["admin"]).join(", "),
+    isActive: user?.isActive ?? true,
+  };
+}
+
+function parseRoles(value: string): string[] | undefined {
+  const parts = value
+    .split(/[,\s]+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  return Array.from(new Set(parts));
+}
+
+export function AdminLocalUsersPage(): JSX.Element {
+  const { token, user: currentUser, refresh } = useAdminAuth();
+  const [users, setUsers] = useState<AdminLocalUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [formState, setFormState] = useState<LocalUserFormState>(() => createFormState());
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [mode, setMode] = useState<"create" | "edit">("create");
+  const [passwordModalOpen, setPasswordModalOpen] = useState(false);
+  const [passwordValue, setPasswordValue] = useState("");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [selectedUser, setSelectedUser] = useState<AdminLocalUser | null>(null);
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await admin.localUsers.list(token);
+      setUsers(response.users);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de récupérer les comptes internes.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void fetchUsers();
+  }, [fetchUsers]);
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setFormState(createFormState());
+    setFormError(null);
+    setSelectedUser(null);
+  };
+
+  const openCreateModal = () => {
+    setMode("create");
+    setFormState(createFormState());
+    setFormError(null);
+    setModalOpen(true);
+  };
+
+  const openEditModal = (user: AdminLocalUser) => {
+    setMode("edit");
+    setSelectedUser(user);
+    setFormState(createFormState(user));
+    setFormError(null);
+    setModalOpen(true);
+  };
+
+  const openPasswordModal = (user: AdminLocalUser) => {
+    setSelectedUser(user);
+    setPasswordValue("");
+    setPasswordError(null);
+    setPasswordModalOpen(true);
+  };
+
+  const closePasswordModal = () => {
+    setSelectedUser(null);
+    setPasswordValue("");
+    setPasswordError(null);
+    setPasswordModalOpen(false);
+  };
+
+  const upsertUser = (user: AdminLocalUser) => {
+    setUsers((current) => {
+      const index = current.findIndex((item) => item.username === user.username);
+      if (index === -1) {
+        return [...current, user].sort((a, b) => a.username.localeCompare(b.username));
+      }
+      const next = [...current];
+      next[index] = user;
+      return next;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setFormError(null);
+    try {
+      const username = formState.username.trim();
+      if (!username) {
+        setFormError("Le nom d’utilisateur est obligatoire.");
+        setSaving(false);
+        return;
+      }
+      const payloadRoles = parseRoles(formState.roles);
+      if (mode === "create") {
+        const password = formState.password.trim();
+        if (password.length < 8) {
+          setFormError("Le mot de passe doit contenir au moins 8 caractères.");
+          setSaving(false);
+          return;
+        }
+        const payload: AdminLocalUserCreatePayload = {
+          username,
+          password,
+          isActive: formState.isActive,
+          roles: payloadRoles,
+        };
+        const response = await admin.localUsers.create(payload, token);
+        upsertUser(response.user);
+      } else if (selectedUser) {
+        const payload: AdminLocalUserUpdatePayload = {
+          isActive: formState.isActive,
+          roles: payloadRoles,
+        };
+        const response = await admin.localUsers.update(username, payload, token);
+        upsertUser(response.user);
+        if (currentUser?.username === username) {
+          void refresh();
+        }
+      }
+      closeModal();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Enregistrement impossible.";
+      setFormError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedUser) {
+      return;
+    }
+    const password = passwordValue.trim();
+    if (password.length < 8) {
+      setPasswordError("Le mot de passe doit contenir au moins 8 caractères.");
+      return;
+    }
+    try {
+      await admin.localUsers.resetPassword(selectedUser.username, { password }, token);
+      setPasswordModalOpen(false);
+      setPasswordValue("");
+      setPasswordError(null);
+      if (currentUser?.username === selectedUser.username) {
+        void refresh();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de mettre à jour le mot de passe.";
+      setPasswordError(message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b border-[color:var(--brand-charcoal)]/10 pb-4">
+        <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">Comptes internes</h2>
+        <p className="mt-1 text-sm text-[color:var(--brand-charcoal)]">
+          Crée des accès administrateur ou facilitateur pour tes collègues et maintiens leurs droits d’accès.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="button"
+          onClick={openCreateModal}
+          className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600"
+        >
+          + Nouveau compte
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            void fetchUsers();
+          }}
+          className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+        >
+          Rafraîchir
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50/80 p-4 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      {loading ? (
+        <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-inner">
+          <AdminSkeleton lines={6} />
+          <div className="mt-4">
+            <AdminSkeleton lines={6} />
+          </div>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-[color:var(--brand-charcoal)]/30 bg-white/80 p-6 text-center text-sm text-[color:var(--brand-charcoal)]">
+          Aucun compte interne n’a encore été créé.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
+          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+            <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Utilisateur</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Rôles</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Statut</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Origine</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[color:var(--brand-charcoal)]/10 bg-white/95">
+              {users.map((user) => (
+                <tr key={user.username} className="transition hover:bg-[color:var(--brand-sand)]/40">
+                  <td className="px-4 py-3">
+                    <div className="flex flex-col">
+                      <span className="font-semibold text-[color:var(--brand-black)]">{user.username}</span>
+                      <span className="text-xs text-[color:var(--brand-charcoal)]/70">
+                        Créé le {formatDate(user.createdAt)}
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-2">
+                      {user.roles.map((role) => (
+                        <span
+                          key={role}
+                          className="inline-flex items-center rounded-full bg-[color:var(--brand-sand)]/70 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]"
+                        >
+                          {role}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    {user.isActive ? (
+                      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-green-700">
+                        Actif
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-red-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-red-700">
+                        Inactif
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">
+                    {user.fromEnv ? "Configuration" : "Interface"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => openEditModal(user)}
+                        className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-3 py-1 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+                      >
+                        Modifier
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => openPasswordModal(user)}
+                        className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-3 py-1 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+                      >
+                        Mot de passe
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <AdminModal
+        open={modalOpen}
+        onClose={closeModal}
+        title={mode === "create" ? "Créer un compte interne" : `Modifier ${selectedUser?.username ?? "le compte"}`}
+        description={
+          mode === "create"
+            ? "Attribue un mot de passe fort et les rôles attendus."
+            : "Active ou ajuste les rôles d’un compte existant."
+        }
+        footer={
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={closeModal}
+              className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-sm font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              form="admin-local-user-form"
+              disabled={saving}
+              className="rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-400"
+            >
+              {saving ? "Enregistrement…" : mode === "create" ? "Créer" : "Mettre à jour"}
+            </button>
+          </div>
+        }
+      >
+        {formError ? <p className="rounded-3xl bg-red-50 p-3 text-xs text-red-600">{formError}</p> : null}
+        <form id="admin-local-user-form" className="grid gap-4" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Nom d’utilisateur
+            <input
+              type="text"
+              value={formState.username}
+              onChange={(event) => setFormState((prev) => ({ ...prev, username: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="ex: admin"
+              required
+              disabled={mode === "edit"}
+            />
+          </label>
+          {mode === "create" ? (
+            <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+              Mot de passe initial
+              <input
+                type="password"
+                value={formState.password}
+                onChange={(event) => setFormState((prev) => ({ ...prev, password: event.target.value }))}
+                className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+                placeholder="Au moins 8 caractères"
+                required
+              />
+            </label>
+          ) : null}
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Rôles (séparés par une virgule)
+            <input
+              type="text"
+              value={formState.roles}
+              onChange={(event) => setFormState((prev) => ({ ...prev, roles: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="admin, facilitator"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            <input
+              type="checkbox"
+              checked={formState.isActive}
+              onChange={(event) => setFormState((prev) => ({ ...prev, isActive: event.target.checked }))}
+              className="h-4 w-4 rounded border-[color:var(--brand-charcoal)]/30 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+            />
+            Compte actif
+          </label>
+        </form>
+      </AdminModal>
+
+      <AdminModal
+        open={passwordModalOpen}
+        onClose={closePasswordModal}
+        title={`Réinitialiser ${selectedUser?.username ?? "le mot de passe"}`}
+        description="Définis un nouveau mot de passe temporaire pour ce compte."
+        footer={
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={closePasswordModal}
+              className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-sm font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              form="admin-password-form"
+              className="rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600"
+            >
+              Mettre à jour
+            </button>
+          </div>
+        }
+      >
+        {passwordError ? <p className="rounded-3xl bg-red-50 p-3 text-xs text-red-600">{passwordError}</p> : null}
+        <form id="admin-password-form" className="space-y-4" onSubmit={handlePasswordSubmit}>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Nouveau mot de passe
+            <input
+              type="password"
+              value={passwordValue}
+              onChange={(event) => setPasswordValue(event.target.value)}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="Au moins 8 caractères"
+              required
+            />
+          </label>
+        </form>
+      </AdminModal>
+    </div>
+  );
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString();
+}

--- a/frontend/src/pages/admin/AdminLoginPage.tsx
+++ b/frontend/src/pages/admin/AdminLoginPage.tsx
@@ -1,0 +1,133 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+
+import logoPrincipal from "../../assets/logo_principal.svg";
+import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+export function AdminLoginPage(): JSX.Element {
+  const { status, login, error, isProcessing } = useAdminAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [remember, setRemember] = useState(true);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const redirectTo = useMemo(() => {
+    const state = location.state as { from?: string } | undefined;
+    return state?.from && state.from.startsWith("/admin") ? state.from : "/admin";
+  }, [location.state]);
+
+  if (status === "authenticated") {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  if (status === "loading") {
+    return (
+      <div className="auth-background landing-gradient flex min-h-screen items-center justify-center p-6">
+        <div className="w-full max-w-md rounded-3xl border border-white/70 bg-white/90 p-8 shadow-2xl backdrop-blur">
+          <p className="text-sm font-medium text-[color:var(--brand-charcoal)]/80">
+            Vérification de votre session administrateur…
+          </p>
+          <div className="mt-4">
+            <AdminSkeleton lines={4} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const combinedError = formError ?? error;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    const trimmedUsername = username.trim();
+    const trimmedPassword = password.trim();
+    if (!trimmedUsername || !trimmedPassword) {
+      setFormError("Saisis un identifiant et un mot de passe.");
+      return;
+    }
+    const result = await login({ username: trimmedUsername, password: trimmedPassword, remember });
+    if (result.ok) {
+      navigate(redirectTo, { replace: true });
+    } else {
+      setFormError(result.error);
+    }
+  };
+
+  return (
+    <div className="auth-background landing-gradient flex min-h-screen items-center justify-center p-6">
+      <div className="w-full max-w-lg animate-fade-in-up rounded-3xl border border-white/70 bg-white/95 p-8 shadow-2xl backdrop-blur">
+        <div className="flex flex-col gap-6 text-center">
+          <div className="flex flex-col items-center gap-3 animate-float-soft">
+            <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto filter brightness-0" />
+            <span className="text-xs uppercase tracking-[0.4em] text-[color:var(--brand-red)]">Administration</span>
+          </div>
+          <div className="space-y-3">
+            <h1 className="text-2xl font-semibold text-[color:var(--brand-black)]">Connexion administrateur</h1>
+            <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
+              Identifie-toi pour accéder aux paramètres avancés de Formation IA.
+            </p>
+          </div>
+        </div>
+        <div className="my-6 h-px bg-gradient-to-r from-transparent via-[color:var(--brand-charcoal)]/20 to-transparent" />
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="text-left">
+            <label className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]" htmlFor="admin-username">
+              Nom d’utilisateur
+            </label>
+            <input
+              id="admin-username"
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              className="mt-1 w-full rounded-full border border-white/60 bg-white/90 px-4 py-2 text-sm shadow-inner focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="Identifiant administrateur"
+            />
+          </div>
+          <div className="text-left">
+            <label className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]" htmlFor="admin-password">
+              Mot de passe
+            </label>
+            <input
+              id="admin-password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 w-full rounded-full border border-white/60 bg-white/90 px-4 py-2 text-sm shadow-inner focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="Mot de passe sécurisé"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-left text-xs text-[color:var(--brand-charcoal)]">
+            <input
+              type="checkbox"
+              checked={remember}
+              onChange={(event) => setRemember(event.target.checked)}
+              className="h-4 w-4 rounded border-[color:var(--brand-charcoal)]/30 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+            />
+            Se souvenir de moi sur cet appareil
+          </label>
+          {combinedError ? (
+            <p className="rounded-3xl bg-red-50 p-3 text-xs text-red-600">{combinedError}</p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={isProcessing}
+            className="w-full rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-400"
+          >
+            {isProcessing ? "Connexion…" : "Se connecter"}
+          </button>
+        </form>
+        <div className="mt-6 text-center text-xs text-[color:var(--brand-charcoal)]/70">
+          <Link to="/activites" className="font-medium text-[color:var(--brand-red)] hover:underline">
+            ← Retourner aux activités
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminLtiUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminLtiUsersPage.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { admin, type AdminLtiUser } from "../../api";
+import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+type SortKey = "lastLoginAt" | "loginCount" | "completedActivities";
+type SortDirection = "asc" | "desc";
+
+function formatDate(value?: string | null): string {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+}
+
+function sortUsers(users: AdminLtiUser[], key: SortKey, direction: SortDirection): AdminLtiUser[] {
+  const factor = direction === "asc" ? 1 : -1;
+  return [...users].sort((a, b) => {
+    if (key === "loginCount") {
+      return (a.loginCount - b.loginCount) * factor;
+    }
+    if (key === "completedActivities") {
+      return (a.completedActivities - b.completedActivities) * factor;
+    }
+    const dateA = a.lastLoginAt ? new Date(a.lastLoginAt).getTime() : 0;
+    const dateB = b.lastLoginAt ? new Date(b.lastLoginAt).getTime() : 0;
+    return (dateA - dateB) * factor;
+  });
+}
+
+export function AdminLtiUsersPage(): JSX.Element {
+  const { token } = useAdminAuth();
+  const [users, setUsers] = useState<AdminLtiUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(25);
+  const [totalPages, setTotalPages] = useState(0);
+  const [search, setSearch] = useState("");
+  const [issuer, setIssuer] = useState<string>("");
+  const [sortKey, setSortKey] = useState<SortKey>("lastLoginAt");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [includeDetails, setIncludeDetails] = useState(false);
+  const [issuerOptions, setIssuerOptions] = useState<string[]>([]);
+
+  const loadUsers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await admin.ltiUsers.list(
+        {
+          page,
+          pageSize,
+          search: search.trim() || undefined,
+          issuer: issuer || undefined,
+          includeDetails,
+        },
+        token
+      );
+      setUsers(response.items);
+      setTotalPages(response.totalPages);
+      setIssuerOptions((previous) => {
+        const issuers = new Set(previous);
+        response.items.forEach((item) => {
+          if (item.issuer) {
+            issuers.add(item.issuer);
+          }
+        });
+        const next = Array.from(issuers).sort();
+        if (next.length === previous.length && next.every((value, index) => value === previous[index])) {
+          return previous;
+        }
+        return next;
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de récupérer les utilisateurs LTI.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, pageSize, search, issuer, includeDetails, token]);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const sortedUsers = useMemo(() => sortUsers(users, sortKey, sortDirection), [users, sortKey, sortDirection]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDirection(key === "lastLoginAt" ? "desc" : "desc");
+    }
+  };
+
+  const sortLabel = (key: SortKey) => {
+    if (sortKey !== key) {
+      return "↕";
+    }
+    return sortDirection === "asc" ? "↑" : "↓";
+  };
+
+  const canGoPrevious = page > 1;
+  const canGoNext = page < totalPages;
+
+  return (
+    <div className="space-y-6">
+      <header className="border-b border-[color:var(--brand-charcoal)]/10 pb-4">
+        <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">Utilisateurs LTI</h2>
+        <p className="mt-1 text-sm text-[color:var(--brand-charcoal)]">
+          Analyse les connexions et l’activité des comptes synchronisés via les plateformes partenaires.
+        </p>
+      </header>
+
+      <section className="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/90 p-4 shadow-sm md:flex-row md:items-end md:justify-between">
+        <div className="flex flex-col gap-3 text-sm text-[color:var(--brand-charcoal)] md:flex-row md:items-end">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]">Recherche</span>
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value);
+                setPage(1);
+              }}
+              placeholder="Nom, courriel ou sujet"
+              className="w-full rounded-full border border-[color:var(--brand-charcoal)]/20 bg-white px-4 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]">Issuer</span>
+            <select
+              value={issuer}
+              onChange={(event) => {
+                setIssuer(event.target.value);
+                setPage(1);
+              }}
+              className="w-full rounded-full border border-[color:var(--brand-charcoal)]/20 bg-white px-4 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+            >
+              <option value="">Tous</option>
+              {issuerOptions.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 rounded-full bg-[color:var(--brand-sand)]/70 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)]">
+            <input
+              type="checkbox"
+              checked={includeDetails}
+              onChange={(event) => {
+                setIncludeDetails(event.target.checked);
+                setPage(1);
+              }}
+              className="h-4 w-4 rounded border-[color:var(--brand-charcoal)]/30 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+            />
+            Activités détaillées
+          </label>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-[color:var(--brand-charcoal)]">
+          <label className="flex items-center gap-2">
+            <span>Par page</span>
+            <select
+              value={pageSize}
+              onChange={(event) => {
+                setPageSize(Number(event.target.value));
+                setPage(1);
+              }}
+              className="rounded-full border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-1 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+            >
+              {[25, 50, 100].map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </section>
+
+      {error ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50/80 p-4 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      {loading ? (
+        <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-inner">
+          <AdminSkeleton lines={8} />
+          <div className="mt-4">
+            <AdminSkeleton lines={8} />
+          </div>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-[color:var(--brand-charcoal)]/30 bg-white/80 p-6 text-center text-sm text-[color:var(--brand-charcoal)]">
+          Aucun utilisateur à afficher pour ces filtres.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
+          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+            <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Utilisateur</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Courriel</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Issuer</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Subject</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1"
+                    onClick={() => handleSort("loginCount")}
+                  >
+                    Connexions {sortLabel("loginCount")}
+                  </button>
+                </th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1"
+                    onClick={() => handleSort("completedActivities")}
+                  >
+                    Activités {sortLabel("completedActivities")}
+                  </button>
+                </th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1"
+                    onClick={() => handleSort("lastLoginAt")}
+                  >
+                    Dernière connexion {sortLabel("lastLoginAt")}
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[color:var(--brand-charcoal)]/10 bg-white/95">
+              {sortedUsers.map((user) => (
+                <tr key={`${user.issuer}-${user.subject}`} className="transition hover:bg-[color:var(--brand-sand)]/40">
+                  <td className="px-4 py-3">
+                    <div className="flex flex-col">
+                      <span className="font-semibold text-[color:var(--brand-black)]">{user.displayName}</span>
+                      {user.profileMissing ? (
+                        <span className="text-xs text-[color:var(--brand-red)]">Profil incomplet</span>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.email ?? "—"}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.issuer}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.subject}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-black)]">{user.loginCount}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-black)]">{user.completedActivities}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{formatDate(user.lastLoginAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <footer className="flex flex-col items-center justify-between gap-4 rounded-3xl border border-white/60 bg-white/90 p-4 text-xs text-[color:var(--brand-charcoal)] md:flex-row">
+        <div>
+          Page {page} sur {Math.max(totalPages, 1)}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPage((value) => Math.max(1, value - 1))}
+            disabled={!canGoPrevious}
+            className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 font-medium transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)] disabled:cursor-not-allowed disabled:border-transparent disabled:text-[color:var(--brand-charcoal)]/40"
+          >
+            Précédent
+          </button>
+          <button
+            type="button"
+            onClick={() => setPage((value) => value + 1)}
+            disabled={!canGoNext}
+            className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 font-medium transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)] disabled:cursor-not-allowed disabled:border-transparent disabled:text-[color:var(--brand-charcoal)]/40"
+          >
+            Suivant
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminPlatformsPage.tsx
+++ b/frontend/src/pages/admin/AdminPlatformsPage.tsx
@@ -1,0 +1,417 @@
+import { FormEvent, useCallback, useEffect, useState } from "react";
+
+import {
+  admin,
+  type AdminPlatform,
+  type AdminPlatformPayload,
+  type AdminPlatformSaveMode,
+} from "../../api";
+import { AdminModal } from "../../components/admin/AdminModal";
+import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+interface PlatformFormState {
+  issuer: string;
+  clientId: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  deploymentId: string;
+  deploymentIds: string;
+  audience: string;
+}
+
+function createFormState(platform?: AdminPlatform | null): PlatformFormState {
+  const deploymentIds = Array.from(new Set(platform?.deploymentIds ?? [])).join("\n");
+  return {
+    issuer: platform?.issuer ?? "",
+    clientId: platform?.clientId ?? "",
+    authorizationEndpoint: platform?.authorizationEndpoint ?? "",
+    tokenEndpoint: platform?.tokenEndpoint ?? "",
+    jwksUri: platform?.jwksUri ?? "",
+    deploymentId: platform?.deploymentId ?? "",
+    deploymentIds,
+    audience: platform?.audience ?? "",
+  };
+}
+
+function normalizePayload(state: PlatformFormState): AdminPlatformPayload {
+  const deployments = new Set<string>();
+  const deploymentId = state.deploymentId.trim();
+  if (deploymentId) {
+    deployments.add(deploymentId);
+  }
+  const extraDeployments = state.deploymentIds
+    .split(/\r?\n|,/) // handle newline or comma separated values
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  extraDeployments.forEach((value) => deployments.add(value));
+
+  const deploymentIds = Array.from(deployments);
+
+  return {
+    issuer: state.issuer.trim(),
+    clientId: state.clientId.trim(),
+    authorizationEndpoint: state.authorizationEndpoint.trim() || null,
+    tokenEndpoint: state.tokenEndpoint.trim() || null,
+    jwksUri: state.jwksUri.trim() || null,
+    deploymentId: deploymentId || null,
+    deploymentIds,
+    audience: state.audience.trim() || null,
+  };
+}
+
+export function AdminPlatformsPage(): JSX.Element {
+  const { token } = useAdminAuth();
+  const [platforms, setPlatforms] = useState<AdminPlatform[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingPlatform, setEditingPlatform] = useState<AdminPlatform | null>(null);
+  const [formState, setFormState] = useState<PlatformFormState>(() => createFormState());
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const fetchPlatforms = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await admin.platforms.list(token);
+      setPlatforms(response.platforms);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de récupérer les plateformes.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void fetchPlatforms();
+  }, [fetchPlatforms]);
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setEditingPlatform(null);
+    setFormState(createFormState());
+    setFormError(null);
+  };
+
+  const openCreateModal = () => {
+    setEditingPlatform(null);
+    setFormState(createFormState());
+    setFormError(null);
+    setModalOpen(true);
+  };
+
+  const openEditModal = (platform: AdminPlatform) => {
+    setEditingPlatform(platform);
+    setFormState(createFormState(platform));
+    setFormError(null);
+    setModalOpen(true);
+  };
+
+  const upsertPlatformInList = (platform: AdminPlatform) => {
+    setPlatforms((current) => {
+      const existingIndex = current.findIndex(
+        (item) => item.issuer === platform.issuer && item.clientId === platform.clientId
+      );
+      if (existingIndex === -1) {
+        return [...current, platform].sort((a, b) => {
+          const issuerCompare = a.issuer.localeCompare(b.issuer);
+          if (issuerCompare !== 0) {
+            return issuerCompare;
+          }
+          return a.clientId.localeCompare(b.clientId);
+        });
+      }
+      const next = [...current];
+      next[existingIndex] = platform;
+      return next;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSaving(true);
+    setFormError(null);
+    try {
+      const payload = normalizePayload(formState);
+      if (!payload.issuer || !payload.clientId) {
+        setFormError("L’issuer et le client ID sont requis.");
+        setSaving(false);
+        return;
+      }
+      const mode: AdminPlatformSaveMode = editingPlatform ? "replace" : "create";
+      const response = await admin.platforms.save(payload, { mode, token });
+      upsertPlatformInList(response.platform);
+      closeModal();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Échec de l’enregistrement de la plateforme.";
+      setFormError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (platform: AdminPlatform) => {
+    const confirmMessage = `Supprimer la plateforme ${platform.issuer} (${platform.clientId}) ?`;
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+    try {
+      await admin.platforms.remove(platform.issuer, platform.clientId, token);
+      setPlatforms((current) =>
+        current.filter((item) => !(item.issuer === platform.issuer && item.clientId === platform.clientId))
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Impossible de supprimer la plateforme.";
+      setError(message);
+    }
+  };
+
+  const modalTitle = editingPlatform ? "Modifier la plateforme LTI" : "Ajouter une plateforme LTI";
+  const modalDescription = editingPlatform
+    ? "Les modifications seront appliquées immédiatement."
+    : "Enregistre les informations fournies par ton fournisseur LTI.";
+  const isReadOnly = editingPlatform?.readOnly ?? false;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 border-b border-[color:var(--brand-charcoal)]/10 pb-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">Plateformes LTI</h2>
+          <p className="mt-1 text-sm text-[color:var(--brand-charcoal)]">
+            Déclare les plateformes de confiance et maintiens leurs paramètres d’authentification.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600"
+          >
+            + Nouvelle plateforme
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void fetchPlatforms();
+            }}
+            className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+          >
+            Rafraîchir
+          </button>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50/80 p-4 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-inner">
+          <AdminSkeleton lines={6} />
+          <div className="mt-4">
+            <AdminSkeleton lines={6} />
+          </div>
+        </div>
+      ) : platforms.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-[color:var(--brand-charcoal)]/30 bg-white/80 p-6 text-center text-sm text-[color:var(--brand-charcoal)]">
+          Aucune plateforme configurée pour le moment.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
+          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+            <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
+              <tr>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Issuer</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Client ID</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Audience</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Déploiements</th>
+                <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Statut</th>
+                <th className="px-4 py-3 text-right font-semibold uppercase tracking-wide">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[color:var(--brand-charcoal)]/10 bg-white/95">
+              {platforms.map((platform) => (
+                <tr key={`${platform.issuer}-${platform.clientId}`} className="transition hover:bg-[color:var(--brand-sand)]/40">
+                  <td className="px-4 py-3 font-medium text-[color:var(--brand-black)]">{platform.issuer}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{platform.clientId}</td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">
+                    {platform.audience ? platform.audience : <span className="text-xs italic text-[color:var(--brand-charcoal)]/60">(non défini)</span>}
+                  </td>
+                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">
+                    {platform.deploymentIds.length > 0 ? platform.deploymentIds.join(", ") : "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    {platform.readOnly ? (
+                      <span className="inline-flex items-center rounded-full bg-[color:var(--brand-charcoal)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
+                        Lecture seule
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-green-700">
+                        Éditable
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => openEditModal(platform)}
+                        className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-3 py-1 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+                      >
+                        Détails
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          void handleDelete(platform);
+                        }}
+                        className="rounded-full border border-red-200 px-3 py-1 text-xs font-medium text-red-600 transition hover:bg-red-50"
+                        disabled={platform.readOnly}
+                      >
+                        Supprimer
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <AdminModal
+        open={modalOpen}
+        onClose={closeModal}
+        title={modalTitle}
+        description={modalDescription}
+        size="lg"
+        footer={
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={closeModal}
+              className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-sm font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              form="admin-platform-form"
+              disabled={saving || isReadOnly}
+              className="rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-400"
+            >
+              {isReadOnly ? "Lecture seule" : saving ? "Enregistrement…" : "Enregistrer"}
+            </button>
+          </div>
+        }
+      >
+        {formError ? (
+          <p className="rounded-3xl bg-red-50 p-3 text-xs text-red-600">{formError}</p>
+        ) : null}
+        <form id="admin-platform-form" className="grid gap-4 sm:grid-cols-2" onSubmit={handleSubmit}>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Issuer
+            <input
+              type="url"
+              value={formState.issuer}
+              onChange={(event) => setFormState((prev) => ({ ...prev, issuer: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="https://lti.example"
+              required
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Client ID
+            <input
+              type="text"
+              value={formState.clientId}
+              onChange={(event) => setFormState((prev) => ({ ...prev, clientId: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="Identifiant fourni"
+              required
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            URL d’autorisation
+            <input
+              type="url"
+              value={formState.authorizationEndpoint}
+              onChange={(event) => setFormState((prev) => ({ ...prev, authorizationEndpoint: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="https://platform.example/auth"
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Token endpoint
+            <input
+              type="url"
+              value={formState.tokenEndpoint}
+              onChange={(event) => setFormState((prev) => ({ ...prev, tokenEndpoint: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="https://platform.example/token"
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            JWKS URI
+            <input
+              type="url"
+              value={formState.jwksUri}
+              onChange={(event) => setFormState((prev) => ({ ...prev, jwksUri: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="https://platform.example/jwks"
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Audience
+            <input
+              type="text"
+              value={formState.audience}
+              onChange={(event) => setFormState((prev) => ({ ...prev, audience: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="Audience optionnelle"
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Deployment ID principal
+            <input
+              type="text"
+              value={formState.deploymentId}
+              onChange={(event) => setFormState((prev) => ({ ...prev, deploymentId: event.target.value }))}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder="ex: deployment-123"
+              disabled={isReadOnly}
+            />
+          </label>
+          <label className="sm:col-span-2 flex flex-col gap-2 text-xs font-medium uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+            Autres deployment IDs (un par ligne)
+            <textarea
+              value={formState.deploymentIds}
+              onChange={(event) => setFormState((prev) => ({ ...prev, deploymentIds: event.target.value }))}
+              rows={3}
+              className="rounded-2xl border border-[color:var(--brand-charcoal)]/20 bg-white px-3 py-2 text-sm text-[color:var(--brand-black)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
+              placeholder={"deployment-456\ndeployment-789"}
+              disabled={isReadOnly}
+            />
+          </label>
+        </form>
+        {isReadOnly ? (
+          <p className="rounded-2xl bg-[color:var(--brand-sand)]/70 p-3 text-xs text-[color:var(--brand-charcoal)]">
+            Cette plateforme est gérée automatiquement et ne peut pas être modifiée depuis l’interface.
+          </p>
+        ) : null}
+      </AdminModal>
+    </div>
+  );
+}

--- a/frontend/src/providers/AdminAuthProvider.tsx
+++ b/frontend/src/providers/AdminAuthProvider.tsx
@@ -1,0 +1,246 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import {
+  admin,
+  type AdminAuthResponse,
+  type AdminLoginPayload,
+  type AdminMeResponse,
+  type AdminSession,
+  type AdminUser,
+} from "../api";
+
+type AdminAuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+interface StoredSession {
+  token: string;
+  expiresAt: string | null;
+}
+
+interface AdminAuthContextValue {
+  status: AdminAuthStatus;
+  user: AdminUser | null;
+  token: string | null;
+  expiresAt: string | null;
+  error: string | null;
+  isProcessing: boolean;
+  login: (payload: AdminLoginPayload) => Promise<{ ok: true } | { ok: false; error: string }>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+  applySession: (session: AdminSession) => void;
+}
+
+const STORAGE_KEY = "formationia.admin.session";
+
+const AdminAuthContext = createContext<AdminAuthContextValue | undefined>(undefined);
+
+function readStoredSession(): StoredSession | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+    if (!parsed || typeof parsed.token !== "string" || parsed.token.length === 0) {
+      return null;
+    }
+    return {
+      token: parsed.token,
+      expiresAt: typeof parsed.expiresAt === "string" ? parsed.expiresAt : null,
+    };
+  } catch (error) {
+    console.warn("Invalid admin session in storage", error);
+    return null;
+  }
+}
+
+function persistSession(session: StoredSession | null): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    if (!session || !session.token) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  } catch (error) {
+    console.warn("Unable to persist admin session", error);
+  }
+}
+
+interface AdminAuthProviderProps {
+  children: ReactNode;
+}
+
+export function AdminAuthProvider({ children }: AdminAuthProviderProps): JSX.Element {
+  const stored = useMemo(() => readStoredSession(), []);
+  const [status, setStatus] = useState<AdminAuthStatus>("loading");
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [token, setToken] = useState<string | null>(stored?.token ?? null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(stored?.expiresAt ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const tokenRef = useRef<string | null>(token);
+  useEffect(() => {
+    tokenRef.current = token;
+  }, [token]);
+
+  const applySession = useCallback(
+    (session: AdminSession) => {
+      setUser(session.user);
+      setToken(session.token);
+      setExpiresAt(session.expiresAt ?? null);
+      setStatus("authenticated");
+      setError(null);
+      if (session.token) {
+        persistSession({ token: session.token, expiresAt: session.expiresAt ?? null });
+      } else {
+        persistSession(null);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const bootstrap = async () => {
+      setStatus("loading");
+      try {
+        const response = await admin.auth.me(tokenRef.current);
+        if (cancelled) {
+          return;
+        }
+        const session: AdminSession = {
+          token: tokenRef.current ?? stored?.token ?? null,
+          expiresAt: response.expiresAt ?? null,
+          user: response.user,
+        };
+        applySession(session);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setUser(null);
+        setToken(null);
+        setExpiresAt(null);
+        setStatus("unauthenticated");
+        const message = err instanceof Error ? err.message : "Session administrateur expirée.";
+        setError(message);
+        persistSession(null);
+      }
+    };
+
+    void bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [applySession, stored?.token]);
+
+  const login = useCallback(
+    async (payload: AdminLoginPayload) => {
+      setIsProcessing(true);
+      setError(null);
+      try {
+        const response: AdminAuthResponse = await admin.auth.login(payload);
+        const session: AdminSession = {
+          token: response.token,
+          expiresAt: response.expiresAt ?? null,
+          user: response.user,
+        };
+        applySession(session);
+        return { ok: true } as const;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Impossible de se connecter.";
+        setUser(null);
+        setToken(null);
+        setExpiresAt(null);
+        setStatus("unauthenticated");
+        setError(message);
+        persistSession(null);
+        return { ok: false, error: message } as const;
+      } finally {
+        setIsProcessing(false);
+      }
+    },
+    [applySession]
+  );
+
+  const logout = useCallback(async () => {
+    setIsProcessing(true);
+    try {
+      await admin.auth.logout(tokenRef.current);
+    } catch (err) {
+      console.warn("Failed to logout admin", err);
+    } finally {
+      setUser(null);
+      setToken(null);
+      setExpiresAt(null);
+      setStatus("unauthenticated");
+      setError(null);
+      persistSession(null);
+      setIsProcessing(false);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    setIsProcessing(true);
+    try {
+      const response: AdminMeResponse = await admin.auth.me(tokenRef.current);
+      const session: AdminSession = {
+        token: tokenRef.current,
+        expiresAt: response.expiresAt ?? null,
+        user: response.user,
+      };
+      applySession(session);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Session administrateur expirée.";
+      setError(message);
+      setUser(null);
+      setToken(null);
+      setExpiresAt(null);
+      setStatus("unauthenticated");
+      persistSession(null);
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [applySession]);
+
+  const value = useMemo<AdminAuthContextValue>(
+    () => ({
+      status,
+      user,
+      token,
+      expiresAt,
+      error,
+      isProcessing,
+      login,
+      logout,
+      refresh,
+      applySession,
+    }),
+    [status, user, token, expiresAt, error, isProcessing, login, logout, refresh, applySession]
+  );
+
+  return <AdminAuthContext.Provider value={value}>{children}</AdminAuthContext.Provider>;
+}
+
+export function useAdminAuth(): AdminAuthContextValue {
+  const context = useContext(AdminAuthContext);
+  if (!context) {
+    throw new Error("useAdminAuth doit être utilisé dans un AdminAuthProvider.");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add an admin API client and authentication provider that persists the session token
- create the administration routes, layouts, and pages for platforms, LTI users, and local accounts with reusable modals
- surface the admin entry points in the existing navigation when an administrator is logged in

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd3771f634832283018ae2bdd72f6f