### PR TITLE
feat: add ActivityLayout and refactor activity pages

### DIFF
--- a/frontend/src/components/ActivityLayout.tsx
+++ b/frontend/src/components/ActivityLayout.tsx
@@ -1,0 +1,93 @@
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+import logoPrincipal from "../assets/logo_principal.svg";
+
+interface ActivityLayoutProps {
+  activityId?: string;
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  leadingContent?: ReactNode;
+  headerActions?: ReactNode;
+  headerChildren?: ReactNode;
+  headerBody?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  containerClassName?: string;
+  headerClassName?: string;
+  contentClassName?: string;
+}
+
+function ActivityLayout({
+  activityId,
+  eyebrow,
+  title,
+  subtitle,
+  badge,
+  leadingContent,
+  headerActions,
+  headerChildren,
+  headerBody,
+  children,
+  className,
+  containerClassName,
+  headerClassName,
+  contentClassName,
+}: ActivityLayoutProps): JSX.Element {
+  const dataAttributes = activityId ? { "data-activity-id": activityId } : undefined;
+  const outerClasses = `landing-gradient min-h-screen px-6 py-16 text-[color:var(--brand-black)] ${
+    className ?? ""
+  }`;
+  const containerClasses = `mx-auto max-w-6xl space-y-10 ${containerClassName ?? ""}`;
+  const headerClasses = `space-y-6 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur ${
+    headerClassName ?? ""
+  }`;
+  const mainClasses = `space-y-10 ${contentClassName ?? ""}`;
+  const showActionGroup = Boolean(badge) || Boolean(headerActions);
+
+  return (
+    <div className={outerClasses} {...dataAttributes}>
+      <div className={containerClasses}>
+        {leadingContent}
+        <header className={headerClasses}>
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <Link to="/" className="flex items-center gap-3">
+              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-14" />
+              {eyebrow ? (
+                <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
+                  {eyebrow}
+                </span>
+              ) : null}
+            </Link>
+            {showActionGroup ? (
+              <div className="flex flex-col items-center gap-3 md:flex-row md:items-center md:gap-4">
+                {badge ? (
+                  <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
+                    {badge}
+                  </span>
+                ) : null}
+                {headerActions}
+              </div>
+            ) : null}
+          </div>
+          {headerBody ?? (
+            <div className="space-y-3 text-center md:text-left">
+              <h1 className="text-3xl font-semibold md:text-4xl">{title}</h1>
+              {subtitle ? (
+                <p className="mx-auto max-w-3xl text-sm leading-relaxed text-[color:var(--brand-charcoal)] md:text-base">
+                  {subtitle}
+                </p>
+              ) : null}
+            </div>
+          )}
+          {headerChildren}
+        </header>
+        <main className={mainClasses}>{children}</main>
+      </div>
+    </div>
+  );
+}
+
+export default ActivityLayout;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from "react";
-import { Link } from "react-router-dom";
 
