### PR TITLE
Exclude snowy and dead trees from random selection

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -115,6 +115,12 @@ function getTilesByType(type: AtlasEntry["type"], subtype?: string): AtlasEntry[
       if (entry.overlay && entry.transparent_bg === false) {
         continue; // Passer ce sprite
       }
+      if (type === "object" && subtype === "tree") {
+        const description = entry.description?.toLowerCase() ?? "";
+        if (description.includes("neige") || description.includes("mort")) {
+          continue;
+        }
+      }
       results.push(entry);
     }
   }


### PR DESCRIPTION
## Summary
- filter atlas tree tiles whose description mentions "neige" or "mort" when picking random tree overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce827e491c83229ae4e88f0f97877c