### PR TITLE
feat: add sand base borders around lakes

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -795,8 +795,13 @@ function generateWorld(): TerrainTile[][] {
 
   // Ponds and beaches
   fillRect(6, 5, 10, 4, TILE_KIND.WATER);
-  outlineRect(5, 4, 12, 6, TILE_KIND.SAND, true); // true = en overlay
+  // Bordure de sable en base pour éviter que le décor repose sur du gazon
+  outlineRect(5, 4, 12, 6, TILE_KIND.SAND);
+  // Conserver une transition douce éventuellement utilisée par le rendu
+  outlineRect(5, 4, 12, 6, TILE_KIND.SAND, true);
+
   fillRect(42, 30, 10, 6, TILE_KIND.WATER);
+  outlineRect(41, 29, 12, 8, TILE_KIND.SAND);
   outlineRect(41, 29, 12, 8, TILE_KIND.SAND, true);
 
   // Farmland belt in the south-west


### PR DESCRIPTION
## Summary
- ensure lake shore tiles switch to sand at the base layer before applying decorative overlays
- keep optional sand overlay to preserve soft shoreline transitions around interior ponds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce8c782db48322bab368039edfd6a7