### PR TITLE
Refactor activity catalog and selector flows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
+import { useEffect, useMemo, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import ActivitySelector from "./pages/ActivitySelector";
-import { ACTIVITY_DEFINITIONS, buildActivityElement } from "./config/activities";
+import {
+  ACTIVITY_CATALOG,
+  buildActivityElement,
+  resolveActivityDefinition,
+  type ActivityConfigEntry,
+} from "./config/activities";
 import { ActivityAccessGuard } from "./components/ActivityAccessGuard";
 import { AdminGuard } from "./pages/admin/AdminGuard";
 import { AdminLayout } from "./pages/admin/AdminLayout";
@@ -10,8 +16,73 @@ import { LoginPage } from "./pages/LoginPage";
 import { AdminLtiUsersPage } from "./pages/admin/AdminLtiUsersPage";
 import { AdminPlatformsPage } from "./pages/admin/AdminPlatformsPage";
 import { AdminActivityTrackingPage } from "./pages/admin/AdminActivityTrackingPage";
+import { activities as activitiesClient } from "./api";
 
 function App(): JSX.Element {
+  const [configEntries, setConfigEntries] = useState<ActivityConfigEntry[] | null>(
+    null
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadConfig = async () => {
+      try {
+        const response = await activitiesClient.getConfig();
+        if (cancelled) {
+          return;
+        }
+        if (Array.isArray(response.activities)) {
+          setConfigEntries(response.activities as ActivityConfigEntry[]);
+        } else {
+          setConfigEntries([]);
+        }
+      } catch (error) {
+        console.warn("Impossible de charger la configuration des activités", error);
+        if (!cancelled) {
+          setConfigEntries([]);
+        }
+      }
+    };
+
+    void loadConfig();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const resolvedActivities = useMemo(() => {
+    const entries: ActivityConfigEntry[] = [];
+    const seen = new Set<string>();
+
+    if (configEntries && configEntries.length > 0) {
+      for (const entry of configEntries) {
+        if (entry && typeof entry.id === "string") {
+          entries.push(entry);
+          seen.add(entry.id);
+        }
+      }
+    }
+
+    for (const id of Object.keys(ACTIVITY_CATALOG)) {
+      if (!seen.has(id)) {
+        entries.push({ id } as ActivityConfigEntry);
+      }
+    }
+
+    if (entries.length === 0) {
+      for (const id of Object.keys(ACTIVITY_CATALOG)) {
+        entries.push({ id } as ActivityConfigEntry);
+      }
+    }
+
+    return entries.map((entry) => ({
+      entry,
+      definition: resolveActivityDefinition(entry),
+    }));
+  }, [configEntries]);
+
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/activites" replace />} />
@@ -33,13 +104,19 @@ function App(): JSX.Element {
           <Route path="activity-tracking" element={<AdminActivityTrackingPage />} />
         </Route>
       </Route>
-      {ACTIVITY_DEFINITIONS.map((definition) => (
-        <Route
-          key={definition.id}
-          path={definition.path}
-          element={<ActivityAccessGuard>{buildActivityElement(definition)}</ActivityAccessGuard>}
-        />
-      ))}
+      {resolvedActivities
+        .filter(({ definition }) => definition.enabled !== false)
+        .map(({ entry, definition }) => (
+          <Route
+            key={definition.id}
+            path={definition.path}
+            element={
+              <ActivityAccessGuard>
+                {buildActivityElement(entry)}
+              </ActivityAccessGuard>
+            }
+          />
+        ))}
       <Route path="*" element={<Navigate to="/activites" replace />} />
     </Routes>
   );

--- a/frontend/src/pages/admin/AdminActivityTrackingPage.tsx
+++ b/frontend/src/pages/admin/AdminActivityTrackingPage.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { admin, type AdminLtiUser, type PaginatedResponse } from "../../api";
-import { ACTIVITY_DEFINITIONS } from "../../config/activities";
+import { getDefaultActivityDefinitions } from "../../config/activities";
 import { AdminSkeleton } from "../../components/admin/AdminSkeleton";
 import { useAdminAuth } from "../../providers/AdminAuthProvider";
 
@@ -19,6 +19,10 @@ interface ActivityStats {
 
 export function AdminActivityTrackingPage(): JSX.Element {
   const { token } = useAdminAuth();
+  const catalogActivities = useMemo(
+    () => getDefaultActivityDefinitions(),
+    []
+  );
   const [users, setUsers] = useState<AdminLtiUser[]>([]);
   const [stats, setStats] = useState<ActivityStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -58,7 +62,7 @@ export function AdminActivityTrackingPage(): JSX.Element {
         });
       });
 
-      const activityBreakdown = ACTIVITY_DEFINITIONS.map(activity => {
+      const activityBreakdown = catalogActivities.map(activity => {
         const completions = activityCompletions.get(activity.id) || 0;
         return {
           activityId: activity.id,
@@ -82,7 +86,7 @@ export function AdminActivityTrackingPage(): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, [token, catalogActivities]);
 
   useEffect(() => {
     void fetchUsers(1, searchTerm);
@@ -185,7 +189,7 @@ export function AdminActivityTrackingPage(): JSX.Element {
             className="rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-red-200"
           >
             <option value="all">Toutes les activités</option>
-            {ACTIVITY_DEFINITIONS.map((activity) => (
+            {catalogActivities.map((activity) => (
               <option key={activity.id} value={activity.id}>
                 {activity.card.title}
               </option>
@@ -258,7 +262,7 @@ export function AdminActivityTrackingPage(): JSX.Element {
                         {user.completedActivityIds.length > 0 && (
                           <div className="flex flex-wrap gap-1">
                             {user.completedActivityIds.map((activityId) => {
-                              const activity = ACTIVITY_DEFINITIONS.find(a => a.id === activityId);
+                              const activity = catalogActivities.find(a => a.id === activityId);
                               return activity ? (
                                 <span
                                   key={activityId}


### PR DESCRIPTION
## Summary
- refactor `activities.tsx` to expose an `ACTIVITY_CATALOG`, React `COMPONENT_REGISTRY`, serialization helpers, and resilient activity rendering
- load activity configuration in `App` to build routes from enabled catalog entries at runtime
- update the selector and admin tracking pages to rely on the new catalog, including a modal to add catalog entries and refreshed persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd79a12dc08322ac4b4e399a90160e