-import logoPrincipal from "../assets/logo_principal.svg";
+import ActivityLayout from "./ActivityLayout";
 
 interface LayoutProps {
   currentStep: number;
@@ -15,65 +14,63 @@ const STEPS = [
 ];
 
 function Layout({ currentStep, children }: LayoutProps): JSX.Element {
-  return (
-    <div className="landing-gradient min-h-screen px-6 pb-16 pt-10 text-[color:var(--brand-black)]">
-      <div className="mx-auto flex max-w-6xl flex-col gap-12">
-        <header className="space-y-8 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur">
-          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-            <Link to="/" className="flex items-center gap-3">
-              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-16" />
-              <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
-                Atelier comparatif IA
-              </span>
-            </Link>
-            <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-              Trois étapes guidées
-            </span>
-          </div>
-          <div className="grid gap-6 md:grid-cols-[3fr_2fr] md:items-start">
-            <div className="space-y-3">
-              <h1 className="text-3xl font-semibold leading-tight md:text-4xl">
-                Cadrez, comparez, synthétisez vos essais IA
-              </h1>
-              <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base">
-                Suivez une progression claire pour préparer votre contexte, explorer deux profils IA en flux continu puis transformer les sorties en ressources réutilisables.
-              </p>
-            </div>
-            <div className="rounded-3xl border border-white/60 bg-white/85 p-6 text-sm shadow-sm">
-              <p className="font-semibold uppercase tracking-wide text-[color:var(--brand-red)]">Au programme</p>
-              <ul className="mt-3 space-y-2 text-[color:var(--brand-charcoal)]">
-                <li>• Décrire précisément le contexte et les attentes.</li>
-                <li>• Ajuster modèle, verbosité et effort de raisonnement.</li>
-                <li>• Comparer les productions pour créer une synthèse fiable.</li>
-              </ul>
-            </div>
-          </div>
-          <nav className="grid gap-3 md:grid-cols-3">
-            {STEPS.map((step) => {
-              const isActive = currentStep === step.number;
-              const isCompleted = currentStep > step.number;
-              const baseClasses = "rounded-full px-5 py-3 text-sm font-semibold transition shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
-              const stateClasses = isActive
-                ? "bg-[color:var(--brand-red)] text-white"
-                : isCompleted
-                ? "bg-white text-[color:var(--brand-black)]"
-                : "bg-white/70 text-[color:var(--brand-charcoal)]/80 hover:bg-white";
-              return (
-                <div
-                  key={step.number}
-                  className={`${baseClasses} ${stateClasses}`}
-                  aria-current={isActive ? "step" : undefined}
-                >
-                  Étape {step.number} · {step.label}
-                </div>
-              );
-            })}
-          </nav>
-        </header>
+  const title = "Cadrez, comparez, synthétisez vos essais IA";
+  const subtitle =
+    "Suivez une progression claire pour préparer votre contexte, explorer deux profils IA en flux continu puis transformer les sorties en ressources réutilisables.";
 
-        <main className="space-y-12">{children}</main>
-      </div>
-    </div>
+  return (
+    <ActivityLayout
+      activityId="atelier-comparatif"
+      eyebrow="Atelier comparatif IA"
+      title={title}
+      subtitle={subtitle}
+      badge="Trois étapes guidées"
+      className="pb-16 pt-10"
+      containerClassName="space-y-12"
+      headerClassName="space-y-8"
+      contentClassName="space-y-12"
+      headerBody={
+        <div className="grid gap-6 md:grid-cols-[3fr_2fr] md:items-start">
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold leading-tight md:text-4xl">{title}</h1>
+            <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base">{subtitle}</p>
+          </div>
+          <div className="rounded-3xl border border-white/60 bg-white/85 p-6 text-sm shadow-sm">
+            <p className="font-semibold uppercase tracking-wide text-[color:var(--brand-red)]">Au programme</p>
+            <ul className="mt-3 space-y-2 text-[color:var(--brand-charcoal)]">
+              <li>• Décrire précisément le contexte et les attentes.</li>
+              <li>• Ajuster modèle, verbosité et effort de raisonnement.</li>
+              <li>• Comparer les productions pour créer une synthèse fiable.</li>
+            </ul>
+          </div>
+        </div>
+      }
+      headerChildren={
+        <nav className="grid gap-3 md:grid-cols-3">
+          {STEPS.map((step) => {
+            const isActive = currentStep === step.number;
+            const isCompleted = currentStep > step.number;
+            const baseClasses = "rounded-full px-5 py-3 text-sm font-semibold transition shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
+            const stateClasses = isActive
+              ? "bg-[color:var(--brand-red)] text-white"
+              : isCompleted
+              ? "bg-white text-[color:var(--brand-black)]"
+              : "bg-white/70 text-[color:var(--brand-charcoal)]/80 hover:bg-white";
+            return (
+              <div
+                key={step.number}
+                className={`${baseClasses} ${stateClasses}`}
+                aria-current={isActive ? "step" : undefined}
+              >
+                Étape {step.number} · {step.label}
+              </div>
+            );
+          })}
+        </nav>
+      }
+    >
+      {children}
+    </ActivityLayout>
   );
 }
 

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
-import logoPrincipal from "../assets/logo_principal.svg";
 import { getProgress, type ProgressResponse } from "../api";
 import {
   ACTIVITY_DEFINITIONS,
   type ActivityDefinition,
 } from "../config/activities";
 import { useLTI } from "../hooks/useLTI";
+import ActivityLayout from "../components/ActivityLayout";
 
 function ActivitySelector(): JSX.Element {
   const [completedMap, setCompletedMap] = useState<Record<string, boolean>>({});
@@ -85,115 +85,107 @@ function ActivitySelector(): JSX.Element {
     };
   }, []);
 
-  return (
-    <div className="landing-gradient min-h-screen px-6 py-16 text-[color:var(--brand-black)]">
-      <div className="mx-auto flex max-w-6xl flex-col gap-12">
-        {completedActivity ? (
-          <div className="animate-section flex flex-col gap-4 rounded-3xl border border-green-200/80 bg-green-50/90 p-6 text-green-900 shadow-sm backdrop-blur">
-            <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-wider text-green-700/80">
-                Activité terminée
-              </p>
-              <p className="text-lg font-semibold md:text-xl">
-                Tu as complété l’activité « {completedActivity.title} »
-              </p>
-            </div>
-            <div className="flex flex-col gap-3 text-sm text-green-800 md:flex-row md:items-center md:justify-between">
-              <span className="text-sm md:text-base">
-                Tu peux rouvrir l’activité pour revoir tes actions ou poursuivre une autre compétence.
-              </span>
-              <div className="flex flex-col items-stretch gap-2 md:flex-row md:items-center">
-                <Link
-                  to={completedActivity.cta.to}
-                  className="cta-button cta-button--secondary inline-flex items-center justify-center gap-2 border-green-600/40 bg-white/80 px-4 py-2 text-green-800 transition hover:border-green-600/70 hover:bg-white"
-                  onClick={() => setCompletedActivity(null)}
-                >
-                  Ouvrir l’activité
-                  <span className="text-lg">↗</span>
-                </Link>
-                <button
-                  type="button"
-                  className="inline-flex items-center justify-center rounded-full border border-green-600/30 px-4 py-2 text-sm font-medium text-green-700 transition hover:border-green-600/60 hover:text-green-800"
-                  onClick={() => setCompletedActivity(null)}
-                >
-                  Fermer
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : null}
-        {shouldShowWelcome ? (
-          <div className="animate-section rounded-3xl border border-white/70 bg-white/90 p-6 text-center shadow-sm backdrop-blur">
-            <p className="text-lg font-medium text-[color:var(--brand-charcoal)] md:text-xl">
-              Bienvenue <span className="font-semibold text-[color:var(--brand-black)]">{displayName}</span>
-            </p>
-          </div>
-        ) : null}
-        <header className="space-y-6 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur animate-section">
-          <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
-            <Link to="/" className="flex items-center gap-3">
-              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-14" />
-              <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
-                Choisis ton activité
-              </span>
-            </Link>
-            <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-              Objectifs pédagogiques
-            </span>
-          </div>
-          <div className="space-y-3 text-center md:text-left">
-            <h1 className="text-3xl font-semibold md:text-4xl">
-              Quelle compétence veux-tu travailler avec l’IA ?
-            </h1>
-            <p className="mx-auto max-w-3xl text-sm text-[color:var(--brand-charcoal)] md:text-base">
-              Chaque activité se concentre sur une intention distincte : cadrer une demande, affiner un prompt, tester une consigne ou vérifier l’exhaustivité d’un brief.
-            </p>
-          </div>
-        </header>
-
-        <div className="grid gap-6 md:grid-cols-2 animate-section-delayed">
-          {ACTIVITY_DEFINITIONS.map((activity: ActivityDefinition) => (
-            <article
-              key={activity.id}
-              className="group relative flex h-full flex-col gap-6 rounded-3xl border border-white/60 bg-white/90 p-8 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg"
-            >
-              {completedMap[activity.id] ? (
-                <span className="absolute right-6 top-6 flex h-9 w-9 items-center justify-center rounded-full bg-green-100 text-green-700 shadow-sm">
-                  ✓
-                </span>
-              ) : null}
-              <div className="space-y-3">
-                <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">
-                  {activity.title}
-                </h2>
-                <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90">
-                  {activity.description}
+  const leadingContent = completedActivity || shouldShowWelcome
+    ? (
+        <>
+          {completedActivity ? (
+            <div className="animate-section flex flex-col gap-4 rounded-3xl border border-green-200/80 bg-green-50/90 p-6 text-green-900 shadow-sm backdrop-blur">
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-wider text-green-700/80">
+                  Activité terminée
+                </p>
+                <p className="text-lg font-semibold md:text-xl">
+                  Tu as complété l’activité « {completedActivity.title} »
                 </p>
               </div>
-              <ul className="flex flex-col gap-2 text-sm text-[color:var(--brand-charcoal)]">
-                {activity.highlights.map((item) => (
-                  <li key={item} className="flex items-center gap-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-                      +
-                    </span>
-                    <span>{item}</span>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-auto">
-                <Link
-                  to={activity.cta.to}
-                  className="cta-button cta-button--primary inline-flex items-center gap-2"
-                >
-                  {activity.cta.label}
-                  <span className="inline-block text-lg transition group-hover:translate-x-1">→</span>
-                </Link>
+              <div className="flex flex-col gap-3 text-sm text-green-800 md:flex-row md:items-center md:justify-between">
+                <span className="text-sm md:text-base">
+                  Tu peux rouvrir l’activité pour revoir tes actions ou poursuivre une autre compétence.
+                </span>
+                <div className="flex flex-col items-stretch gap-2 md:flex-row md:items-center">
+                  <Link
+                    to={completedActivity.cta.to}
+                    className="cta-button cta-button--secondary inline-flex items-center justify-center gap-2 border-green-600/40 bg-white/80 px-4 py-2 text-green-800 transition hover:border-green-600/70 hover:bg-white"
+                    onClick={() => setCompletedActivity(null)}
+                  >
+                    Ouvrir l’activité
+                    <span className="text-lg">↗</span>
+                  </Link>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-full border border-green-600/30 px-4 py-2 text-sm font-medium text-green-700 transition hover:border-green-600/60 hover:text-green-800"
+                    onClick={() => setCompletedActivity(null)}
+                  >
+                    Fermer
+                  </button>
+                </div>
               </div>
-            </article>
-          ))}
-        </div>
+            </div>
+          ) : null}
+          {shouldShowWelcome ? (
+            <div className="animate-section rounded-3xl border border-white/70 bg-white/90 p-6 text-center shadow-sm backdrop-blur">
+              <p className="text-lg font-medium text-[color:var(--brand-charcoal)] md:text-xl">
+                Bienvenue <span className="font-semibold text-[color:var(--brand-black)]">{displayName}</span>
+              </p>
+            </div>
+          ) : null}
+        </>
+      )
+    : null;
+
+  return (
+    <ActivityLayout
+      activityId="activity-selector"
+      eyebrow="Choisis ton activité"
+      title="Quelle compétence veux-tu travailler avec l’IA ?"
+      subtitle="Chaque activité se concentre sur une intention distincte : cadrer une demande, affiner un prompt, tester une consigne ou vérifier l’exhaustivité d’un brief."
+      badge="Objectifs pédagogiques"
+      leadingContent={leadingContent}
+      containerClassName="space-y-12"
+      headerClassName="animate-section"
+    >
+      <div className="grid gap-6 md:grid-cols-2 animate-section-delayed">
+        {ACTIVITY_DEFINITIONS.map((activity: ActivityDefinition) => (
+          <article
+            key={activity.id}
+            className="group relative flex h-full flex-col gap-6 rounded-3xl border border-white/60 bg-white/90 p-8 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            {completedMap[activity.id] ? (
+              <span className="absolute right-6 top-6 flex h-9 w-9 items-center justify-center rounded-full bg-green-100 text-green-700 shadow-sm">
+                ✓
+              </span>
+            ) : null}
+            <div className="space-y-3">
+              <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">
+                {activity.title}
+              </h2>
+              <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90">
+                {activity.description}
+              </p>
+            </div>
+            <ul className="flex flex-col gap-2 text-sm text-[color:var(--brand-charcoal)]">
+              {activity.highlights.map((item) => (
+                <li key={item} className="flex items-center gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
+                    +
+                  </span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-auto">
+              <Link
+                to={activity.cta.to}
+                className="cta-button cta-button--primary inline-flex items-center gap-2"
+              >
+                {activity.cta.label}
+                <span className="inline-block text-lg transition group-hover:translate-x-1">→</span>
+              </Link>
+            </div>
+          </article>
+        ))}
       </div>
-    </div>
+    </ActivityLayout>
   );
 }
 

--- a/frontend/src/pages/ClarityPath.tsx
+++ b/frontend/src/pages/ClarityPath.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { API_AUTH_KEY, API_BASE_URL } from "../config";
 import { useLTI } from "../hooks/useLTI";
 import { updateActivityProgress } from "../api";
+import ActivityLayout from "../components/ActivityLayout";
 
 const GRID_SIZE = 10;
 
@@ -869,139 +870,145 @@ function ClarityPath(): JSX.Element {
     return `Échec : le plan s’est arrêté après ${stats.stepsExecuted} pas (${optimalPart}).\nAjoute des directions explicites et indique le nombre de cases pour guider le modèle.`;
   }, [stats]);
 
+  const isIntro = phase === "intro";
+  const introTitle = "Donner une bonne consigne, c’est gagner du temps.";
+  const introSubtitle =
+    "Avant de jouer, découvre comment la précision de tes instructions influence directement le trajet de notre bonhomme. Formule une consigne claire pour atteindre la cible rapidement.";
+  const gameTitle = "Guide le bonhomme avec une consigne limpide";
+  const gameSubtitle =
+    "Écris une instruction en langue naturelle. Le backend demande au modèle gpt-5-nano un plan complet, valide la trajectoire puis te montre l’exécution pas à pas.";
+
   return (
-    <div className="landing-gradient min-h-screen px-6 py-16 text-[color:var(--brand-black)]">
-      {phase === "intro" ? (
-        <div className="mx-auto flex max-w-4xl flex-col gap-10 text-center">
-          <span className="inline-flex items-center justify-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]">
-            Parcours de la clarté
-          </span>
-          <div className="space-y-4">
-            <h1 className="text-3xl font-semibold md:text-4xl">
-              Donner une bonne consigne, c’est gagner du temps.
-            </h1>
-            <p className="mx-auto max-w-3xl text-sm text-[color:var(--brand-charcoal)] md:text-base">
-              Avant de jouer, découvre comment la précision de tes instructions influence directement le trajet de notre bonhomme. Formule une consigne claire pour atteindre la cible rapidement.
-            </p>
+    <ActivityLayout
+      activityId="clarity"
+      eyebrow="Parcours de la clarté"
+      title={isIntro ? introTitle : gameTitle}
+      subtitle={isIntro ? introSubtitle : gameSubtitle}
+      containerClassName={isIntro ? "max-w-4xl" : undefined}
+      headerBody={
+        isIntro ? (
+          <div className="space-y-4 text-center">
+            <h1 className="text-3xl font-semibold md:text-4xl">{introTitle}</h1>
+            <p className="mx-auto max-w-3xl text-sm text-[color:var(--brand-charcoal)] md:text-base">{introSubtitle}</p>
           </div>
-          <div className="grid gap-4 text-left text-sm text-[color:var(--brand-charcoal)] md:grid-cols-3">
-            <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
-              Une consigne vague = essais, détours, blocages.
-            </div>
-            <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
-              Une consigne précise = trajectoire directe et résultat fiable.
-            </div>
-            <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
-              Ici, ta formulation influe sur le chemin du bonhomme.
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={handleStart}
-            className="cta-button cta-button--primary mx-auto inline-flex items-center gap-2"
-          >
-            Jouer
-            <span className="text-lg">→</span>
-          </button>
-        </div>
-      ) : (
-        <div className="relative mx-auto flex max-w-6xl flex-col gap-10">
-          <FireworksOverlay active={celebrating} />
-          <header className="space-y-4">
-            <span className="inline-flex items-center justify-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]">
-              Parcours de la clarté
-            </span>
-            <h2 className="text-3xl font-semibold md:text-4xl">
-              Guide le bonhomme avec une consigne limpide
-            </h2>
-            <p className="max-w-3xl text-sm text-[color:var(--brand-charcoal)] md:text-base">
-              Écris une instruction en langue naturelle. Le backend demande au modèle gpt-5-nano un plan complet, valide la trajectoire puis te montre l’exécution pas à pas.
-            </p>
-          </header>
-
-          <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
-            <section className="rounded-3xl border border-white/60 bg-white/85 p-8 shadow-sm backdrop-blur">
-              <div className="flex flex-col gap-8">
-                <div className="space-y-4 text-sm text-[color:var(--brand-charcoal)]">
-                  <p>
-                    Objectif actuel : <strong>🎯 ({target.x}, {target.y})</strong>. Bonhomme au départ : <strong>(0,0)</strong>.
-                  </p>
-                  <p>
-                    Mouvements autorisés : left, right, up, down. Le backend génère d’abord un plan complet, le valide puis diffuse l’animation.
-                  </p>
-                </div>
-
-                <ClarityGrid player={player} target={target} blocked={blocked} visited={visitedCells} />
-
-                {message && (
-                  <div
-                    className={`rounded-2xl p-4 text-sm ${
-                      status === "success"
-                        ? "bg-[color:var(--brand-green,#66CDAA)]/20 text-[color:var(--brand-black)]"
-                        : status === "blocked"
-                        ? "bg-[color:var(--brand-red)]/15 text-[color:var(--brand-charcoal)]"
-                        : "bg-white/70 text-[color:var(--brand-charcoal)]"
-                    }`}
-                  >
-                    {message}
-                  </div>
-                )}
+        ) : undefined
+      }
+      headerChildren={
+        isIntro ? (
+          <>
+            <div className="grid gap-4 text-left text-sm text-[color:var(--brand-charcoal)] md:grid-cols-3">
+              <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
+                Une consigne vague = essais, détours, blocages.
               </div>
-            </section>
+              <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
+                Une consigne précise = trajectoire directe et résultat fiable.
+              </div>
+              <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
+                Ici, ta formulation influe sur le chemin du bonhomme.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleStart}
+              className="cta-button cta-button--primary mx-auto inline-flex items-center gap-2"
+            >
+              Jouer
+              <span className="text-lg">→</span>
+            </button>
+          </>
+        ) : undefined
+      }
+    >
+      {isIntro ? null : (
+        <>
+          <div className="relative">
+            <FireworksOverlay active={celebrating} />
+            <div className="grid gap-6 xl:grid-cols-[1.2fr_1fr]">
+              <section className="rounded-3xl border border-white/60 bg-white/85 p-8 shadow-sm backdrop-blur">
+                <div className="flex flex-col gap-8">
+                  <div className="space-y-4 text-sm text-[color:var(--brand-charcoal)]">
+                    <p>
+                      Objectif actuel : <strong>🎯 ({target.x}, {target.y})</strong>. Bonhomme au départ : <strong>(0,0)</strong>.
+                    </p>
+                    <p>
+                      Mouvements autorisés : left, right, up, down. Le backend génère d’abord un plan complet, le valide puis diffuse l’animation.
+                    </p>
+                  </div>
 
-            <aside className="flex flex-col gap-6">
-              <section className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <h3 className="text-lg font-semibold text-[color:var(--brand-black)]">Ta consigne</h3>
-                    <button
-                      type="button"
-                      className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--brand-charcoal)] hover:text-[color:var(--brand-black)]"
-                      onClick={() => setInstruction("Descends 9 cases puis va à droite 9 cases jusqu’à l’objet en bas à droite.")}
-                      disabled={isInstructionDisabled}
+                  <ClarityGrid player={player} target={target} blocked={blocked} visited={visitedCells} />
+
+                  {message && (
+                    <div
+                      className={`rounded-2xl p-4 text-sm ${
+                        status === "success"
+                          ? "bg-[color:var(--brand-green,#66CDAA)]/20 text-[color:var(--brand-black)]"
+                          : status === "blocked"
+                          ? "bg-[color:var(--brand-red)]/15 text-[color:var(--brand-charcoal)]"
+                          : "bg-white/70 text-[color:var(--brand-charcoal)]"
+                      }`}
                     >
-                      Exemple clair
-                    </button>
-                  </div>
-                  <textarea
-                    value={instruction}
-                    onChange={(event) => setInstruction(event.target.value)}
-                    placeholder="Exemple : Descends 9 cases puis va à droite 9 cases jusqu'à l’objet en bas à droite."
-                    rows={4}
-                    className="w-full rounded-2xl border border-white/60 bg-white/95 p-4 text-sm text-[color:var(--brand-charcoal)] shadow-sm outline-none transition focus:border-[color:var(--brand-red)]/40 focus:ring-2 focus:ring-[color:var(--brand-red)]/30"
-                    disabled={isInstructionDisabled}
-                  />
-                  <div className="flex flex-wrap gap-2 text-xs text-[color:var(--brand-charcoal)]/90">
-                    {MICRO_TIPS.map((tip) => (
-                      <span key={tip} className="rounded-full bg-[color:var(--brand-yellow)]/40 px-3 py-1">
-                        {tip}
-                      </span>
-                    ))}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <button
-                      type="submit"
-                      className="cta-button cta-button--primary inline-flex items-center gap-2"
-                      disabled={isInstructionDisabled}
-                    >
-                      {isLoading ? "Calcul en cours…" : "Envoyer"}
-                      <span className="text-lg">→</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="cta-button inline-flex items-center gap-2 border border-[color:var(--brand-red)]/25 bg-white/80 text-[color:var(--brand-red)] hover:bg-white"
-                      onClick={handleShuffleObstacles}
-                      disabled={areObstacleActionsDisabled}
-                    >
-                      Changer les obstacles
-                    </button>
-                  </div>
-                </form>
+                      {message}
+                    </div>
+                  )}
+                </div>
               </section>
 
-              <PlanPreview plan={plan} notes={notes} />
-              <ClarityTipsPanel />
-            </aside>
+              <aside className="flex flex-col gap-6">
+                <section className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
+                  <form onSubmit={handleSubmit} className="space-y-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-lg font-semibold text-[color:var(--brand-black)]">Ta consigne</h3>
+                      <button
+                        type="button"
+                        className="text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--brand-charcoal)] hover:text-[color:var(--brand-black)]"
+                        onClick={() =>
+                          setInstruction("Descends 9 cases puis va à droite 9 cases jusqu’à l’objet en bas à droite.")
+                        }
+                        disabled={isInstructionDisabled}
+                      >
+                        Exemple clair
+                      </button>
+                    </div>
+                    <textarea
+                      value={instruction}
+                      onChange={(event) => setInstruction(event.target.value)}
+                      placeholder="Exemple : Descends 9 cases puis va à droite 9 cases jusqu'à l’objet en bas à droite."
+                      rows={4}
+                      className="w-full rounded-2xl border border-white/60 bg-white/95 p-4 text-sm text-[color:var(--brand-charcoal)] shadow-sm outline-none transition focus:border-[color:var(--brand-red)]/40 focus:ring-2 focus:ring-[color:var(--brand-red)]/30"
+                      disabled={isInstructionDisabled}
+                    />
+                    <div className="flex flex-wrap gap-2 text-xs text-[color:var(--brand-charcoal)]/90">
+                      {MICRO_TIPS.map((tip) => (
+                        <span key={tip} className="rounded-full bg-[color:var(--brand-yellow)]/40 px-3 py-1">
+                          {tip}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <button
+                        type="submit"
+                        className="cta-button cta-button--primary inline-flex items-center gap-2"
+                        disabled={isInstructionDisabled}
+                      >
+                        {isLoading ? "Calcul en cours…" : "Envoyer"}
+                        <span className="text-lg">→</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="cta-button inline-flex items-center gap-2 border border-[color:var(--brand-red)]/25 bg-white/80 text-[color:var(--brand-red)] hover:bg-white"
+                        onClick={handleShuffleObstacles}
+                        disabled={areObstacleActionsDisabled}
+                      >
+                        Changer les obstacles
+                      </button>
+                    </div>
+                  </form>
+                </section>
+
+                <PlanPreview plan={plan} notes={notes} />
+                <ClarityTipsPanel />
+              </aside>
+            </div>
           </div>
 
           {stats && isStatsModalOpen && (
@@ -1024,9 +1031,9 @@ function ClarityPath(): JSX.Element {
               }}
             />
           )}
-        </div>
+        </>
       )}
-    </div>
+    </ActivityLayout>
   );
 }
 

--- a/frontend/src/pages/ClarteDabord.tsx
+++ b/frontend/src/pages/ClarteDabord.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import type { Mission, StageAnswer, StageRecord } from "../api";
 import { getMissions, submitStage, updateActivityProgress } from "../api";
 import FinalReveal from "../components/FinalReveal";
 import MissionSelector from "../components/MissionSelector";
 import PromptStage from "../components/PromptStage";
-import logoPrincipal from "../assets/logo_principal.svg";
+import ActivityLayout from "../components/ActivityLayout";
 
 function generateRunId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -192,55 +192,37 @@ function ClarteDabord(): JSX.Element {
   };
 
   return (
-    <div className="landing-gradient min-h-screen px-6 py-16">
-      <div className="mx-auto flex max-w-6xl flex-col gap-10">
-        <header className="space-y-6 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur">
-          <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
-            <Link to="/" className="flex items-center gap-3">
-              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-14" />
-              <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
-                Clarté d’abord !
-              </span>
-            </Link>
-            <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-              Trois manches guidées
-            </span>
-          </div>
-          <div className="space-y-2 text-center md:text-left">
-            <h1 className="text-3xl font-semibold md:text-4xl">
-              Identifie ce qu’il fallait dire dès la première consigne
-            </h1>
-            <p className="mx-auto max-w-3xl text-sm text-[color:var(--brand-charcoal)] md:text-base">
-              Tu joues l’IA : l’usager précise son besoin manche après manche. Observe ce qui manquait au brief initial et retiens la checklist idéale.
-            </p>
-          </div>
-        </header>
-
-        {loading ? (
-          <div className="rounded-3xl border border-white/60 bg-white/90 p-6 text-center text-sm text-[color:var(--brand-charcoal)]">
-            Chargement des missions…
-          </div>
-        ) : error ? (
-          <div className="space-y-4 rounded-3xl border border-white/60 bg-white/90 p-6 text-center shadow-sm">
-            <p className="text-sm font-semibold text-red-600">{error}</p>
-            <button
-              type="button"
-              className="cta-button cta-button--light"
-              onClick={() => {
-                setSelectedMissionId(null);
-                setReloadCount((count) => count + 1);
-              }}
-            >
-              Réessayer
-            </button>
-          </div>
-        ) : !selectedMission ? (
-          <MissionSelector missions={missions} onSelect={startMission} />
-        ) : (
-          missionContent()
-        )}
-      </div>
-    </div>
+    <ActivityLayout
+      activityId="clarte-dabord"
+      eyebrow="Clarté d’abord !"
+      title="Identifie ce qu’il fallait dire dès la première consigne"
+      subtitle="Tu joues l’IA : l’usager précise son besoin manche après manche. Observe ce qui manquait au brief initial et retiens la checklist idéale."
+      badge="Trois manches guidées"
+    >
+      {loading ? (
+        <div className="rounded-3xl border border-white/60 bg-white/90 p-6 text-center text-sm text-[color:var(--brand-charcoal)]">
+          Chargement des missions…
+        </div>
+      ) : error ? (
+        <div className="space-y-4 rounded-3xl border border-white/60 bg-white/90 p-6 text-center shadow-sm">
+          <p className="text-sm font-semibold text-red-600">{error}</p>
+          <button
+            type="button"
+            className="cta-button cta-button--light"
+            onClick={() => {
+              setSelectedMissionId(null);
+              setReloadCount((count) => count + 1);
+            }}
+          >
+            Réessayer
+          </button>
+        </div>
+      ) : !selectedMission ? (
+        <MissionSelector missions={missions} onSelect={startMission} />
+      ) : (
+        missionContent()
+      )}
+    </ActivityLayout>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a reusable `ActivityLayout` component that wraps the landing background, header content, and main area
- refactor the workshop layout and each activity page to rely on `ActivityLayout` instead of duplicating markup
- adjust the clarity path intro and gameplay views to render through the shared layout component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd39ac14888322a8e62f27cd6279f8