### PR TITLE
Expose activities config publicly

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1705,6 +1705,13 @@ def admin_list_lti_users(
     }
 
 
+@app.get("/activities-config")
+def get_activities_config() -> dict[str, Any]:
+    """Endpoint public renvoyant la configuration des activités."""
+    activities = _load_activities_config()
+    return {"activities": activities}
+
+
 @admin_router.get("/activities")
 def admin_get_activities_config(
     _: LocalUser = Depends(_require_admin_user),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -344,6 +344,11 @@ export interface SaveActivityConfigResponse {
   message: string;
 }
 
+export const activities = {
+  getConfig: async (): Promise<ActivityConfigResponse> =>
+    fetchJson<ActivityConfigResponse>(`${API_BASE_URL}/activities-config`),
+};
+
 export const admin = {
   activities: {
     get: async (token?: string | null): Promise<ActivityConfigResponse> =>

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import ActivityLayout from "../components/ActivityLayout";
-import { getProgress, admin, type ProgressResponse } from "../api";
+import {
+  getProgress,
+  admin,
+  activities as activitiesClient,
+  type ProgressResponse,
+} from "../api";
 import {
   ACTIVITY_DEFINITIONS,
   type ActivityDefinition,
@@ -110,10 +115,8 @@ function ActivitySelector(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (canShowAdminButton) {
-      loadSavedConfig();
-    }
-  }, [canShowAdminButton]);
+    void loadSavedConfig();
+  }, []);
 
   const handleMoveActivity = (fromIndex: number, toIndex: number) => {
     if (!isEditMode) return;
@@ -269,7 +272,7 @@ function ActivitySelector(): JSX.Element {
 
     setIsLoading(true);
     try {
-      const response = await admin.activities.get(token);
+      const response = await activitiesClient.getConfig();
       if (response.activities && response.activities.length > 0) {
         setEditableActivities(response.activities as ActivityDefinition[]);
       }


### PR DESCRIPTION
## Summary
- add a public FastAPI route that serves the activities configuration without requiring admin auth
- expose a frontend API client to fetch the public configuration and load it on the selector and activity pages for every user
- keep the admin-only save flow while reloading the saved configuration through the public endpoint

## Testing
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd62ad2604832281b38be9cc60d8f2