### PR TITLE
Normalize path tile matching for NESO intersections

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,11 @@ Chaque module intègre des encarts pédagogiques pour ancrer les notions clés e
 - Les contrôles UI gèrent les erreurs réseau et affichent l’état du flux continu pour faciliter les démonstrations.
 - Le backend s’appuie sur le SDK `openai>=1.99.2` (utilisé ici comme client Responses) afin d’accéder aux paramètres de verbosité et de raisonnement des modèles GPT-5.
 - L’interface adopte l’esthétique du Cégep Limoilou (palette noir/rouge, typographie Poppins, bandeaux arrondis) tout en conservant la progression pédagogique en trois pages distinctes.
+
+### Vérification manuelle — carrefour NESO
+
+Après avoir appliqué les correctifs de sprites de chemin, vous pouvez confirmer visuellement que la tuile de croisement NESO (`mapTile_128.png`) est bien sélectionnée :
+
+1. Lancer le frontend localement (`cd frontend && npm install && npm run dev -- --host`).
+2. Ouvrir http://localhost:5173 et naviguer jusqu’à l’activité « Explorateur IA ».
+3. Activer/désactiver quelques chemins pour créer une intersection nord-est-sud-ouest et vérifier que la tuile de carrefour s’affiche correctement.

--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -1178,12 +1178,24 @@ function getPathTileCoord(x: number, y: number): TileCoord {
   if (north) directionList.push("north");
   if (south) directionList.push("south");
   if (west) directionList.push("west");
+  directionList.sort();
   const connectionString = directionList.join(",");
 
   // Chercher une tuile qui correspond exactement aux connexions, en priorisant les tuiles recommandées
   const availableMatches = [];
   for (const [tileName, entry] of MAP_PACK_ATLAS.entries()) {
-    if (entry.type === "path" && entry.connections === connectionString) {
+    if (entry.type !== "path" || !entry.connections) {
+      continue;
+    }
+
+    const entryConnections = entry.connections
+      .split(",")
+      .map((dir) => dir.trim())
+      .filter(Boolean)
+      .sort()
+      .join(",");
+
+    if (entryConnections === connectionString) {
       // Tuiles prioritaires spécifiées par l'utilisateur
       const priorityTiles = [
         "mapTile_126.png", "mapTile_127.png", "mapTile_128.png", "mapTile_123.png", "mapTile_124.png",
@@ -1230,8 +1242,8 @@ function getPathTileCoord(x: number, y: number): TileCoord {
     if (!east) return atlas("mapTile_126.png"); // nord-sud simple au lieu du T
     if (!west) return atlas("mapTile_126.png"); // nord-sud simple au lieu du T
   } else {
-    // 4 connexions : préférer une tuile simple au lieu du croisement complet
-    return atlas("mapTile_126.png"); // trajet nord-sud simple
+    // 4 connexions : préférer la tuile de croisement NESO standard
+    return atlas("mapTile_128.png");
   }
 
   return atlas("mapTile_126.png"); // Default: ligne droite nord-sud


### PR DESCRIPTION
## Summary
- normalize path connection matching by comparing sorted directions against the atlas metadata
- ensure the four-way fallback explicitly uses the NESO intersection tile
- document a manual in-game verification procedure for the NESO crossing sprite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce7f30c98c8322aa6adbec7c28eba9