### PR TITLE
Persist activity selector header edits

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -331,13 +331,19 @@ export interface AdminLocalUserResponse {
   user: AdminLocalUser;
 }
 
-export interface ActivityConfig {
-  activities: any[];
+export interface ActivitySelectorHeaderConfig {
+  eyebrow?: string;
+  title?: string;
+  subtitle?: string;
+  badge?: string;
 }
 
-export interface ActivityConfigResponse {
+export interface ActivityConfig {
   activities: any[];
+  activitySelectorHeader?: ActivitySelectorHeaderConfig;
 }
+
+export interface ActivityConfigResponse extends ActivityConfig {}
 
 export interface SaveActivityConfigResponse {
   ok: boolean;


### PR DESCRIPTION
## Summary
- allow the activities configuration endpoint to persist an optional activitySelectorHeader block and expose it through the admin routes
- extend the frontend API typings for the new header payload
- load, edit and save the activity selector header alongside activities while sanitising saved values

## Testing
- npm run build
- PYTHONPATH=. pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68cd6ab95c5c832294734f104b9362c5