### PR TITLE
Define default login credentials in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       context: ./frontend
       args:
         VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8001}
-        VITE_LOGIN_USERNAME: ${VITE_LOGIN_USERNAME}
-        VITE_LOGIN_PASSWORD: ${VITE_LOGIN_PASSWORD}
+        VITE_LOGIN_USERNAME: ${VITE_LOGIN_USERNAME:-test}
+        VITE_LOGIN_PASSWORD: ${VITE_LOGIN_PASSWORD:-Telecom2025$}
         VITE_API_AUTH_KEY: ${VITE_API_AUTH_KEY}
     depends_on:
       - backend


### PR DESCRIPTION
## Summary
- set default values for VITE_LOGIN_USERNAME and VITE_LOGIN_PASSWORD build args in docker-compose to avoid warnings when env vars are not provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd8d85e0088322ad49b7c3c030f17a