### PR TITLE
feat: ajouter l’activité explorateur IA

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -15,6 +15,7 @@ import ClarityPath from "../pages/ClarityPath";
 import ClarteDabord from "../pages/ClarteDabord";
 import PromptDojo from "../pages/PromptDojo";
 import WorkshopExperience from "../pages/WorkshopExperience";
+import ExplorateurIA from "../pages/ExplorateurIA";
 
 export interface ActivityHeaderConfig {
   eyebrow: string;
@@ -69,6 +70,7 @@ export const COMPONENT_REGISTRY = {
   "prompt-dojo": PromptDojo,
   "clarity-path": ClarityPath,
   "clarte-dabord": ClarteDabord,
+  "explorateur-ia": ExplorateurIA,
 } as const satisfies Record<string, ComponentType<ActivityProps>>;
 
 export type ActivityComponentKey = keyof typeof COMPONENT_REGISTRY;
@@ -215,6 +217,38 @@ export const ACTIVITY_CATALOG: Record<string, ActivityCatalogEntry> = {
         cta: {
           label: "Lancer Clarté d’abord !",
           to: "/clarte-dabord",
+        },
+      },
+    },
+  },
+  "explorateur-ia": {
+    componentKey: "explorateur-ia",
+    path: "/explorateur-ia",
+    defaults: {
+      completionId: "explorateur-ia",
+      enabled: true,
+      header: {
+        eyebrow: "Activité 5",
+        title: "L’Explorateur IA",
+        subtitle:
+          "Parcours une mini-ville façon Game Boy pour valider quatre compétences IA sans jamais taper au clavier.",
+        badge: "Ville interactive",
+      },
+      layout: {
+        contentClassName: "space-y-12",
+      },
+      card: {
+        title: "L’Explorateur IA",
+        description:
+          "Objectif : compléter un parcours ludique mêlant quiz, drag-and-drop, décisions et dilemmes éthiques.",
+        highlights: [
+          "Déplacements façon jeu vidéo et interactions à la souris",
+          "Quatre mini-activités pédagogiques sans saisie de texte",
+          "Export JSON immédiat et impression PDF du bilan",
+        ],
+        cta: {
+          label: "Entrer dans la ville",
+          to: "/explorateur-ia",
         },
       },
     },

--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -1,0 +1,1427 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent,
+  type ReactNode,
+} from "react";
+
+import tinyTownAtlas from "../assets/kenney_tiny-town/Tilemap/tilemap_packed.png";
+import { useActivityCompletion } from "../hooks/useActivityCompletion";
+import type { ActivityProps } from "../config/activities";
+
+// ---
+// "Explorateur IA" — Frontend React (module web auto-portant)
+// Style: mini jeu top-down façon Game Boy/Pokémon pour naviguer entre 4 quartiers.
+// Aucune saisie de texte par l'étudiant — seulement clics, touches de direction, drag-and-drop.
+// Technologies: React + Tailwind CSS (prévu), aucune dépendance externe requise.
+// Export JSON + impression PDF via window.print().
+// ---
+
+type QuarterId = "clarte" | "creation" | "decision" | "ethique" | "mairie";
+
+type Progress = {
+  clarte: { done: boolean; score: number };
+  creation: { done: boolean; spec?: CreationSpec };
+  decision: { done: boolean; choicePath?: string[] };
+  ethique: { done: boolean; score: number };
+  visited: QuarterId[];
+};
+
+const GRID_W = 14;
+const GRID_H = 10;
+const TILE = 32;
+
+function dataUri(svg: string) {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+const SPR_TILE_GRASS = dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+  <rect width='16' height='16' fill='#46a049'/>
+  <rect x='0' y='8' width='16' height='1' fill='#3d8f43'/>
+  <rect x='8' y='0' width='1' height='16' fill='#3d8f43'/>
+  <rect x='2' y='2' width='2' height='2' fill='#67c16a'/>
+  <rect x='10' y='5' width='2' height='2' fill='#67c16a'/>
+  <rect x='6' y='11' width='2' height='2' fill='#67c16a'/>
+</svg>`);
+const SPR_TILE_PATH = dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+  <rect width='16' height='16' fill='#caa56a'/>
+  <rect x='0' y='7' width='16' height='2' fill='#b18959'/>
+  <rect x='7' y='0' width='2' height='16' fill='#b18959'/>
+</svg>`);
+const SPR_TILE_WATER = dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+  <rect width='16' height='16' fill='#4fc3f7'/>
+  <rect x='0' y='7' width='16' height='2' fill='#29b6f6'/>
+  <rect x='2' y='3' width='12' height='1' fill='#81d4fa'/>
+  <rect x='4' y='11' width='8' height='1' fill='#81d4fa'/>
+</svg>`);
+
+function houseSvg(roof: string, wall = "#f4f4f5") {
+  return dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+    <rect x='3' y='7' width='10' height='7' fill='${wall}' stroke='#9aa0a6' stroke-width='1'/>
+    <polygon points='8,3 2,8 14,8' fill='${roof}' stroke='#5b5b5b' stroke-width='1'/>
+    <rect x='7' y='10' width='2' height='4' fill='#8d6e63'/>
+    <rect x='4' y='9' width='2' height='2' fill='#90caf9'/>
+    <rect x='10' y='9' width='2' height='2' fill='#90caf9'/>
+  </svg>`);
+}
+
+const SPR_HOUSE_GREEN = houseSvg("#06d6a0");
+const SPR_HOUSE_BLUE = houseSvg("#118ab2");
+const SPR_HOUSE_RED = houseSvg("#ef476f");
+const SPR_HOUSE_PURP = houseSvg("#8338ec");
+const SPR_TOWN_HALL = dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+  <rect x='2' y='8' width='12' height='6' fill='#ffe08a' stroke='#bfa15c' stroke-width='1'/>
+  <rect x='6' y='9' width='4' height='5' fill='#d7ccc8'/>
+  <polygon points='8,3 1,8 15,8' fill='#f4c430' stroke='#bfa15c' stroke-width='1'/>
+  <rect x='4' y='9' width='2' height='2' fill='#fff3c4'/>
+  <rect x='10' y='9' width='2' height='2' fill='#fff3c4'/>
+</svg>`);
+
+const SPR_PLAYER = dataUri(`<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' shape-rendering='crispEdges'>
+  <rect width='16' height='16' fill='none'/>
+  <rect x='6' y='2' width='4' height='3' fill='#f9d7b6'/>
+  <rect x='5' y='5' width='6' height='1' fill='#3e2723'/>
+  <rect x='5' y='6' width='6' height='5' fill='#1976d2'/>
+  <rect x='6' y='11' width='4' height='3' fill='#263238'/>
+  <rect x='6' y='14' width='2' height='2' fill='#424242'/>
+  <rect x='8' y='14' width='2' height='2' fill='#424242'/>
+</svg>`);
+
+type TilesetMode = "builtin" | "atlas";
+
+type Tileset = {
+  mode: TilesetMode;
+  url?: string;
+  size: number;
+  map: {
+    grass: [number, number];
+    path: [number, number];
+    water: [number, number];
+    house_green: [number, number];
+    house_blue: [number, number];
+    house_red: [number, number];
+    house_purp: [number, number];
+    town_hall: [number, number];
+    player: [[number, number], [number, number]];
+  };
+};
+
+const DEFAULT_ATLAS: Tileset = {
+  mode: "atlas",
+  url: tinyTownAtlas,
+  size: 16,
+  map: {
+    grass: [0, 0],
+    path: [1, 2],
+    water: [2, 8],
+    house_green: [6, 8],
+    house_blue: [8, 8],
+    house_red: [10, 8],
+    house_purp: [11, 8],
+    town_hall: [7, 8],
+    player: [
+      [0, 0],
+      [0, 0],
+    ],
+  },
+};
+
+function cloneTileset(source: Tileset): Tileset {
+  return {
+    ...source,
+    map: { ...source.map },
+  };
+}
+
+function useTileset(): [Tileset, (t: Tileset) => void] {
+  const [ts, setTs] = useState<Tileset>(() => {
+    if (typeof window !== "undefined") {
+      const raw = window.localStorage.getItem("explorateur.tileset");
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as Tileset;
+          if (parsed && typeof parsed === "object") {
+            return parsed;
+          }
+        } catch {
+          // ignore invalid cache
+        }
+      }
+    }
+    return cloneTileset(DEFAULT_ATLAS);
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(
+      "explorateur.tileset",
+      JSON.stringify(ts)
+    );
+  }, [ts]);
+
+  return [ts, setTs];
+}
+
+function SpriteFromAtlas({
+  ts,
+  coord,
+  scale = TILE,
+}: {
+  ts: Tileset;
+  coord: [number, number];
+  scale?: number;
+}) {
+  if (ts.mode !== "atlas" || !ts.url) {
+    return null;
+  }
+  const [cx, cy] = coord;
+  const offsetX = -cx * ts.size;
+  const offsetY = -cy * ts.size;
+  const zoom = scale / ts.size;
+  return (
+    <div
+      style={{
+        width: scale,
+        height: scale,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          width: ts.size,
+          height: ts.size,
+          backgroundImage: `url(${ts.url})`,
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: `${offsetX}px ${offsetY}px`,
+          imageRendering: "pixelated",
+          transform: `scale(${zoom})`,
+          transformOrigin: "top left",
+        }}
+      />
+    </div>
+  );
+}
+
+function TilesetControls({
+  ts,
+  setTs,
+}: {
+  ts: Tileset;
+  setTs: (t: Tileset) => void;
+}) {
+  const [url, setUrl] = useState(ts.url ?? tinyTownAtlas);
+  const [size, setSize] = useState(ts.size ?? 16);
+
+  const apply = (mode: TilesetMode) => {
+    if (mode === "builtin") {
+      setTs({ mode: "builtin", size, map: ts.map });
+    } else {
+      setTs({ mode: "atlas", url: url || tinyTownAtlas, size, map: ts.map });
+    }
+  };
+
+  return (
+    <div className="space-y-2 text-xs">
+      <div className="flex items-center justify-between">
+        <span>Mode tileset</span>
+        <div className="flex gap-1">
+          <button
+            className={
+              ts.mode === "builtin"
+                ? "px-2 py-1 rounded bg-slate-800 text-white"
+                : "px-2 py-1 rounded bg-slate-100"
+            }
+            onClick={() => apply("builtin")}
+          >
+            builtin
+          </button>
+          <button
+            className={
+              ts.mode === "atlas"
+                ? "px-2 py-1 rounded bg-slate-800 text-white"
+                : "px-2 py-1 rounded bg-slate-100"
+            }
+            onClick={() => apply("atlas")}
+          >
+            atlas
+          </button>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-2">
+        <label className="flex items-center gap-2">
+          URL
+          <input
+            value={url}
+            onChange={(event) => setUrl(event.target.value)}
+            placeholder="/assets/tileset.png"
+            className="flex-1 px-2 py-1 border rounded"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Tile size
+          <input
+            type="number"
+            value={size}
+            onChange={(event) =>
+              setSize(parseInt(event.target.value || "16", 10))
+            }
+            className="w-20 px-2 py-1 border rounded"
+          />
+        </label>
+        <p className="text-slate-500">
+          Dépose un atlas PNG (16x16) dans public/assets et renseigne l'URL. Packs
+          recommandés: Kenney (CC0) Topdown/RPG.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const world: number[][] = [
+  [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+  [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2],
+  [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+  [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+  [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+  [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+  [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+  [2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2],
+  [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+  [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+];
+
+const buildings: Array<{
+  id: QuarterId;
+  x: number;
+  y: number;
+  label: string;
+  color: string;
+}> = [
+  { id: "mairie", x: 2, y: 2, label: "Mairie (Bilan)", color: "#ffd166" },
+  { id: "clarte", x: 5, y: 3, label: "Quartier Clarté", color: "#06d6a0" },
+  { id: "creation", x: 9, y: 3, label: "Quartier Création", color: "#118ab2" },
+  { id: "decision", x: 4, y: 5, label: "Quartier Décision", color: "#ef476f" },
+  { id: "ethique", x: 10, y: 5, label: "Quartier Éthique", color: "#8338ec" },
+];
+
+const START = { x: 2, y: 6 };
+
+function classNames(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+function PlayerSprite({ ts, step }: { ts: Tileset; step: number }) {
+  if (ts.mode === "atlas" && ts.url) {
+    const frame = ts.map.player[step % ts.map.player.length];
+    return <SpriteFromAtlas ts={ts} coord={frame} />;
+  }
+  return (
+    <div
+      className="w-full h-full rounded-sm"
+      style={{
+        backgroundImage: `url(${SPR_PLAYER})`,
+        backgroundSize: "cover",
+        imageRendering: "pixelated",
+      }}
+    />
+  );
+}
+
+function BuildingSprite({
+  id,
+  ts,
+}: {
+  id: QuarterId;
+  ts: Tileset;
+}) {
+  if (ts.mode === "atlas" && ts.url) {
+    const coord =
+      id === "mairie"
+        ? ts.map.town_hall
+        : id === "clarte"
+        ? ts.map.house_green
+        : id === "creation"
+        ? ts.map.house_blue
+        : id === "decision"
+        ? ts.map.house_red
+        : ts.map.house_purp;
+    return <SpriteFromAtlas ts={ts} coord={coord} />;
+  }
+
+  let src = SPR_HOUSE_GREEN;
+  if (id === "creation") src = SPR_HOUSE_BLUE;
+  else if (id === "decision") src = SPR_HOUSE_RED;
+  else if (id === "ethique") src = SPR_HOUSE_PURP;
+  else if (id === "mairie") src = SPR_TOWN_HALL;
+  return (
+    <div
+      className="w-5 h-5"
+      style={{
+        backgroundImage: `url(${src})`,
+        backgroundSize: "cover",
+        imageRendering: "pixelated",
+      }}
+      aria-hidden
+    />
+  );
+}
+
+function isWalkable(x: number, y: number) {
+  if (x < 0 || y < 0 || y >= world.length || x >= world[0].length) {
+    return false;
+  }
+  return world[y][x] !== 2;
+}
+
+function DPad({ onMove }: { onMove: (dx: number, dy: number) => void }) {
+  return (
+    <div className="grid grid-cols-3 gap-2 select-none">
+      <div />
+      <button
+        onClick={() => onMove(0, -1)}
+        className="px-3 py-2 rounded-xl bg-white/80 hover:bg-white shadow text-sm"
+        aria-label="Haut"
+      >
+        ▲
+      </button>
+      <div />
+      <button
+        onClick={() => onMove(-1, 0)}
+        className="px-3 py-2 rounded-xl bg-white/80 hover:bg-white shadow text-sm"
+        aria-label="Gauche"
+      >
+        ◀
+      </button>
+      <div />
+      <button
+        onClick={() => onMove(1, 0)}
+        className="px-3 py-2 rounded-xl bg-white/80 hover:bg-white shadow text-sm"
+        aria-label="Droite"
+      >
+        ▶
+      </button>
+      <div />
+      <button
+        onClick={() => onMove(0, 1)}
+        className="px-3 py-2 rounded-xl bg-white/80 hover:bg-white shadow text-sm col-start-2"
+        aria-label="Bas"
+      >
+        ▼
+      </button>
+      <div />
+    </div>
+  );
+}
+
+function Tile({ kind }: { kind: number }) {
+  const img = kind === 2 ? SPR_TILE_WATER : kind === 1 ? SPR_TILE_PATH : SPR_TILE_GRASS;
+  return (
+    <div
+      className="rounded-sm"
+      style={{
+        width: TILE,
+        height: TILE,
+        backgroundImage: `url(${img})`,
+        backgroundSize: "cover",
+        imageRendering: "pixelated",
+      }}
+    />
+  );
+}
+
+function TileWithTs({ kind, ts }: { kind: number; ts: Tileset }) {
+  if (ts.mode === "atlas" && ts.url) {
+    const coord =
+      kind === 2 ? ts.map.water : kind === 1 ? ts.map.path : ts.map.grass;
+    return <SpriteFromAtlas ts={ts} coord={coord} scale={TILE} />;
+  }
+  return <Tile kind={kind} />;
+}
+
+function Modal({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="relative z-10 max-w-4xl w-full rounded-2xl bg-white shadow-xl border border-slate-200">
+        <div className="flex items-center justify-between px-5 py-3 border-b">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <button
+            className="px-3 py-1 rounded-lg bg-slate-100 hover:bg-slate-200"
+            onClick={onClose}
+            aria-label="Fermer"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function Fireworks({ show }: { show: boolean }) {
+  if (!show) return null;
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center">
+      <svg viewBox="0 0 200 200" className="w-[50vmin] h-[50vmin] opacity-90">
+        {Array.from({ length: 12 }).map((_, index) => (
+          <g key={index} transform={`rotate(${(index * 360) / 12} 100 100)`}>
+            <circle cx="100" cy="40" r="3" fill="#ef476f">
+              <animate
+                attributeName="cy"
+                values="100;40;100"
+                dur="1.6s"
+                repeatCount="indefinite"
+                begin={`${index * 0.1}s`}
+              />
+              <animate
+                attributeName="r"
+                values="1;4;1"
+                dur="1.6s"
+                repeatCount="indefinite"
+                begin={`${index * 0.1}s`}
+              />
+            </circle>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+const CLARTE_QUESTIONS = [
+  {
+    q: "Quel est le meilleur énoncé pour obtenir un plan clair?",
+    options: [
+      {
+        id: "A",
+        text: "Écris un plan.",
+        explain: "Trop vague : objectifs, sections, longueur… manquent.",
+        score: 0,
+      },
+      {
+        id: "B",
+        text: "Donne un plan en 5 sections sur l'énergie solaire pour débutants, avec titres et 2 sous-points chacun.",
+        explain: "Précis, contraint et adapté au public cible.",
+        score: 100,
+      },
+      {
+        id: "C",
+        text: "Plan énergie solaire?",
+        explain: "Formulation télégraphique, ambiguë.",
+        score: 10,
+      },
+    ],
+  },
+];
+
+function ClarteQuiz({ onDone }: { onDone: (score: number) => void }) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string>("");
+  const [score, setScore] = useState(0);
+
+  const choose = (optionId: string) => {
+    setSelected(optionId);
+    const option = CLARTE_QUESTIONS[0].options.find((candidate) => candidate.id === optionId);
+    if (!option) return;
+    setFeedback(option.explain);
+    setScore(option.score);
+  };
+
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <div>
+        <h4 className="font-semibold mb-2">Question</h4>
+        <p className="mb-4">{CLARTE_QUESTIONS[0].q}</p>
+        <div className="space-y-2">
+          {CLARTE_QUESTIONS[0].options.map((option) => (
+            <button
+              key={option.id}
+              onClick={() => choose(option.id)}
+              className={classNames(
+                "w-full text-left p-3 rounded-xl border shadow-sm",
+                selected === option.id
+                  ? "bg-emerald-50 border-emerald-300"
+                  : "bg-white hover:bg-slate-50"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-xs bg-black/10 rounded px-1">{option.id}</span>
+                {option.text}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h4 className="font-semibold mb-2">Impact de votre choix</h4>
+        <MiniAnimation strength={score} />
+        <p className="mt-3 text-sm text-slate-700">
+          {selected
+            ? feedback
+            : "Choisissez une option pour voir l'effet sur la qualité de la réponse."}
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <span className="text-sm">Score:</span>
+          <div className="flex-1 h-3 rounded-full bg-slate-200 overflow-hidden">
+            <div style={{ width: `${score}%` }} className="h-full bg-emerald-500 transition-all" />
+          </div>
+          <span className="text-sm tabular-nums w-10 text-right">{score}</span>
+        </div>
+        <button
+          disabled={selected == null}
+          onClick={() => onDone(score)}
+          className="mt-4 px-4 py-2 rounded-xl bg-emerald-600 text-white disabled:opacity-50"
+        >
+          Valider
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MiniAnimation({ strength }: { strength: number }) {
+  const blocks = 12;
+  return (
+    <div className="grid grid-cols-6 gap-2">
+      {Array.from({ length: blocks }).map((_, index) => {
+        const align = strength >= (index + 1) * (100 / blocks);
+        return (
+          <div
+            key={index}
+            className={classNames(
+              "h-6 rounded transition-all",
+              align ? "bg-emerald-500" : "bg-emerald-200 translate-y-[2px]"
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+type CreationSpec = {
+  action: string | null;
+  media: string | null;
+  style: string | null;
+  theme: string | null;
+};
+
+const CREATION_POOL = {
+  action: ["créer", "rédiger", "composer"],
+  media: ["affiche", "article", "capsule audio"],
+  style: ["cartoon", "académique", "minimaliste"],
+  theme: ["énergie", "ville intelligente", "biodiversité"],
+};
+
+function CreationBuilder({ onDone }: { onDone: (spec: CreationSpec) => void }) {
+  const [spec, setSpec] = useState<CreationSpec>({
+    action: null,
+    media: null,
+    style: null,
+    theme: null,
+  });
+  const [previewKey, setPreviewKey] = useState(0);
+
+  const ready = spec.action && spec.media && spec.style && spec.theme;
+
+  const setField = <K extends keyof CreationSpec>(key: K, value: CreationSpec[K]) => {
+    setSpec((current) => ({ ...current, [key]: value }));
+  };
+
+  const handleDrop = (slot: keyof CreationSpec, value: string) => {
+    setField(slot, value);
+  };
+
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <div>
+        <h4 className="font-semibold mb-3">Assemblez votre consigne (drag-and-drop ou clic)</h4>
+        <div className="grid grid-cols-2 gap-3">
+          {Object.entries(CREATION_POOL).map(([slot, items]) => (
+            <div key={slot} className="border rounded-xl p-3 bg-slate-50">
+              <div className="text-xs uppercase tracking-wide text-slate-500 mb-2">
+                {slot}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {items.map((item) => (
+                  <DraggablePill
+                    key={item}
+                    label={item}
+                    onPick={() => setField(slot as keyof CreationSpec, item)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 grid grid-cols-4 gap-3">
+          {(["action", "media", "style", "theme"] as const).map((slot) => (
+            <DropSlot
+              key={slot}
+              label={slot}
+              value={spec[slot] ?? undefined}
+              onSelect={(value) => handleDrop(slot, value)}
+              onClear={() => setField(slot, null)}
+            />
+          ))}
+        </div>
+        <button
+          disabled={!ready}
+          onClick={() => ready && onDone(spec)}
+          className="mt-4 px-4 py-2 rounded-xl bg-blue-600 text-white disabled:opacity-50"
+        >
+          Générer
+        </button>
+      </div>
+      <div>
+        <h4 className="font-semibold mb-3">Aperçu généré (démo locale)</h4>
+        <div className="border rounded-2xl p-4 bg-white shadow">
+          <GeneratedPreview key={previewKey} spec={spec} />
+          <div className="text-xs text-slate-500 mt-3">
+            Note: ici, un vrai backend IA peut remplacer cet aperçu local.
+          </div>
+        </div>
+        <div className="mt-3 flex gap-2">
+          <button
+            className="px-3 py-1 rounded-lg bg-slate-100 hover:bg-slate-200"
+            onClick={() => setPreviewKey((count) => count + 1)}
+          >
+            Rafraîchir
+          </button>
+          <button
+            className="px-3 py-1 rounded-lg bg-slate-100 hover:bg-slate-200"
+            onClick={() =>
+              setSpec({ action: null, media: null, style: null, theme: null })
+            }
+          >
+            Réinitialiser
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DraggablePill({
+  label,
+  onPick,
+}: {
+  label: string;
+  onPick: () => void;
+}) {
+  const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    event.dataTransfer.setData("text/plain", label);
+  };
+  return (
+    <button
+      draggable
+      onDragStart={handleDragStart}
+      onClick={onPick}
+      className="px-2 py-1 rounded-full bg-white shadow border text-sm hover:bg-emerald-50"
+    >
+      {label}
+    </button>
+  );
+}
+
+function DropSlot({
+  label,
+  value,
+  onSelect,
+  onClear,
+}: {
+  label: string;
+  value?: string;
+  onSelect: (value: string) => void;
+  onClear: () => void;
+}) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsOver(false);
+    const dropped = event.dataTransfer.getData("text/plain");
+    if (dropped) {
+      onSelect(dropped);
+    }
+  };
+
+  return (
+    <div
+      onDragOver={(event) => {
+        event.preventDefault();
+        setIsOver(true);
+      }}
+      onDragLeave={() => setIsOver(false)}
+      onDrop={handleDrop}
+      className={classNames(
+        "rounded-xl p-3 border text-sm bg-white min-h-[56px]",
+        isOver && "ring-2 ring-emerald-300"
+      )}
+    >
+      <div className="text-[10px] uppercase tracking-wide text-slate-500">{label}</div>
+      {value ? (
+        <div className="mt-1 flex items-center justify-between">
+          <div className="px-2 py-1 rounded-full bg-emerald-100 text-emerald-800">{value}</div>
+          <button onClick={onClear} className="text-slate-500 hover:text-slate-700">
+            ✕
+          </button>
+        </div>
+      ) : (
+        <div className="mt-1 text-slate-400">Glissez ou cliquez un choix…</div>
+      )}
+    </div>
+  );
+}
+
+function GeneratedPreview({ spec }: { spec: CreationSpec }) {
+  const title = [spec.action, spec.media].filter(Boolean).join(" → ") || "Préparez votre consigne";
+  const subtitle = [spec.style, spec.theme].filter(Boolean).join(" • ") || "Complétez les paramètres";
+  return (
+    <div className="grid md:grid-cols-2 gap-4 items-center">
+      <div>
+        <div className="rounded-xl border p-3 bg-gradient-to-br from-slate-50 to-white">
+          <h5 className="font-semibold">{title}</h5>
+          <p className="text-sm text-slate-600">{subtitle}</p>
+          <ul className="mt-2 text-sm list-disc pl-5 text-slate-700 space-y-1">
+            <li>Contrainte: 150–200 mots, ton accessible.</li>
+            <li>Structure: titre, 3 sections, conclusion.</li>
+            <li>Sortie: Markdown.</li>
+          </ul>
+        </div>
+        <p className="text-xs text-slate-500 mt-2">Texte simulé — remplaçable par une API de génération.</p>
+      </div>
+      <div>
+        <svg viewBox="0 0 300 200" className="w-full h-auto rounded-xl border bg-white">
+          <rect x="10" y="10" width="280" height="180" rx="12" fill="#F1F5F9" />
+          <text x="24" y="50" fontSize="16" fontWeight={600} fill="#0F172A">
+            {title || "Affiche / Article"}
+          </text>
+          <text x="24" y="75" fontSize="12" fill="#334155">
+            {subtitle || "Style / Thème"}
+          </text>
+          <circle cx="250" cy="100" r="28" fill="#e2e8f0" />
+          <circle cx="250" cy="100" r="22" fill="#94a3b8" />
+          <g>
+            <rect x="24" y="95" width="160" height="10" fill="#CBD5E1" />
+            <rect x="24" y="115" width="140" height="10" fill="#E2E8F0" />
+            <rect x="24" y="135" width="170" height="10" fill="#E2E8F0" />
+          </g>
+        </svg>
+        <p className="text-xs text-slate-500 mt-2">Image simulée — remplaçable par une API d'image.</p>
+      </div>
+    </div>
+  );
+}
+
+const DECISIONS = [
+  {
+    prompt: "Votre équipe doit annoncer un projet. Choisissez une stratégie de communication:",
+    options: [
+      { id: "A", title: "A — Rapide", impact: "+ vitesse / – profondeur", next: 1 },
+      { id: "B", title: "B — Équilibrée", impact: "+ clarté / – temps", next: 1 },
+      { id: "C", title: "C — Personnalisée", impact: "+ pertinence / – effort", next: 1 },
+    ],
+  },
+  {
+    prompt: "Le public réagit. Ensuite?",
+    options: [
+      { id: "A", title: "A — FAQ automatisée", impact: "+ échelle / – nuance", next: null },
+      { id: "B", title: "B — Atelier interactif", impact: "+ engagement / – logistique", next: null },
+      { id: "C", title: "C — Messages ciblés", impact: "+ efficacité / – données", next: null },
+    ],
+  },
+];
+
+function DecisionPath({ onDone }: { onDone: (path: string[]) => void }) {
+  const [step, setStep] = useState(0);
+  const [path, setPath] = useState<string[]>([]);
+
+  const choose = (id: string) => {
+    const nextOptions = DECISIONS[step];
+    if (!nextOptions) return;
+    const next = nextOptions.options.find((option) => option.id === id)?.next ?? null;
+    const updatedPath = [...path, id];
+    setPath(updatedPath);
+    if (next == null) {
+      onDone(updatedPath);
+    } else {
+      setStep(next);
+    }
+  };
+
+  const current = DECISIONS[step];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="font-semibold mb-1">Étape {step + 1}</h4>
+        <p className="text-slate-700">{current.prompt}</p>
+      </div>
+      <div className="grid md:grid-cols-3 gap-3">
+        {current.options.map((option) => (
+          <button
+            key={option.id}
+            onClick={() => choose(option.id)}
+            className="text-left p-3 rounded-xl border bg-white hover:bg-slate-50"
+          >
+            <div className="font-semibold mb-1">{option.title}</div>
+            <div className="text-sm text-slate-600">{option.impact}</div>
+          </button>
+        ))}
+      </div>
+      {path.length > 0 && (
+        <div className="text-xs text-slate-500">Chemin choisi: {path.join(" → ")}</div>
+      )}
+    </div>
+  );
+}
+
+const DILEMMAS = [
+  {
+    s: "Un outil génère un résumé contenant des stéréotypes.",
+    options: [
+      {
+        id: "ignorer",
+        label: "Ignorer",
+        fb: "Risque d'amplifier le biais et de diffuser une erreur.",
+        score: 0,
+      },
+      {
+        id: "corriger",
+        label: "Corriger et justifier",
+        fb: "Bonne pratique: signalez et corrigez les biais.",
+        score: 100,
+      },
+      {
+        id: "expliquer",
+        label: "Demander des explications",
+        fb: "Utile, mais sans correction le risque demeure.",
+        score: 60,
+      },
+    ],
+  },
+  {
+    s: "Un modèle révèle des données sensibles dans un exemple.",
+    options: [
+      {
+        id: "ignorer",
+        label: "Ignorer",
+        fb: "Non-conforme à la protection des données.",
+        score: 0,
+      },
+      {
+        id: "corriger",
+        label: "Supprimer et anonymiser",
+        fb: "Conforme aux bonnes pratiques.",
+        score: 100,
+      },
+      {
+        id: "expliquer",
+        label: "Demander justification",
+        fb: "Insuffisant sans retrait immédiat.",
+        score: 40,
+      },
+    ],
+  },
+];
+
+function EthicsDilemmas({ onDone }: { onDone: (score: number) => void }) {
+  const [index, setIndex] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  const answer = (score: number) => {
+    const nextIndex = index + 1;
+    const cumulative = total + score;
+    const last = nextIndex >= DILEMMAS.length;
+    setTotal(cumulative);
+    if (last) {
+      onDone(Math.round(cumulative / DILEMMAS.length));
+    } else {
+      setIndex(nextIndex);
+    }
+  };
+
+  const dilemma = DILEMMAS[index];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="font-semibold">
+          Situation {index + 1} / {DILEMMAS.length}
+        </h4>
+        <p className="text-slate-700">{dilemma.s}</p>
+      </div>
+      <div className="grid md:grid-cols-3 gap-3">
+        {dilemma.options.map((option) => (
+          <button
+            key={option.id}
+            onClick={() => answer(option.score)}
+            className="text-left p-3 rounded-xl border bg-white hover:bg-slate-50"
+          >
+            <div className="font-semibold mb-1">{option.label}</div>
+            <div className="text-sm text-slate-600">{option.fb}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProgressBar({
+  value,
+  color,
+}: {
+  value: number;
+  color: "emerald" | "blue" | "rose" | "violet";
+}) {
+  const colorMap: Record<string, string> = {
+    emerald: "bg-emerald-500",
+    blue: "bg-blue-500",
+    rose: "bg-rose-500",
+    violet: "bg-violet-500",
+  };
+  return (
+    <div className="h-2 rounded-full bg-slate-200 overflow-hidden">
+      <div style={{ width: `${value}%` }} className={classNames("h-full transition-all", colorMap[color])} />
+    </div>
+  );
+}
+
+function BadgeView({
+  progress,
+  onDownloadJSON,
+}: {
+  progress: Progress;
+  onDownloadJSON: () => void;
+}) {
+  const total =
+    progress.clarte.score +
+    (progress.ethique.score || 0) +
+    (progress.creation.spec ? 100 : 0) +
+    (progress.decision.choicePath ? 100 : 0);
+  const percent = Math.round((total / 400) * 100);
+
+  return (
+    <div className="flex flex-col md:flex-row gap-6 items-start">
+      <div className="border rounded-2xl p-5 bg-white shadow min-w-[260px]">
+        <div className="text-xs uppercase tracking-wide text-slate-500">
+          Carte de compétences IA
+        </div>
+        <div className="mt-2 text-2xl font-black">Explorateur IA</div>
+        <div className="mt-3 space-y-2">
+          <div className="text-sm flex items-center justify-between">
+            <span>Clarté</span>
+            <span className="tabular-nums">{progress.clarte.score}</span>
+          </div>
+          <ProgressBar value={progress.clarte.score} color="emerald" />
+          <div className="text-sm flex items-center justify-between">
+            <span>Création</span>
+            <span className="tabular-nums">{progress.creation.spec ? 100 : 0}</span>
+          </div>
+          <ProgressBar value={progress.creation.spec ? 100 : 0} color="blue" />
+          <div className="text-sm flex items-center justify-between">
+            <span>Décision</span>
+            <span className="tabular-nums">{progress.decision.choicePath ? 100 : 0}</span>
+          </div>
+          <ProgressBar value={progress.decision.choicePath ? 100 : 0} color="rose" />
+          <div className="text-sm flex items-center justify-between">
+            <span>Éthique</span>
+            <span className="tabular-nums">{progress.ethique.score}</span>
+          </div>
+          <ProgressBar value={progress.ethique.score} color="violet" />
+        </div>
+        <div className="mt-4 p-3 rounded-xl bg-slate-50 border">
+          <div className="text-sm">Indice global</div>
+          <div className="text-3xl font-black">
+            {percent}
+            <span className="text-base font-semibold">%</span>
+          </div>
+        </div>
+        <div className="mt-4 flex gap-2">
+          <button
+            onClick={onDownloadJSON}
+            className="px-3 py-2 rounded-xl bg-slate-800 text-white"
+          >
+            Télécharger JSON
+          </button>
+          <button
+            onClick={() => window.print()}
+            className="px-3 py-2 rounded-xl bg-slate-100 border"
+          >
+            Imprimer PDF
+          </button>
+        </div>
+      </div>
+      <div className="flex-1">
+        <p className="text-sm text-slate-600">
+          Cette carte résume vos actions. Exportez-la pour dépôt ou portfolio.
+        </p>
+        {progress.creation.spec && (
+          <div className="mt-4 text-sm text-slate-700">
+            <div className="font-semibold mb-1">Spécification de création</div>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>action: {progress.creation.spec.action}</li>
+              <li>media: {progress.creation.spec.media}</li>
+              <li>style: {progress.creation.spec.style}</li>
+              <li>theme: {progress.creation.spec.theme}</li>
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ExplorateurIA({
+  completionId,
+  navigateToActivities,
+}: ActivityProps) {
+  const [player, setPlayer] = useState(START);
+  const [open, setOpen] = useState<QuarterId | null>(null);
+  const [progress, setProgress] = useState<Progress>({
+    clarte: { done: false, score: 0 },
+    creation: { done: false },
+    decision: { done: false },
+    ethique: { done: false, score: 0 },
+    visited: [],
+  });
+  const [celebrate, setCelebrate] = useState(false);
+  const [tileset, setTileset] = useTileset();
+  const [walkStep, setWalkStep] = useState(0);
+  const completionTriggered = useRef(false);
+
+  const { markCompleted } = useActivityCompletion({
+    activityId: completionId,
+    onCompleted: () => navigateToActivities(),
+  });
+
+  useEffect(() => {
+    const handleKey = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d"].includes(key)) {
+        event.preventDefault();
+        const delta:
+          | [number, number]
+          | null = key === "arrowup" || key === "w"
+          ? [0, -1]
+          : key === "arrowdown" || key === "s"
+          ? [0, 1]
+          : key === "arrowleft" || key === "a"
+          ? [-1, 0]
+          : key === "arrowright" || key === "d"
+          ? [1, 0]
+          : null;
+        if (delta) {
+          move(delta[0], delta[1]);
+        }
+      }
+      if (key === "enter") {
+        const hit = buildingAt(player.x, player.y);
+        if (hit) setOpen(hit.id);
+      }
+      if (key === "escape") setOpen(null);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [player]);
+
+  useEffect(() => {
+    if (completionTriggered.current) {
+      return;
+    }
+    if (
+      progress.clarte.done &&
+      progress.creation.done &&
+      progress.decision.done &&
+      progress.ethique.done
+    ) {
+      completionTriggered.current = true;
+      void markCompleted({ triggerCompletionCallback: true });
+    }
+  }, [progress, markCompleted]);
+
+  const move = (dx: number, dy: number) => {
+    const nx = player.x + dx;
+    const ny = player.y + dy;
+    if (!isWalkable(nx, ny)) return;
+    setPlayer({ x: nx, y: ny });
+    setWalkStep((step) => step + 1);
+  };
+
+  const buildingAt = (x: number, y: number) => {
+    return buildings.find((building) => building.x === x && building.y === y) || null;
+  };
+
+  const openIfOnBuilding = () => {
+    const hit = buildingAt(player.x, player.y);
+    if (hit) setOpen(hit.id);
+  };
+
+  const complete = (id: QuarterId, payload?: unknown) => {
+    setProgress((previous) => {
+      const visited = previous.visited.includes(id)
+        ? previous.visited
+        : [...previous.visited, id];
+      const next: Progress = {
+        ...previous,
+        visited,
+        clarte:
+          id === "clarte"
+            ? { done: true, score: typeof payload === "number" ? payload : previous.clarte.score }
+            : previous.clarte,
+        creation:
+          id === "creation"
+            ? { done: true, spec: (payload as CreationSpec) ?? previous.creation.spec }
+            : previous.creation,
+        decision:
+          id === "decision"
+            ? {
+                done: true,
+                choicePath: (payload as string[]) ?? previous.decision.choicePath,
+              }
+            : previous.decision,
+        ethique:
+          id === "ethique"
+            ? { done: true, score: typeof payload === "number" ? payload : previous.ethique.score }
+            : previous.ethique,
+      };
+      return next;
+    });
+    setOpen(null);
+    setCelebrate(true);
+    setTimeout(() => setCelebrate(false), 1800);
+  };
+
+  const downloadJSON = () => {
+    const data = {
+      activity: "Explorateur IA",
+      timestamp: new Date().toISOString(),
+      progress,
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `explorateur_ia_${Date.now()}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const at = buildingAt(player.x, player.y);
+
+  return (
+    <div className="relative space-y-6">
+      <Fireworks show={celebrate} />
+      <div className="grid md:grid-cols-[minmax(0,1fr)_260px] gap-6">
+        <div className="rounded-2xl border bg-white p-4 shadow relative overflow-hidden">
+          <div className="absolute right-3 top-3 text-[10px] text-slate-500 bg-slate-100/60 px-2 py-1 rounded-full border">
+            Tiny Town
+          </div>
+          <div
+            className="grid"
+            style={{
+              gridTemplateColumns: `repeat(${GRID_W}, ${TILE}px)`,
+              gridTemplateRows: `repeat(${GRID_H}, ${TILE}px)`,
+              gap: 2,
+            }}
+          >
+            {world.map((row, y) =>
+              row.map((tileKind, x) => (
+                <div key={`${x}-${y}`} className="relative">
+                  <TileWithTs kind={tileKind} ts={tileset} />
+                  {tileKind === 1 && (
+                    <div className="absolute inset-0 rounded bg-amber-200/30" />
+                  )}
+                  {buildings.map(
+                    (building) =>
+                      building.x === x &&
+                      building.y === y && (
+                        <button
+                          key={building.id}
+                          onClick={() => setOpen(building.id)}
+                          className="absolute inset-1 rounded-lg border-2 flex items-center justify-center shadow"
+                          style={{
+                            borderColor: building.color,
+                            background: "rgba(255,255,255,0.9)",
+                          }}
+                          title={building.label}
+                        >
+                          <BuildingSprite id={building.id} ts={tileset} />
+                        </button>
+                      )
+                  )}
+                  {player.x === x && player.y === y && (
+                    <div className="absolute inset-1 animate-[float_1.2s_ease-in-out_infinite]">
+                      <PlayerSprite ts={tileset} step={walkStep} />
+                    </div>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+          <style>{`
+            @keyframes float { 0%,100%{ transform: translateY(0) } 50%{ transform: translateY(-2px) } }
+          `}</style>
+          <div className="mt-3 flex items-center justify-between text-sm">
+            <div>
+              {at ? (
+                <span>
+                  Vous êtes devant: <span className="font-semibold">{at.label}</span>
+                </span>
+              ) : (
+                <span>Explorez la ville et entrez dans un quartier.</span>
+              )}
+            </div>
+            <button
+              onClick={openIfOnBuilding}
+              className="px-3 py-1 rounded-lg bg-slate-100 border"
+            >
+              Entrer
+            </button>
+          </div>
+        </div>
+        <aside className="space-y-4">
+          <div className="rounded-2xl border bg-white p-4 shadow">
+            <div className="text-xs uppercase tracking-wide text-slate-500">
+              Progression
+            </div>
+            <ul className="mt-2 text-sm space-y-2">
+              {buildings.map((building) => (
+                <li key={building.id} className="flex items-center justify-between gap-3">
+                  <button
+                    onClick={() => setOpen(building.id)}
+                    className="text-left hover:underline"
+                    style={{ color: building.color }}
+                  >
+                    {building.label}
+                  </button>
+                  <span className="text-xs px-2 py-0.5 rounded-full border bg-slate-50">
+                    {building.id === "clarte" && (progress.clarte.done ? "OK" : "À faire")}
+                    {building.id === "creation" && (progress.creation.done ? "OK" : "À faire")}
+                    {building.id === "decision" && (progress.decision.done ? "OK" : "À faire")}
+                    {building.id === "ethique" && (progress.ethique.done ? "OK" : "À faire")}
+                    {building.id === "mairie" && "—"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="rounded-2xl border bg-white p-4 shadow">
+            <div className="text-xs uppercase tracking-wide text-slate-500">
+              Contrôles
+            </div>
+            <div className="mt-2 grid grid-cols-2 gap-3">
+              <DPad onMove={move} />
+              <div className="text-xs text-slate-600 space-y-1">
+                <p>Entrer: Ouvrir</p>
+                <p>Échap: Fermer</p>
+                <p>Clic: Accès direct</p>
+              </div>
+            </div>
+          </div>
+          <div className="rounded-2xl border bg-white p-4 shadow">
+            <div className="text-xs uppercase tracking-wide text-slate-500">
+              Tileset
+            </div>
+            <TilesetControls ts={tileset} setTs={setTileset} />
+          </div>
+          <div className="rounded-2xl border bg-white p-4 shadow">
+            <div className="text-xs uppercase tracking-wide text-slate-500">
+              Export
+            </div>
+            <div className="mt-2 flex gap-2">
+              <button
+                onClick={downloadJSON}
+                className="px-3 py-2 rounded-xl bg-slate-800 text-white"
+              >
+                JSON
+              </button>
+              <button
+                onClick={() => window.print()}
+                className="px-3 py-2 rounded-xl bg-slate-100 border"
+              >
+                PDF
+              </button>
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <Modal
+        open={open === "clarte"}
+        onClose={() => setOpen(null)}
+        title="Quartier Clarté"
+      >
+        <p className="text-sm text-slate-600 mb-4">
+          Choisissez la meilleure consigne pour obtenir un plan clair. Pas de saisie:
+          uniquement des options.
+        </p>
+        <ClarteQuiz onDone={(score) => complete("clarte", score)} />
+      </Modal>
+
+      <Modal
+        open={open === "creation"}
+        onClose={() => setOpen(null)}
+        title="Quartier Création"
+      >
+        <p className="text-sm text-slate-600 mb-4">
+          Assemblez une consigne en combinant des paramètres. La génération est simulée côté
+          client.
+        </p>
+        <CreationBuilder onDone={(spec) => complete("creation", spec)} />
+      </Modal>
+
+      <Modal
+        open={open === "decision"}
+        onClose={() => setOpen(null)}
+        title="Quartier Décision"
+      >
+        <p className="text-sm text-slate-600 mb-4">
+          Choisissez une trajectoire. Chaque choix révèle avantages et limites.
+        </p>
+        <DecisionPath onDone={(path) => complete("decision", path)} />
+      </Modal>
+
+      <Modal
+        open={open === "ethique"}
+        onClose={() => setOpen(null)}
+        title="Quartier Éthique"
+      >
+        <p className="text-sm text-slate-600 mb-4">
+          Réagissez à des dilemmes. Retour immédiat sur les enjeux.
+        </p>
+        <EthicsDilemmas onDone={(score) => complete("ethique", score)} />
+      </Modal>
+
+      <Modal
+        open={open === "mairie"}
+        onClose={() => setOpen(null)}
+        title="Mairie — Bilan visuel"
+      >
+        <BadgeView progress={progress} onDownloadJSON={downloadJSON} />
+      </Modal>
+
+      <footer className="text-center text-xs text-slate-500">
+        Module web auto-portant — aucune saisie de texte requise. © Explorateur IA
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé
- ajouter la nouvelle page Explorateur IA avec mini-jeux pour les quatre quartiers
- intégrer le tileset Tiny Town par défaut avec contrôles atlas/builtin
- enregistrer l’activité dans le catalogue et la rendre disponible depuis l’accueil

## Tests
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8fc8d5dc832286a0df4a20ba8b29