### PR TITLE
Redirect LTI sessions to activity list

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,6 +1,8 @@
-import { Link } from "react-router-dom";
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
 
 import logoPrincipal from "../assets/logo_principal.svg";
+import { useLTI } from "../hooks/useLTI";
 
 const heroHighlights = [
   {
@@ -70,6 +72,15 @@ const onboardingSteps = [
 ];
 
 function LandingPage(): JSX.Element {
+  const navigate = useNavigate();
+  const { isLTISession, loading: ltiLoading } = useLTI();
+
+  useEffect(() => {
+    if (!ltiLoading && isLTISession) {
+      navigate("/activites", { replace: true });
+    }
+  }, [isLTISession, ltiLoading, navigate]);
+
   return (
     <div className="landing-gradient min-h-screen px-6 pb-24 pt-10 text-[color:var(--brand-black)]">
       <div className="mx-auto flex max-w-6xl flex-col gap-16">


### PR DESCRIPTION
## Summary
- redirect active LTI sessions that land on the home page to the activity catalog

## Testing
- npm run build *(fails: Could not resolve "../assets/kenney_tiny-town/Tilemap/tilemap_packed.png" from "src/pages/ExplorateurIA.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68cd977e187883228ba17ce571bb4485