### PR TITLE
Normalize activity config persistence on backend

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -331,12 +331,45 @@ export interface AdminLocalUserResponse {
   user: AdminLocalUser;
 }
 
+export interface ActivityCardConfig {
+  title?: string;
+  description?: string;
+  highlights?: string[];
+  cta?: {
+    label?: string;
+    to?: string;
+  };
+}
+
+export interface ActivityConfigEntry {
+  id: string;
+  path?: string;
+  completionId?: string;
+  header?: {
+    eyebrow?: string;
+    title?: string;
+    subtitle?: string;
+    badge?: string;
+    titleAlign?: "left" | "center";
+  };
+  layout?: {
+    activityId?: string;
+    outerClassName?: string;
+    innerClassName?: string;
+    headerClassName?: string;
+    contentClassName?: string;
+    contentAs?: string;
+  };
+  card?: ActivityCardConfig;
+  enabled?: boolean;
+}
+
 export interface ActivityConfig {
-  activities: any[];
+  activities: ActivityConfigEntry[];
 }
 
 export interface ActivityConfigResponse {
-  activities: any[];
+  activities: ActivityConfigEntry[];
 }
 
 export interface SaveActivityConfigResponse {


### PR DESCRIPTION
## Summary
- add a typed activity configuration entry model that normalizes the new `enabled` flag
- reuse the serializer to validate persisted entries and API payloads while ensuring defaults are written

## Testing
- PYTHONPATH=.. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd67f26b50832291d7ccbc66fdb975