### PR TITLE
Fix activities config API path

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1757,6 +1757,7 @@ def admin_list_lti_users(
     }
 
 
+@app.get("/api/activities-config")
 @app.get("/activities-config")
 def get_activities_config() -> dict[str, Any]:
     """Endpoint public renvoyant la configuration des activités."""


### PR DESCRIPTION
## Summary
- expose the public activities configuration endpoint under the `/api` prefix while keeping the previous route for compatibility

## Testing
- PYTHONPATH=. pytest backend

------
https://chatgpt.com/codex/tasks/task_e_68cd68f0da648322be8921fd4ecf8c69