### PR TITLE
Fix contour placement around islands

### DIFF
--- a/frontend/src/assets/kenney_map-pack/Spritesheet/CONSTRUCTION_RULES.md
+++ b/frontend/src/assets/kenney_map-pack/Spritesheet/CONSTRUCTION_RULES.md
@@ -1,0 +1,47 @@
+# Règles de construction du tileset enrichi
+
+Ce document décrit comment interpréter les métadonnées fournies dans `mapPack_enriched.xml` pour générer des cartes cohérentes. Chaque `SubTexture` représente une tuile de 64×64 px enrichie avec des attributs normalisés (`type`, `subtype`, `category`, `connections`, `walkable`, etc.).
+
+## 1. Gestion des catégories
+- **terrain** : tuiles de sol ou de falaise. Elles combinent `type` (`bordure`, `coin_interieur`, `falaise`, `material`…) et `subtype` (sable, gazon, glace, etc.). Les variantes `material` représentent les dalles pleines et couvrent toute la case (`transparent="false"`) tandis que les bordures, coins intérieurs et falaises restent translucides (`transparent="true"`). Toutes les tuiles de cette catégorie sont non franchissables (`walkable="false"`).
+- **path** : chemins praticables classiques. Les `connections` exposent toutes les directions ouvertes (`north`, `south`, `east`, `west`). Conserver la cohérence de graphe (ex. une tuile T doit relier les trois directions annoncées).
+- **bulle_verte** : variantes de chemins translucides. Elles suivent les mêmes règles que `path`, y compris `walkable="true"`, mais portent `type="bulle_verte"` pour pouvoir appliquer un style spécifique.
+- **object**, **character**, **ui** : éléments décoratifs ou interactifs posés en surcouche (`overlay="true"`). Par défaut ils sont non franchissables, sauf les tuiles numérotées (`subtype="number"`) utilisées comme balises de parcours, qui doivent être traitées comme des chemins.
+
+## 2. Attributs directionnels
+- `connections` est obligatoire pour toute tuile `walkable="true"` (chemins, bulles vertes, chiffres). Le set de directions indique les sorties disponibles depuis la tuile.
+- Les falaises et bords peuvent également exposer `connections` pour préciser leur orientation visuelle, mais celles-ci n’impliquent pas de traversabilité.
+- Les `coin_interieur` — seuls ou combinés à `falaise` — utilisent des directions diagonales (`northwest`, `northeast`, `southeast`, `southwest`). Ces valeurs décrivent l’orientation du renfoncement :
+
+  | `connections` | Orientation visuelle | Utilisation typique |
+  | --- | --- | --- |
+  | `northwest` | angle creusé vers le nord et l’ouest | placer l’intérieur d’un virage en haut à gauche d’une falaise ou d’un plateau |
+  | `northeast` | angle creusé vers le nord et l’est | compléter un virage en haut à droite |
+  | `southeast` | angle creusé vers le sud et l’est | refermer un relief en bas à droite |
+  | `southwest` | angle creusé vers le sud et l’ouest | dessiner un retour de falaise en bas à gauche |
+
+  Lors de l’assemblage, associer chaque coin intérieur avec ses bordures adjacentes (ex. une falaise au nord nécessite une tuile `connections="north"`) pour garantir que les textures se rejoignent sans cassure.
+
+## 3. Gestion de la traversabilité
+- Seules les tuiles des catégories `path`, `bulle_verte` et les chiffres (`subtype="number"`) sont `walkable="true"`.
+- Toute autre tuile doit rester `walkable="false"` pour éviter des collisions fantômes.
+- Lors du placement d’une entité, vérifier que toutes les cases cibles sont `walkable="true"` avant d’autoriser un déplacement.
+
+## 4. Superposition et rendu
+- Les tuiles avec `overlay="true"` (arbres, personnages, objets, chiffres, marqueurs) doivent être dessinées dans une couche supérieure afin de ne pas masquer les chemins sous-jacents.
+- Toutes les sous-textures exposent désormais un indicateur `transparent`. Sa valeur est `false` uniquement pour les dalles de matériau pleines (`type` contenant `material` mais pas `coin_interieur`), ce qui signale qu’elles remplacent complètement la case. Toutes les autres tuiles (bordures, coins, falaises, chemins, objets…) restent translucides (`transparent="true"`) et laissent apparaître les couches inférieures.
+
+## 5. Extensions
+- Tout ajout de tuile doit renseigner au minimum `category`, `type`, `walkable` et, si applicable, `subtype`, `connections`, `overlay`, `transparent`.
+- Pour rester compatible avec le script `scripts/add_png_metadata.py`, conserver les noms de fichiers et les dimensions d’origine.
+
+## 6. Construire une carte procédurale
+Le script `scripts/build_map_png.py` automatise la construction d’une île en respectant les règles ci-dessus. La séquence recommandée est la suivante :
+
+1. **Fond aquatique** : remplir toute la carte avec une tuile d’eau (`subtype="water"`, `water_shallow` ou `water_deep`).
+2. **Sélection d’un matériau d’île** : choisir un unique matériau plein (`type` contenant `material`) – aléatoirement ou via `--material` – et générer une masse terrestre connectée d’une forme organique (croissance radiale aléatoire plutôt qu’un simple carré).
+3. **Contour** : appliquer des bordures (`type` contenant `bordure`/`coin_interieur`) ou des falaises (`type` contenant `falaise`) **sur les cases d’eau adjacentes** au matériau. Chaque case aquatique qui touche l’île sur un côté cardinal reçoit la variante opposée (`north`, `east`, `south`, `west`). Les coins sortants se complètent avec les diagonales correspondantes (`northeast`, `northwest`, `southeast`, `southwest`), tandis que les coins intérieurs emploient les variantes `coin_interieur` qui réunissent deux directions (ex. `southwest` lorsque la case d’eau est en contact avec l’île au nord et à l’est). Veillez à conserver la continuité visuelle : un bloc `north-east` doit avoir un bloc `north` à gauche et un bloc `east` en dessous, un coin intérieur `south-west` est bordé par un bloc `south` à sa gauche et un bloc `west` en dessous, un bloc `south` est encadré par deux autres blocs portant aussi `south`, etc. Le paramètre `--edge-style` permet de forcer l’un ou l’autre, la valeur `auto` privilégiant les falaises et repliant sur les bordures si nécessaire.
+4. **Trajet numéroté** : creuser un chemin continu à l’intérieur de l’île avec les tuiles `category="path"` (ou `type="bulle_verte"` pour la variante). Placer ensuite une séquence de chiffres `subtype="number"` – marchables et transparents – le long de ce trajet pour servir de jalons. Le nombre de chiffres peut être imposé avec `--numbers`, sinon il est déduit de la taille de la carte.
+5. **Décorations** : disposer aléatoirement des arbres ou objets (`category="object"`, `overlay="true"`, `walkable="false"`) sur les cases de l’île qui ne sont pas occupées par le trajet. Le paramètre `--objects` fixe leur quantité et `--seed` permet de reproduire exactement un rendu.
+
+Les paramètres facultatifs du script permettent d’adapter chaque étape à une consigne spécifique sans déroger aux métadonnées du spritesheet.

--- a/frontend/src/assets/kenney_map-pack/Spritesheet/mapPack_enriched.xml
+++ b/frontend/src/assets/kenney_map-pack/Spritesheet/mapPack_enriched.xml
@@ -1,272 +1,191 @@
 <?xml version='1.0' encoding='utf-8'?>
 <TextureAtlas imagePath="mapPack_spritesheet.png">
-
-  <!-- ====== TERRAIN TYPES ====== -->
-
-  <!-- Gazon -->
-  <SubTexture name="mapTile_022.png" x="768" y="128" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon"
-    walkable="true" />
-  <SubTexture name="mapTile_006.png" x="832" y="256" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon nord-ouest"
-    connections="northwest" walkable="true" />
-  <SubTexture name="mapTile_007.png" x="832" y="192" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon nord"
-    connections="north" walkable="true" />
-  <SubTexture name="mapTile_008.png" x="832" y="128" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon nord-est"
-    connections="northeast" walkable="true" />
-  <SubTexture name="mapTile_021.png" x="768" y="192" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon ouest"
-    connections="west" walkable="true" />
-  <SubTexture name="mapTile_023.png" x="768" y="64" width="64" height="64"
-    type="terrain" subtype="grass" desc="gazon est"
-    connections="east" walkable="true" />
-
-  <!-- Sable -->
-  <SubTexture name="mapTile_017.png" x="768" y="448" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable"
-    walkable="true" />
-  <SubTexture name="mapTile_001.png" x="0" y="192" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable nord-ouest"
-    connections="northwest" walkable="true" />
-  <SubTexture name="mapTile_002.png" x="0" y="128" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable nord"
-    connections="north" walkable="true" />
-  <SubTexture name="mapTile_003.png" x="0" y="64" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable nord-est"
-    connections="northeast" walkable="true" />
-  <SubTexture name="mapTile_016.png" x="768" y="512" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable ouest"
-    connections="west" walkable="true" />
-  <SubTexture name="mapTile_018.png" x="768" y="384" width="64" height="64"
-    type="terrain" subtype="sand" desc="sable est"
-    connections="east" walkable="true" />
-
-  <!-- Eau -->
-  <SubTexture name="mapTile_188.png" x="0" y="256" width="64" height="64"
-    type="terrain" subtype="water" desc="eau profonde"
-    walkable="false" />
-  <SubTexture name="mapTile_171.png" x="64" y="448" width="64" height="64"
-    type="terrain" subtype="water" desc="eau peu profonde"
-    walkable="false" />
-  <SubTexture name="mapTile_187.png" x="0" y="320" width="64" height="64"
-    type="terrain" subtype="water" desc="eau"
-    walkable="false" />
-
-  <!-- Terre -->
-  <SubTexture name="mapTile_087.png" x="448" y="448" width="64" height="64"
-    type="terrain" subtype="farmland" desc="terre cultivée"
-    walkable="true" />
-
-  <!-- ====== PATH TYPES ====== -->
-
-  <!-- Trajets droits -->
-  <SubTexture name="mapTile_126.png" x="256" y="640" width="64" height="64"
-    type="path" subtype="straight" desc="trajet nord-sud"
-    connections="north,south" walkable="true" transparent="true" />
-  <SubTexture name="mapTile_127.png" x="256" y="576" width="64" height="64"
-    type="path" subtype="straight" desc="trajet est-ouest"
-    connections="east,west" walkable="true" transparent="true" />
-
-  <!-- Virages -->
-  <SubTexture name="mapTile_140.png" x="192" y="640" width="64" height="64"
-    type="path" subtype="corner" desc="trajet nord-est"
-    connections="north,east" walkable="true" />
-  <SubTexture name="mapTile_141.png" x="192" y="576" width="64" height="64"
-    type="path" subtype="corner" desc="trajet nord-ouest"
-    connections="north,west" walkable="true" />
-  <SubTexture name="mapTile_124.png" x="256" y="768" width="64" height="64"
-    type="path" subtype="corner" desc="trajet sud-ouest"
-    connections="south,west" walkable="true" />
-  <SubTexture name="mapTile_123.png" x="256" y="832" width="64" height="64"
-    type="path" subtype="corner" desc="trajet sud-est"
-    connections="south,east" walkable="true" />
-  <SubTexture name="mapTile_158.png" x="128" y="384" width="64" height="64"
-    type="path" subtype="corner" desc="trajet sud-ouest"
-    connections="south,west" walkable="true" />
-  <SubTexture name="mapTile_156.png" x="128" y="512" width="64" height="64"
-    type="path" subtype="corner" desc="trajet tournant sud-ouest"
-    connections="south,west" walkable="true" />
-  <SubTexture name="mapTile_155.png" x="128" y="576" width="64" height="64"
-    type="path" subtype="corner" desc="trajet tournant sud-est"
-    connections="south,east" walkable="true" />
-  <SubTexture name="mapTile_139.png" x="192" y="704" width="64" height="64"
-    type="path" subtype="corner" desc="trajet tournant nord-ouest"
-    connections="north,west" walkable="true" />
-  <SubTexture name="mapTile_138.png" x="192" y="768" width="64" height="64"
-    type="path" subtype="corner" desc="trajet tournant sud-est"
-    connections="south,east" walkable="true" />
-  <SubTexture name="mapTile_122.png" x="320" y="0" width="64" height="64"
-    type="path" subtype="corner" desc="trajet tournant ouest-sud"
-    connections="south,west" walkable="true" />
-
-  <!-- Intersections T -->
-  <SubTexture name="mapTile_125.png" x="256" y="704" width="64" height="64"
-    type="path" subtype="t_junction" desc="trajet T est-sud-ouest"
-    connections="east,south,west" walkable="true" />
-  <SubTexture name="mapTile_142.png" x="192" y="512" width="64" height="64"
-    type="path" subtype="t_junction" desc="trajet T nord-est-ouest"
-    connections="north,east,west" walkable="true" />
-  <SubTexture name="mapTile_144.png" x="192" y="384" width="64" height="64"
-    type="path" subtype="t_junction" desc="trajet T nord-sud-ouest"
-    connections="north,south,west" walkable="true" />
-  <SubTexture name="mapTile_143.png" x="192" y="448" width="64" height="64"
-    type="path" subtype="t_junction" desc="trajet T nord-est-sud"
-    connections="north,east,south" walkable="true" />
-
-  <!-- Fins de chemins -->
-  <SubTexture name="mapTile_146.png" x="192" y="256" width="64" height="64"
-    type="path" subtype="end" desc="trajet fin nord"
-    connections="north" walkable="true" />
-  <SubTexture name="mapTile_129.png" x="256" y="448" width="64" height="64"
-    type="path" subtype="end" desc="trajet fin sud"
-    connections="south" walkable="true" />
-  <SubTexture name="mapTile_130.png" x="256" y="384" width="64" height="64"
-    type="path" subtype="end" desc="trajet fin ouest"
-    connections="west" walkable="true" />
-  <SubTexture name="mapTile_147.png" x="192" y="192" width="64" height="64"
-    type="path" subtype="end" desc="trajet fin est"
-    connections="east" walkable="true" />
-
-  <!-- Croisements -->
-  <SubTexture name="mapTile_128.png" x="256" y="512" width="64" height="64"
-    type="path" subtype="crossroads" desc="trajet croisement"
-    connections="north,east,south,west" walkable="true" />
-
-  <!-- ====== OBJECTS/DECORATIONS ====== -->
-
-  <!-- Arbres -->
-  <SubTexture name="mapTile_115.png" x="320" y="448" width="64" height="64"
-    type="object" subtype="tree" desc="arbre"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_055.png" x="576" y="704" width="64" height="64"
-    type="object" subtype="tree" desc="arbre"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_040.png" x="640" y="768" width="64" height="64"
-    type="object" subtype="tree" desc="sapin"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_045.png" x="640" y="448" width="64" height="64"
-    type="object" subtype="tree" desc="arbre mauve"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_109.png" x="320" y="832" width="64" height="64"
-    type="object" subtype="tree" desc="arbre avec neige"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_110.png" x="320" y="768" width="64" height="64"
-    type="object" subtype="tree" desc="sapin avec neige"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_120.png" x="320" y="128" width="64" height="64"
-    type="object" subtype="tree" desc="arbre mort"
-    walkable="false" overlay="true" />
-
-  <!-- Fleurs et plantes (seulement celles avec fond transparent) -->
-  <SubTexture name="mapTile_054.png" x="576" y="768" width="64" height="64"
-    type="object" subtype="flower" desc="arbuste fleuri"
-    walkable="false" overlay="true" transparent_bg="true" />
-  <SubTexture name="mapTile_060.png" x="576" y="384" width="64" height="64"
-    type="object" subtype="flower" desc="champignons verts"
-    walkable="false" overlay="true" transparent_bg="true" />
-
-  <!-- Champignons avec fond blanc (exclus temporairement) -->
-  <SubTexture name="mapTile_105.png" x="384" y="192" width="64" height="64"
-    type="object" subtype="flower_whitebg" desc="champignon"
-    walkable="false" overlay="true" transparent_bg="false" />
-  <SubTexture name="mapTile_104.png" x="384" y="256" width="64" height="64"
-    type="object" subtype="flower_whitebg" desc="champignon rouge"
-    walkable="false" overlay="true" transparent_bg="false" />
-  <SubTexture name="mapTile_119.png" x="320" y="192" width="64" height="64"
-    type="object" subtype="flower_whitebg" desc="3 champignons"
-    walkable="false" overlay="true" transparent_bg="false" />
-
-  <!-- Objets spéciaux -->
-  <SubTexture name="mapTile_035.png" x="704" y="192" width="64" height="64"
-    type="object" subtype="plant" desc="cactus"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_039.png" x="640" y="832" width="64" height="64"
-    type="object" subtype="rock" desc="caillou"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_044.png" x="640" y="512" width="64" height="64"
-    type="object" subtype="treasure" desc="diamant rose"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_049.png" x="640" y="192" width="64" height="64"
-    type="object" subtype="rock" desc="tas de terre"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_034.png" x="704" y="256" width="64" height="64"
-    type="object" subtype="rock" desc="tas de terre"
-    walkable="false" overlay="true" />
-
-  <!-- Structures -->
-  <SubTexture name="mapTile_050.png" x="640" y="128" width="64" height="64"
-    type="object" subtype="building" desc="tente"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_095.png" x="384" y="832" width="64" height="64"
-    type="object" subtype="building" desc="igloo"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_099.png" x="832" y="320" width="64" height="64"
-    type="object" subtype="building" desc="tour château"
-    walkable="false" overlay="true" />
-  <SubTexture name="mapTile_100.png" x="384" y="512" width="64" height="64"
-    type="object" subtype="building" desc="château 2 tours"
-    walkable="false" overlay="true" />
-
-  <!-- ====== CHARACTERS ====== -->
-
-  <SubTexture name="mapTile_136.png" x="256" y="0" width="64" height="64"
-    type="character" subtype="player" desc="alien vert"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_137.png" x="192" y="832" width="64" height="64"
-    type="character" subtype="npc" desc="alien bleu"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_153.png" x="128" y="704" width="64" height="64"
-    type="character" subtype="npc" desc="alien rose"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_154.png" x="128" y="640" width="64" height="64"
-    type="character" subtype="npc" desc="alien jaune"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_170.png" x="64" y="512" width="64" height="64"
-    type="character" subtype="npc" desc="alien beige"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_094.png" x="448" y="0" width="64" height="64"
-    type="character" subtype="npc" desc="bonhomme de neige"
-    walkable="true" overlay="true" />
-
-  <!-- ====== UI/NUMBERS ====== -->
-
-  <SubTexture name="mapTile_131.png" x="256" y="320" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 1"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_132.png" x="256" y="256" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 2"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_133.png" x="256" y="192" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 3"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_134.png" x="256" y="128" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 4"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_148.png" x="192" y="128" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 6"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_151.png" x="128" y="832" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 9"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_152.png" x="128" y="768" width="64" height="64"
-    type="ui" subtype="number" desc="chiffre 10"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_145.png" x="192" y="320" width="64" height="64"
-    type="ui" subtype="number" desc="pas de chiffre"
-    walkable="true" overlay="true" />
-
-  <!-- ====== SPECIAL/ITEMS ====== -->
-
-  <SubTexture name="mapTile_179.png" x="0" y="832" width="64" height="64"
-    type="ui" subtype="marker" desc="bulle verte"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_114.png" x="320" y="512" width="64" height="64"
-    type="ui" subtype="marker" desc="carré jaune avec point d'exclamation"
-    walkable="true" overlay="true" />
-  <SubTexture name="mapTile_059.png" x="576" y="448" width="64" height="64"
-    type="object" subtype="vehicle" desc="ovni turquoise"
-    walkable="false" overlay="true" />
-
+  <SubTexture name="mapTile_001.png" x="0" y="192" width="64" height="64" type="bordure" subtype="sand" desc="sable nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_002.png" x="0" y="128" width="64" height="64" type="bordure" subtype="sand" desc="sable nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_003.png" x="0" y="64" width="64" height="64" type="bordure" subtype="sand" desc="sable nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_004.png" x="0" y="0" width="64" height="64" type="coin_interieur falaise" subtype="sand" desc="sable coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_005.png" x="384" y="576" width="64" height="64" type="coin_interieur falaise" subtype="sand" desc="sable coin intérieur falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_006.png" x="832" y="256" width="64" height="64" type="bordure" subtype="grass" desc="gazon nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_007.png" x="832" y="192" width="64" height="64" type="bordure" subtype="grass" desc="gazon nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_008.png" x="832" y="128" width="64" height="64" type="bordure" subtype="grass" desc="gazon nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_009.png" x="832" y="64" width="64" height="64" type="coin_interieur falaise" subtype="grass" desc="gazon coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_010.png" x="832" y="0" width="64" height="64" type="coin_interieur falaise" subtype="grass" desc="gazon coin intérieur falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_011.png" x="768" y="832" width="64" height="64" type="bordure" subtype="dirt_gray" desc="terre grise nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_012.png" x="768" y="768" width="64" height="64" type="bordure" subtype="dirt_gray" desc="terre grise nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_013.png" x="768" y="704" width="64" height="64" type="bordure" subtype="dirt_gray" desc="terre grise nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_014.png" x="768" y="640" width="64" height="64" type="coin_interieur falaise" subtype="dirt_gray" desc="terre grise coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_015.png" x="768" y="576" width="64" height="64" type="coin_interieur falaise" subtype="dirt_gray" desc="terre grise coin intérieur falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_016.png" x="768" y="512" width="64" height="64" type="bordure" subtype="sand" desc="sable ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_017.png" x="768" y="448" width="64" height="64" type="material" subtype="sand" desc="sable" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_018.png" x="768" y="384" width="64" height="64" type="bordure" subtype="sand" desc="sable est" connections="east" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_019.png" x="768" y="320" width="64" height="64" type="coin_interieur" subtype="sand" desc="sable coin intérieur nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_020.png" x="768" y="256" width="64" height="64" type="coin_interieur" subtype="sand" desc="sable coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_021.png" x="768" y="192" width="64" height="64" type="bordure" subtype="grass" desc="gazon ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_022.png" x="768" y="128" width="64" height="64" type="material" subtype="grass" desc="gazon" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_023.png" x="768" y="64" width="64" height="64" type="bordure" subtype="grass" desc="gazon est" connections="east" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_024.png" x="768" y="0" width="64" height="64" type="coin_interieur" subtype="grass" desc="gazon coin intérieur nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_025.png" x="704" y="832" width="64" height="64" type="coin_interieur" subtype="grass" desc="gazon coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_026.png" x="704" y="768" width="64" height="64" type="bordure" subtype="dirt_gray" desc="terre grise ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_027.png" x="704" y="704" width="64" height="64" type="material" subtype="dirt_gray" desc="terre grise" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_028.png" x="704" y="640" width="64" height="64" type="bordure" subtype="dirt_gray" desc="terre grise est" connections="east" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_029.png" x="704" y="576" width="64" height="64" type="material" subtype="dirt_gray" desc="terre grise" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_030.png" x="704" y="512" width="64" height="64" type="coin_interieur" subtype="dirt_gray" desc="terre grise coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_031.png" x="704" y="448" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_032.png" x="704" y="384" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_033.png" x="704" y="320" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_034.png" x="704" y="256" width="64" height="64" type="objet" subtype="rock" desc="tas de terre" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_035.png" x="704" y="192" width="64" height="64" type="objet" subtype="plant" desc="cactus" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_036.png" x="704" y="128" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_037.png" x="704" y="64" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_038.png" x="704" y="0" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_039.png" x="640" y="832" width="64" height="64" type="objet" subtype="rock" desc="caillou" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_040.png" x="640" y="768" width="64" height="64" type="objet" subtype="tree" desc="sapin" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_041.png" x="640" y="704" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_042.png" x="640" y="640" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_043.png" x="640" y="576" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_044.png" x="640" y="512" width="64" height="64" type="objet" subtype="treasure" desc="diamant rose" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_045.png" x="640" y="448" width="64" height="64" type="objet" subtype="tree" desc="arbre mauve" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_046.png" x="640" y="384" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_047.png" x="640" y="320" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_048.png" x="640" y="256" width="64" height="64" type="falaise" subtype="sand" desc="sable falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_049.png" x="640" y="192" width="64" height="64" type="objet" subtype="rock" desc="tas de terre" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_050.png" x="640" y="128" width="64" height="64" type="objet" subtype="building" desc="tente" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_051.png" x="640" y="64" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_052.png" x="640" y="0" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_053.png" x="576" y="832" width="64" height="64" type="falaise" subtype="grass" desc="gazon falaise nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_054.png" x="576" y="768" width="64" height="64" type="objet" subtype="flower" desc="arbuste fleuri" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_055.png" x="576" y="704" width="64" height="64" type="objet" subtype="tree" desc="arbre" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_056.png" x="576" y="640" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_057.png" x="576" y="576" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_058.png" x="576" y="512" width="64" height="64" type="falaise" subtype="dirt_gray" desc="terre grise falaise nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_059.png" x="576" y="448" width="64" height="64" type="objet" subtype="vehicle" desc="ovni turquoise" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_060.png" x="576" y="384" width="64" height="64" type="objet" subtype="flower" desc="champignons verts" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_061.png" x="576" y="320" width="64" height="64" type="bordure" subtype="ice" desc="glace nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_062.png" x="576" y="256" width="64" height="64" type="bordure" subtype="ice" desc="glace nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_063.png" x="576" y="192" width="64" height="64" type="bordure" subtype="ice" desc="glace nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_064.png" x="576" y="128" width="64" height="64" type="coin_interieur falaise" subtype="ice" desc="glace coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_065.png" x="576" y="64" width="64" height="64" type="coin_interieur" subtype="ice" desc="glace coin intérieur sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_066.png" x="576" y="0" width="64" height="64" type="bordure" subtype="dirt" desc="terre nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_067.png" x="512" y="832" width="64" height="64" type="bordure" subtype="dirt_brown" desc="terre brune nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_068.png" x="512" y="768" width="64" height="64" type="bordure" subtype="dirt_brown" desc="terre brune nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_069.png" x="512" y="704" width="64" height="64" type="coin_interieur falaise" subtype="dirt_brown" desc="terre brune coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_070.png" x="512" y="640" width="64" height="64" type="coin_interieur falaise" subtype="dirt_brown" desc="terre brune coin intérieur falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_071.png" x="512" y="576" width="64" height="64" type="bordure" subtype="dirt" desc="terre nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_072.png" x="512" y="512" width="64" height="64" type="bordure" subtype="dirt" desc="terre nord" connections="north" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_073.png" x="512" y="448" width="64" height="64" type="bordure" subtype="dirt" desc="terre nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_074.png" x="512" y="384" width="64" height="64" type="coin_interieur falaise" subtype="dirt" desc="terre coin intérieur falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_075.png" x="512" y="320" width="64" height="64" type="coin_interieur falaise" subtype="dirt" desc="terre coin intérieur falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_076.png" x="512" y="256" width="64" height="64" type="bordure" subtype="ice" desc="glace ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_077.png" x="512" y="192" width="64" height="64" type="material" subtype="ice" desc="glace" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_078.png" x="512" y="128" width="64" height="64" type="bordure" subtype="ice" desc="glace est" connections="east" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_079.png" x="512" y="64" width="64" height="64" type="coin_interieur" subtype="ice" desc="glace coin intérieur nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_080.png" x="512" y="0" width="64" height="64" type="coin_interieur" subtype="ice" desc="glace coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_081.png" x="448" y="832" width="64" height="64" type="bordure" subtype="dirt_brown" desc="terre brune ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_082.png" x="448" y="768" width="64" height="64" type="material" subtype="dirt_brown" desc="terre brune" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_083.png" x="448" y="704" width="64" height="64" type="bordure" subtype="dirt_brown" desc="terre brune est" connections="east" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_084.png" x="448" y="640" width="64" height="64" type="material" subtype="dirt_brown" desc="terre brune" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_085.png" x="448" y="576" width="64" height="64" type="coin_interieur" subtype="dirt_brown" desc="terre brune coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_086.png" x="448" y="512" width="64" height="64" type="bordure" subtype="dirt" desc="terre ouest" connections="west" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_087.png" x="448" y="448" width="64" height="64" type="material" subtype="farmland" desc="terre cultivée" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_088.png" x="448" y="384" width="64" height="64" type="bordure" subtype="dirt" desc="terre sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_089.png" x="448" y="320" width="64" height="64" type="coin_interieur" subtype="dirt" desc="terre coin intérieur nord-est" connections="northeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_090.png" x="448" y="256" width="64" height="64" type="coin_interieur" subtype="dirt" desc="terre coin intérieur nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_091.png" x="448" y="192" width="64" height="64" type="falaise" subtype="ice" desc="glace falaise nord-ouest" connections="northwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_092.png" x="448" y="128" width="64" height="64" type="falaise" subtype="ice" desc="glace falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_093.png" x="448" y="64" width="64" height="64" type="falaise" subtype="ice" desc="glace sud-est falaise" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_094.png" x="448" y="0" width="64" height="64" type="objet" subtype="npc" desc="bonhomme de neige" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_095.png" x="384" y="832" width="64" height="64" type="objet" subtype="building" desc="igloo" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_096.png" x="384" y="768" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_097.png" x="384" y="704" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_098.png" x="384" y="640" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_099.png" x="832" y="320" width="64" height="64" type="objet" subtype="building" desc="tour château" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_100.png" x="384" y="512" width="64" height="64" type="objet" subtype="building" desc="château 2 tours" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_101.png" x="384" y="448" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_102.png" x="384" y="384" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_103.png" x="384" y="320" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_104.png" x="384" y="256" width="64" height="64" type="objet" subtype="flower_whitebg" desc="champignon rouge" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_105.png" x="384" y="192" width="64" height="64" type="objet" subtype="flower_whitebg" desc="champignon" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_106.png" x="384" y="128" width="64" height="64" type="falaise" subtype="ice" desc="glace falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_107.png" x="384" y="64" width="64" height="64" type="falaise" subtype="ice" desc="glace sud falaise" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_108.png" x="384" y="0" width="64" height="64" type="falaise" subtype="ice" desc="glace falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_109.png" x="320" y="832" width="64" height="64" type="objet" subtype="tree" desc="arbre avec neige" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_110.png" x="320" y="768" width="64" height="64" type="objet" subtype="tree" desc="sapin avec neige" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_111.png" x="320" y="704" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_112.png" x="320" y="640" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_113.png" x="320" y="576" width="64" height="64" type="falaise" subtype="dirt_brown" desc="terre brune falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_114.png" x="320" y="512" width="64" height="64" type="objet" subtype="marker" desc="carré jaune avec point d'exclamation" walkable="false" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_115.png" x="320" y="448" width="64" height="64" type="objet" subtype="tree" desc="arbre" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_116.png" x="320" y="384" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud-ouest" connections="southwest" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_117.png" x="320" y="320" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud" connections="south" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_118.png" x="320" y="256" width="64" height="64" type="falaise" subtype="dirt" desc="terre falaise sud-est" connections="southeast" walkable="false" transparent="true" category="terrain" />
+  <SubTexture name="mapTile_119.png" x="320" y="192" width="64" height="64" type="objet" subtype="flower_whitebg" desc="3 champignons" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_120.png" x="320" y="128" width="64" height="64" type="objet" subtype="tree" desc="arbre mort" walkable="false" overlay="true" transparent="true" category="object" />
+  <SubTexture name="mapTile_121.png" x="320" y="64" width="64" height="64" type="bordure" subtype="corner" desc="trajet sud-est" connections="south,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_122.png" x="320" y="0" width="64" height="64" type="bordure" subtype="corner" desc="trajet tournant ouest-sud" connections="south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_123.png" x="256" y="832" width="64" height="64" type="bordure" subtype="corner" desc="trajet sud-est" connections="south,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_124.png" x="256" y="768" width="64" height="64" type="bordure" subtype="corner" desc="trajet sud-ouest" connections="south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_125.png" x="256" y="704" width="64" height="64" type="bordure" subtype="t_junction" desc="trajet T est-sud-ouest" connections="east,south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_126.png" x="256" y="640" width="64" height="64" type="bordure" subtype="straight" desc="trajet nord-sud" connections="north,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_127.png" x="256" y="576" width="64" height="64" type="bordure" subtype="straight" desc="trajet est-ouest" connections="east,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_128.png" x="256" y="512" width="64" height="64" type="bordure" subtype="crossroads" desc="trajet croisement" connections="north,east,south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_129.png" x="256" y="448" width="64" height="64" type="bordure" subtype="end" desc="trajet fin sud" connections="south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_130.png" x="256" y="384" width="64" height="64" type="bordure" subtype="end" desc="trajet fin ouest" connections="west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_131.png" x="256" y="320" width="64" height="64" type="objet" subtype="number" desc="chiffre 1" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_132.png" x="256" y="256" width="64" height="64" type="objet" subtype="number" desc="chiffre 2" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_133.png" x="256" y="192" width="64" height="64" type="objet" subtype="number" desc="chiffre 3" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_134.png" x="256" y="128" width="64" height="64" type="objet" subtype="number" desc="chiffre 4" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_135.png" x="256" y="64" width="64" height="64" type="objet" desc="affiche 5" walkable="false" transparent="true" />
+  <SubTexture name="mapTile_136.png" x="256" y="0" width="64" height="64" type="objet" subtype="player" desc="alien vert" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_137.png" x="192" y="832" width="64" height="64" type="objet" subtype="npc" desc="alien bleu" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_138.png" x="192" y="768" width="64" height="64" type="bordure" subtype="corner" desc="trajet tournant sud-est" connections="south,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_139.png" x="192" y="704" width="64" height="64" type="bordure" subtype="corner" desc="trajet tournant nord-ouest" connections="north,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_140.png" x="192" y="640" width="64" height="64" type="bordure" subtype="corner" desc="trajet nord-est" connections="north,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_141.png" x="192" y="576" width="64" height="64" type="bordure" subtype="corner" desc="trajet nord-ouest" connections="north,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_142.png" x="192" y="512" width="64" height="64" type="bordure" subtype="t_junction" desc="trajet T nord-est-ouest" connections="north,east,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_143.png" x="192" y="448" width="64" height="64" type="bordure" subtype="t_junction" desc="trajet T nord-est-sud" connections="north,east,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_144.png" x="192" y="384" width="64" height="64" type="bordure" subtype="t_junction" desc="trajet T nord-sud-ouest" connections="north,south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_145.png" x="192" y="320" width="64" height="64" type="objet" subtype="number" desc="pas de chiffre" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_146.png" x="192" y="256" width="64" height="64" type="bordure" subtype="end" desc="trajet fin nord" connections="north" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_147.png" x="192" y="192" width="64" height="64" type="bordure" subtype="end" desc="trajet fin est" connections="east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_148.png" x="192" y="128" width="64" height="64" type="objet" subtype="number" desc="chiffre 6" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_149.png" x="192" y="64" width="64" height="64" type="objet" desc="affiche 7" walkable="false" transparent="true" />
+  <SubTexture name="mapTile_150.png" x="192" y="0" width="64" height="64" type="objet" desc="affiche 8" walkable="false" transparent="true" />
+  <SubTexture name="mapTile_151.png" x="128" y="832" width="64" height="64" type="objet" subtype="number" desc="chiffre 9" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_152.png" x="128" y="768" width="64" height="64" type="objet" subtype="number" desc="chiffre 10" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_153.png" x="128" y="704" width="64" height="64" type="objet" subtype="npc" desc="alien rose" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_154.png" x="128" y="640" width="64" height="64" type="objet" subtype="npc" desc="alien jaune" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_155.png" x="128" y="576" width="64" height="64" type="bordure" subtype="corner" desc="trajet tournant sud-est" connections="south,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_156.png" x="128" y="512" width="64" height="64" type="bordure" subtype="corner" desc="trajet tournant sud-ouest" connections="south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_157.png" x="128" y="448" width="64" height="64" type="bulle_verte" subtype="corner" desc="trajet sud-est bulle verte" connections="south,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_158.png" x="128" y="384" width="64" height="64" type="bordure" subtype="corner" desc="trajet sud-ouest" connections="south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_159.png" x="128" y="320" width="64" height="64" type="bulle_verte" subtype="t_junction" desc="trajet T est-ouest-sud bulle verte" connections="east,west,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_160.png" x="128" y="256" width="64" height="64" type="bulle_verte" subtype="straight" desc="trajet nord-sud bulle verte" connections="north,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_161.png" x="128" y="192" width="64" height="64" type="bulle_verte" subtype="straight" desc="trajet est-ouest bulle verte" connections="east,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_162.png" x="128" y="128" width="64" height="64" type="bulle_verte" subtype="crossroads" desc="trajet nord-est-sud-ouest bulle verte" connections="north,east,south,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_163.png" x="128" y="64" width="64" height="64" type="bulle_verte" subtype="end" desc="trajet fin sud bulle verte" connections="south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_164.png" x="128" y="0" width="64" height="64" type="bulle_verte" subtype="end" desc="trajet fin ouest bulle verte" connections="west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_165.png" x="64" y="832" width="64" height="64" type="objet" subtype="number" desc="chiffre 11" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_166.png" x="64" y="768" width="64" height="64" type="objet" subtype="number" desc="chiffre 12" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_167.png" x="64" y="704" width="64" height="64" type="objet" subtype="number" desc="chiffre 13" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_168.png" x="64" y="640" width="64" height="64" type="objet" subtype="number" desc="chiffre 14" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_169.png" x="64" y="576" width="64" height="64" type="objet" subtype="number" desc="chiffre 15" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_170.png" x="64" y="512" width="64" height="64" type="objet" subtype="npc" desc="alien beige" walkable="false" overlay="true" transparent="true" category="character" />
+  <SubTexture name="mapTile_171.png" x="64" y="448" width="64" height="64" type="material" subtype="water_shallow" desc="eau peu profonde" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_172.png" x="64" y="384" width="64" height="64" type="bulle_verte" subtype="corner" desc="trajet tournant nord-est bulle verte" connections="north,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_173.png" x="64" y="320" width="64" height="64" type="bulle_verte" subtype="corner" desc="trajet tournant nord-ouest bulle verte" connections="north,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_174.png" x="64" y="256" width="64" height="64" type="bulle_verte" subtype="corner" desc="trajet nord-est bulle verte" connections="north,east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_175.png" x="64" y="192" width="64" height="64" type="bulle_verte" subtype="corner" desc="trajet nord-ouest bulle verte" connections="north,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_176.png" x="64" y="128" width="64" height="64" type="bulle_verte" subtype="t_junction" desc="trajet T nord-est-ouest bulle verte" connections="north,east,west" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_177.png" x="64" y="64" width="64" height="64" type="bulle_verte" subtype="t_junction" desc="trajet T nord-est-sud bulle verte" connections="north,east,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_178.png" x="64" y="0" width="64" height="64" type="bulle_verte" subtype="t_junction" desc="trajet T nord-ouest-sud bulle verte" connections="north,west,south" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_179.png" x="0" y="832" width="64" height="64" type="bulle_verte" subtype="marker" desc="bulle verte" walkable="false" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_180.png" x="0" y="768" width="64" height="64" type="bulle_verte" subtype="end" desc="trajet fin nord bulle verte" connections="north" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_181.png" x="0" y="704" width="64" height="64" type="bulle_verte" subtype="end" desc="trajet fin est bulle verte" connections="east" walkable="true" transparent="true" category="path" />
+  <SubTexture name="mapTile_182.png" x="0" y="640" width="64" height="64" type="objet" subtype="number" desc="chiffre 16" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_183.png" x="0" y="576" width="64" height="64" type="objet" subtype="number" desc="chiffre 17" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_184.png" x="0" y="512" width="64" height="64" type="objet" subtype="number" desc="chiffre 18" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_185.png" x="0" y="448" width="64" height="64" type="objet" subtype="number" desc="chiffre 19" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_186.png" x="0" y="384" width="64" height="64" type="objet" subtype="number" desc="chiffre 20" walkable="true" overlay="true" transparent="true" category="ui" />
+  <SubTexture name="mapTile_187.png" x="0" y="320" width="64" height="64" type="material" subtype="water" desc="eau" walkable="false" transparent="false" category="terrain" />
+  <SubTexture name="mapTile_188.png" x="0" y="256" width="64" height="64" type="material" subtype="water_deep" desc="eau profonde" walkable="false" transparent="false" category="terrain" />
 </TextureAtlas>

--- a/scripts/build_map_png.py
+++ b/scripts/build_map_png.py
@@ -1,0 +1,771 @@
+#!/usr/bin/env python3
+"""Assembler automatiquement une île respectant les consignes de construction.
+
+Le script génère une carte rectangulaire (`size` × `height`) à partir des
+subtextures décrites dans ``mapPack_enriched.xml``. Il applique
+successionnellement :
+
+1. un fond aquatique,
+2. une île d’un matériau unique choisi aléatoirement (ou via `--material`),
+3. un contour de bordures ou de falaises (`--edge-style`),
+4. un trajet continu jalonné de chiffres (`--numbers`),
+5. des arbres ou objets décoratifs (`--objects`).
+
+Le script n’est **pas** exécuté automatiquement ; lancez-le manuellement
+après avoir installé Pillow si vous souhaitez générer un rendu.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+import random
+import re
+import sys
+from typing import Dict, Iterable, Iterator, List, Tuple
+import xml.etree.ElementTree as ET
+
+try:
+    from PIL import Image
+except ImportError as exc:  # pragma: no cover - dépend de l'environnement d'exécution
+    raise SystemExit(
+        "Pillow doit être installé pour exécuter ce script (pip install Pillow)."
+    ) from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+XML_PATH = (
+    REPO_ROOT
+    / "frontend"
+    / "src"
+    / "assets"
+    / "kenney_map-pack"
+    / "Spritesheet"
+    / "mapPack_enriched.xml"
+)
+PNG_DIR = REPO_ROOT / "frontend" / "src" / "assets" / "kenney_map-pack" / "PNG"
+DEFAULT_OUTPUT = REPO_ROOT / "generated_map.png"
+DEFAULT_BACKGROUND = "mapTile_187.png"  # eau
+
+DEFAULT_MATERIAL_SUBTYPES = (
+    "sand",
+    "grass",
+    "dirt",
+    "dirt_gray",
+    "dirt_brown",
+    "ice",
+)
+
+EDGE_STYLES = ("auto", "bordure", "falaise")
+
+
+CARDINALS = ("north", "east", "south", "west")
+OPPOSITE = {"north": "south", "south": "north", "east": "west", "west": "east"}
+DIAGONAL_LOOKUP: Dict[Tuple[str, str], Tuple[str, ...]] = {
+    tuple(sorted(("north", "east"))): ("northeast",),
+    tuple(sorted(("north", "west"))): ("northwest",),
+    tuple(sorted(("south", "east"))): ("southeast",),
+    tuple(sorted(("south", "west"))): ("southwest",),
+}
+
+
+@dataclass(frozen=True)
+class Texture:
+    """Représente une tuile issue du XML enrichi."""
+
+    name: str
+    width: int
+    height: int
+    category: str
+    type: str | None
+    subtype: str | None
+    connections: Tuple[str, ...]
+    walkable: bool
+    overlay: bool
+    description: str | None
+
+
+def parse_connections(raw: str | None) -> Tuple[str, ...]:
+    """Transforme la chaîne de directions en tuple trié."""
+
+    if not raw:
+        return tuple()
+    parts = [part.strip() for part in raw.split(",") if part.strip()]
+    return tuple(sorted(parts))
+
+
+def load_textures() -> Dict[str, Texture]:
+    """Charge toutes les sous-textures décrites par le XML enrichi."""
+
+    if not XML_PATH.exists():
+        raise FileNotFoundError(f"Fichier XML introuvable : {XML_PATH}")
+
+    tree = ET.parse(XML_PATH)
+    root = tree.getroot()
+    textures: Dict[str, Texture] = {}
+
+    for node in root.findall("SubTexture"):
+        name = node.get("name")
+        if not name:
+            continue
+
+        width = int(node.get("width", "0"))
+        height = int(node.get("height", "0"))
+        category = node.get("category", "")
+        tex_type = node.get("type")
+        subtype = node.get("subtype")
+        connections = parse_connections(node.get("connections"))
+        walkable = node.get("walkable", "false").lower() == "true"
+        overlay = node.get("overlay", "false").lower() == "true"
+        description = node.get("desc")
+
+        textures[name] = Texture(
+            name=name,
+            width=width,
+            height=height,
+            category=category,
+            type=tex_type,
+            subtype=subtype,
+            connections=connections,
+            walkable=walkable,
+            overlay=overlay,
+            description=description,
+        )
+
+    return textures
+
+
+def build_path_index(textures: Dict[str, Texture], style: str) -> Dict[Tuple[str, ...], str]:
+    """Retourne une correspondance entre connexions et nom de tuile de chemin."""
+
+    index: Dict[Tuple[str, ...], list[str]] = {}
+
+    for texture in textures.values():
+        if texture.category != "path":
+            continue
+
+        is_bubble = texture.type == "bulle_verte"
+
+        if style == "standard" and is_bubble:
+            continue
+        if style == "bulle_verte" and not is_bubble:
+            continue
+
+        if not texture.connections:
+            continue
+
+        index.setdefault(texture.connections, []).append(texture.name)
+
+    return {key: sorted(names)[0] for key, names in index.items()}
+
+
+def collect_material_tiles(textures: Dict[str, Texture]) -> Dict[str, Texture]:
+    """Retourne les matériaux pleins indexés par leur sous-type."""
+
+    materials: Dict[str, Texture] = {}
+    for texture in textures.values():
+        if texture.category != "terrain":
+            continue
+        type_tokens = (texture.type or "").split()
+        if "material" not in type_tokens:
+            continue
+        if not texture.subtype:
+            continue
+        materials[texture.subtype] = texture
+    return materials
+
+
+def collect_edge_tiles(
+    textures: Dict[str, Texture],
+    include_bordure: bool,
+    include_falaise: bool,
+) -> Dict[str | None, Dict[Tuple[str, ...], str]]:
+    """Indexe les tuiles de bordure/falaise par sous-type et orientation."""
+
+    result: Dict[str | None, Dict[Tuple[str, ...], str]] = {}
+    for texture in textures.values():
+        if texture.category != "terrain":
+            continue
+        if not texture.connections or not texture.subtype:
+            continue
+
+        type_tokens = (texture.type or "").split()
+        if include_falaise and "falaise" in type_tokens:
+            result.setdefault(texture.subtype, {})[texture.connections] = texture.name
+        elif include_bordure and (
+            "bordure" in type_tokens
+            or ("coin_interieur" in type_tokens and "falaise" not in type_tokens)
+        ):
+            result.setdefault(texture.subtype, {})[texture.connections] = texture.name
+
+    return result
+
+
+NUMBER_PATTERN = re.compile(r"(\d+)")
+
+
+def collect_number_tiles(textures: Dict[str, Texture]) -> List[str]:
+    """Classe les chiffres marchables par ordre croissant."""
+
+    numbers: List[tuple[int, str]] = []
+    for texture in textures.values():
+        if texture.subtype != "number" or not texture.walkable:
+            continue
+        if texture.description:
+            match = NUMBER_PATTERN.search(texture.description)
+        else:
+            match = NUMBER_PATTERN.search(texture.name)
+        if not match:
+            continue
+        value = int(match.group(1))
+        numbers.append((value, texture.name))
+
+    numbers.sort(key=lambda item: item[0])
+    return [name for _, name in numbers]
+
+
+def collect_object_tiles(textures: Dict[str, Texture]) -> List[str]:
+    """Recense les objets décoratifs superposables (arbres, rochers, etc.)."""
+
+    objects: List[str] = []
+    for texture in textures.values():
+        if texture.category != "object":
+            continue
+        if not texture.overlay or texture.walkable:
+            continue
+        objects.append(texture.name)
+    return sorted(objects)
+
+
+class TileLibrary:
+    """Charge et met en cache les images PNG individuelles."""
+
+    def __init__(self, directory: Path) -> None:
+        self._directory = directory
+        self._cache: Dict[str, Image.Image] = {}
+
+    def get(self, name: str) -> Image.Image:
+        if name not in self._cache:
+            path = self._directory / name
+            if not path.exists():
+                raise FileNotFoundError(f"Fichier PNG introuvable : {path}")
+            with Image.open(path) as image:
+                self._cache[name] = image.copy()
+        return self._cache[name]
+
+
+def determine_neighbors(x: int, y: int, path_cells: set[tuple[int, int]]) -> Tuple[str, ...]:
+    """Calcule la liste triée des directions de sortie depuis une case chemin."""
+
+    neighbors = []
+    if (x, y - 1) in path_cells:
+        neighbors.append("north")
+    if (x + 1, y) in path_cells:
+        neighbors.append("east")
+    if (x, y + 1) in path_cells:
+        neighbors.append("south")
+    if (x - 1, y) in path_cells:
+        neighbors.append("west")
+
+    if not neighbors:
+        # Cas dégénéré (ex. carte 1×1) : on force un visuel en croix.
+        return tuple(CARDINALS)
+
+    return tuple(sorted(neighbors))
+
+
+def pick_material_subtype(
+    materials: Dict[str, Texture],
+    requested: str | None,
+    rng: random.Random,
+) -> str:
+    """Choisit le matériau de l'île (optionnellement imposé)."""
+
+    available = sorted(materials)
+    if not available:
+        raise SystemExit("Aucun matériau plein n'est disponible dans le XML.")
+
+    if requested:
+        if requested not in materials:
+            raise SystemExit(
+                "Sous-type de matériau inconnu. Choisissez parmi : "
+                + ", ".join(available)
+            )
+        return requested
+
+    # Favorise les sous-types courants définis en tête.
+    for subtype in DEFAULT_MATERIAL_SUBTYPES:
+        if subtype in materials:
+            return subtype
+
+    return rng.choice(available)
+
+
+def generate_island(
+    width: int,
+    height: int,
+    rng: random.Random,
+    target_ratio: tuple[float, float] = (0.25, 0.4),
+) -> set[tuple[int, int]]:
+    """Crée une forme organique connectée pour l'île."""
+
+    if width < 3 or height < 3:
+        raise SystemExit("La carte doit mesurer au moins 3×3 pour accueillir une île.")
+
+    min_cells = int(width * height * target_ratio[0])
+    max_cells = int(width * height * target_ratio[1])
+    target_size = max(4, rng.randint(min_cells, max(max_cells, min_cells + 1)))
+    target_size = min(target_size, width * height - 1)
+
+    center = (width // 2, height // 2)
+    island: set[tuple[int, int]] = {center}
+    frontier: set[tuple[int, int]] = set()
+
+    def neighbors(cell: tuple[int, int]) -> Iterator[tuple[int, int]]:
+        x, y = cell
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            nx, ny = x + dx, y + dy
+            if 1 <= nx < width - 1 and 1 <= ny < height - 1:
+                yield nx, ny
+
+    frontier.update(neighbors(center))
+
+    attempts = 0
+    while len(island) < target_size and attempts < width * height * 10:
+        if not frontier:
+            # Recharge la frontière autour de l'île courante.
+            for cell in list(island):
+                frontier.update(neighbors(cell))
+            frontier.difference_update(island)
+            if not frontier:
+                break
+
+        candidate = rng.choice(tuple(frontier))
+        frontier.remove(candidate)
+
+        # Bias vers le centre pour éviter les formes trop étalées.
+        weight = 1.0 - (
+            abs(candidate[0] - center[0]) / max(1, width)
+            + abs(candidate[1] - center[1]) / max(1, height)
+        )
+        if rng.random() < max(0.15, weight):
+            island.add(candidate)
+            frontier.update(neighbors(candidate))
+            frontier.difference_update(island)
+        attempts += 1
+
+    return island
+
+
+def build_neighbor_map(cells: set[tuple[int, int]]) -> Dict[tuple[int, int], list[tuple[int, int]]]:
+    """Construit les voisins cardinal des cellules données."""
+
+    neighbor_map: Dict[tuple[int, int], list[tuple[int, int]]] = {}
+    for (x, y) in cells:
+        adjacents: list[tuple[int, int]] = []
+        for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            candidate = (x + dx, y + dy)
+            if candidate in cells:
+                adjacents.append(candidate)
+        neighbor_map[(x, y)] = adjacents
+    return neighbor_map
+
+
+def carve_path(
+    island_cells: set[tuple[int, int]],
+    desired_length: int,
+    rng: random.Random,
+) -> List[tuple[int, int]]:
+    """Recherche un chemin simple de longueur donnée sur l'île."""
+
+    neighbor_map = build_neighbor_map(island_cells)
+    cells = [cell for cell, neighbors in neighbor_map.items() if neighbors]
+    if not cells:
+        return []
+
+    length = min(desired_length, len(cells))
+    min_length = 1
+
+    for current_length in range(length, min_length - 1, -1):
+        for _ in range(200):
+            start = rng.choice(cells)
+            stack: List[tuple[tuple[int, int], list[tuple[int, int]]]] = [
+                (start, rng.sample(neighbor_map[start], len(neighbor_map[start])))
+            ]
+            path = [start]
+            visited = {start}
+
+            while stack:
+                if len(path) >= current_length:
+                    return path
+
+                node, options = stack[-1]
+                while options and options[-1] in visited:
+                    options.pop()
+
+                if not options:
+                    stack.pop()
+                    if stack:
+                        path.pop()
+                    continue
+
+                nxt = options.pop()
+                visited.add(nxt)
+                path.append(nxt)
+                stack[-1] = (node, options)
+                stack.append(
+                    (
+                        nxt,
+                        rng.sample(
+                            neighbor_map[nxt], len(neighbor_map[nxt])
+                        ),
+                    )
+                )
+
+        # Réduit légèrement la cible si la topologie est trop contraignante.
+    # Aucun chemin trouvé : on renvoie un chemin minimal basé sur les cellules disponibles.
+    return [cells[0]]
+
+
+def distribute_indices(total: int, count: int) -> List[int]:
+    """Retourne des indices répartis uniformément sur une séquence."""
+
+    if count <= 0:
+        return []
+    if count == 1 or total == 1:
+        return [0]
+    step = (total - 1) / (count - 1)
+    return [round(i * step) for i in range(count)]
+
+
+def choose_edge_tile(
+    subtype: str,
+    orientation: Tuple[str, ...],
+    preferred_style: str,
+    bordure_tiles: Dict[str | None, Dict[Tuple[str, ...], str]],
+    falaise_tiles: Dict[str | None, Dict[Tuple[str, ...], str]],
+) -> str | None:
+    """Sélectionne la tuile de contour appropriée avec repli."""
+
+    lookup_order: List[Dict[str | None, Dict[Tuple[str, ...], str]]] = []
+    if preferred_style == "falaise":
+        lookup_order = [falaise_tiles, bordure_tiles]
+    elif preferred_style == "bordure":
+        lookup_order = [bordure_tiles, falaise_tiles]
+    else:  # auto
+        lookup_order = [falaise_tiles, bordure_tiles]
+
+    for index in lookup_order:
+        by_subtype = index.get(subtype) or {}
+        if orientation in by_subtype:
+            return by_subtype[orientation]
+
+    return None
+
+
+def _orient_from_directions(directions: set[str]) -> Tuple[str, ...] | None:
+    """Déduit l'orientation d'une tuile à partir des côtés touchant l'île."""
+
+    if not directions:
+        return None
+
+    opposite_dirs = {OPPOSITE[direction] for direction in directions}
+    if len(opposite_dirs) == 1:
+        return (next(iter(opposite_dirs)),)
+
+    diag_key = tuple(sorted(opposite_dirs))
+    if diag_key in DIAGONAL_LOOKUP:
+        return DIAGONAL_LOOKUP[diag_key]
+
+    # Cas dégénérés : privilégie une direction déterministe pour éviter les trous.
+    return (sorted(opposite_dirs)[0],)
+
+
+def compute_island_edges(
+    island: set[tuple[int, int]],
+    subtype: str,
+    preferred_style: str,
+    bordure_tiles: Dict[str | None, Dict[Tuple[str, ...], str]],
+    falaise_tiles: Dict[str | None, Dict[Tuple[str, ...], str]],
+    width: int,
+    height: int,
+) -> List[tuple[str, tuple[int, int]]]:
+    """Calcule les tuiles de contour à superposer sur l'eau autour de l'île."""
+
+    water_adjacency: Dict[tuple[int, int], set[str]] = defaultdict(set)
+
+    for (x, y) in island:
+        cardinal_neighbors = {
+            "north": (x, y - 1),
+            "east": (x + 1, y),
+            "south": (x, y + 1),
+            "west": (x - 1, y),
+        }
+
+        for direction, (nx, ny) in cardinal_neighbors.items():
+            if not (0 <= nx < width and 0 <= ny < height):
+                continue
+            if (nx, ny) in island:
+                continue
+            water_adjacency[(nx, ny)].add(OPPOSITE[direction])
+
+        diagonal_specs = (
+            ("north", "east", (x + 1, y - 1), ("south", "west")),
+            ("north", "west", (x - 1, y - 1), ("south", "east")),
+            ("south", "east", (x + 1, y + 1), ("north", "west")),
+            ("south", "west", (x - 1, y + 1), ("north", "east")),
+        )
+
+        for dir_a, dir_b, (dx, dy), contributions in diagonal_specs:
+            if not (0 <= dx < width and 0 <= dy < height):
+                continue
+            if cardinal_neighbors[dir_a] in island or cardinal_neighbors[dir_b] in island:
+                continue
+            water_adjacency[(dx, dy)].update(contributions)
+
+    overlays: List[tuple[str, tuple[int, int]]] = []
+    for coord, touching in water_adjacency.items():
+        orientation = _orient_from_directions(touching)
+        if not orientation:
+            continue
+
+        tile = choose_edge_tile(
+            subtype,
+            orientation,
+            preferred_style,
+            bordure_tiles,
+            falaise_tiles,
+        )
+        if tile:
+            overlays.append((tile, coord))
+
+    return overlays
+
+
+def assemble_map(
+    width: int,
+    height: int,
+    textures: Dict[str, Texture],
+    path_style: str,
+    background_tile: str,
+    output_path: Path,
+    material_subtype: str | None,
+    edge_style: str,
+    numbers_requested: int | None,
+    object_count: int | None,
+    seed: int | None,
+) -> None:
+    """Compose une île respectant les étapes de construction demandées."""
+
+    if width <= 0 or height <= 0:
+        raise ValueError("La taille doit être strictement positive.")
+
+    if background_tile not in textures:
+        raise KeyError(f"Tuile d'arrière-plan inconnue : {background_tile}")
+
+    background = textures[background_tile]
+    if background.width <= 0 or background.height <= 0:
+        raise ValueError(
+            f"Dimensions invalides pour {background_tile} : {background.width}×{background.height}"
+        )
+
+    if background.width != background.height:
+        raise ValueError("Les tuiles doivent être carrées pour cet assembleur.")
+
+    rng = random.Random(seed)
+
+    materials = collect_material_tiles(textures)
+    chosen_material = pick_material_subtype(materials, material_subtype, rng)
+    material_tile = materials[chosen_material]
+
+    bordure_tiles = collect_edge_tiles(textures, include_bordure=True, include_falaise=False)
+    falaise_tiles = collect_edge_tiles(textures, include_bordure=False, include_falaise=True)
+
+    island_cells = generate_island(width, height, rng)
+
+    tile_size = background.width
+    path_index = build_path_index(textures, path_style)
+    library = TileLibrary(PNG_DIR)
+
+    canvas = Image.new("RGBA", (width * tile_size, height * tile_size))
+
+    background_image = library.get(background_tile)
+    for y in range(height):
+        for x in range(width):
+            canvas.paste(background_image, (x * tile_size, y * tile_size))
+
+    # Remplit l'île avec le matériau choisi.
+    material_image = library.get(material_tile.name)
+    for (x, y) in island_cells:
+        canvas.paste(material_image, (x * tile_size, y * tile_size))
+
+    # Ajoute le contour (falaise ou bordure).
+    edge_overlays = compute_island_edges(
+        island_cells,
+        chosen_material,
+        edge_style,
+        bordure_tiles,
+        falaise_tiles,
+        width,
+        height,
+    )
+    for tile_name, (x, y) in edge_overlays:
+        tile_image = library.get(tile_name)
+        canvas.paste(tile_image, (x * tile_size, y * tile_size), tile_image)
+
+    # Génère un trajet continu à l'intérieur de l'île.
+    if numbers_requested is None:
+        numbers_requested = max(4, (width + height) // 2)
+
+    numbers_available = collect_number_tiles(textures)
+    if not numbers_available:
+        raise SystemExit("Aucun chiffre marchable n'a été trouvé dans le XML.")
+
+    desired_length = min(len(island_cells), max(numbers_requested, (width + height) // 2))
+    path_cells_list = carve_path(island_cells, desired_length, rng)
+    path_cells = set(path_cells_list)
+
+    for (x, y) in path_cells_list:
+        neighbors = determine_neighbors(x, y, path_cells)
+        try:
+            tile_name = path_index[neighbors]
+        except KeyError as exc:  # pragma: no cover - dépend de la complétude du XML
+            raise SystemExit(
+                "Aucune tuile de chemin ne correspond aux connexions "
+                f"{neighbors}. Vérifiez le XML ou ajustez le style."
+            ) from exc
+
+        tile_image = library.get(tile_name)
+        canvas.paste(tile_image, (x * tile_size, y * tile_size), tile_image)
+
+    # Positionne les chiffres le long du trajet.
+    digit_positions: List[tuple[int, int]] = []
+    indices = distribute_indices(len(path_cells_list), min(numbers_requested, len(numbers_available)))
+    for index in indices:
+        if 0 <= index < len(path_cells_list):
+            digit_positions.append(path_cells_list[index])
+
+    for position, tile_name in zip(digit_positions, numbers_available):
+        x, y = position
+        tile_image = library.get(tile_name)
+        canvas.paste(tile_image, (x * tile_size, y * tile_size), tile_image)
+
+    # Ajoute des arbres ou objets décoratifs.
+    decorative_tiles = collect_object_tiles(textures)
+    if not decorative_tiles:
+        raise SystemExit("Aucun objet décoratif disponible pour agrémenter l'île.")
+
+    if object_count is None:
+        object_count = max(1, len(island_cells) // 12)
+
+    available_slots = [cell for cell in island_cells if cell not in path_cells]
+    rng.shuffle(available_slots)
+    placed = 0
+    for cell in available_slots:
+        if placed >= object_count:
+            break
+        tile_name = rng.choice(decorative_tiles)
+        tile_image = library.get(tile_name)
+        x, y = cell
+        canvas.paste(tile_image, (x * tile_size, y * tile_size), tile_image)
+        placed += 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    canvas.save(output_path)
+
+    print(
+        "Carte générée : "
+        f"{output_path} ({width}×{height} tuiles, taille finale {canvas.width}×{canvas.height}px)"
+    )
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Construit une carte PNG procédurale à partir du tileset enrichi."
+    )
+    parser.add_argument(
+        "size",
+        type=int,
+        help="Largeur de la carte en nombre de tuiles. Utilisée aussi comme hauteur si --height n'est pas défini.",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=None,
+        help="Hauteur de la carte en tuiles (défaut : identique à size).",
+    )
+    parser.add_argument(
+        "--path-style",
+        choices=("standard", "bulle_verte"),
+        default="standard",
+        help="Sélectionne l'ensemble de tuiles de chemin à utiliser.",
+    )
+    parser.add_argument(
+        "--background",
+        default=DEFAULT_BACKGROUND,
+        help="Tuile de fond (par défaut : eau profonde).",
+    )
+    parser.add_argument(
+        "--material",
+        default=None,
+        help="Sous-type de matériau pour l'île (ex. grass, sand). Choix aléatoire si absent.",
+    )
+    parser.add_argument(
+        "--edge-style",
+        choices=EDGE_STYLES,
+        default="auto",
+        help="Type de contour à appliquer (falaise, bordure ou auto).",
+    )
+    parser.add_argument(
+        "--numbers",
+        type=int,
+        default=None,
+        help="Nombre de chiffres à placer le long du trajet.",
+    )
+    parser.add_argument(
+        "--objects",
+        type=int,
+        default=None,
+        help="Nombre d'arbres/objets décoratifs à déposer sur l'île.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Graine aléatoire pour reproduire la génération.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Chemin du fichier PNG généré (défaut : {DEFAULT_OUTPUT}).",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    width = args.size
+    height = args.height if args.height is not None else args.size
+
+    textures = load_textures()
+    assemble_map(
+        width=width,
+        height=height,
+        textures=textures,
+        path_style=args.path_style,
+        background_tile=args.background,
+        output_path=args.output,
+        material_subtype=args.material,
+        edge_style=args.edge_style,
+        numbers_requested=args.numbers,
+        object_count=args.objects,
+        seed=args.seed,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- update the procedural map builder so border and cliff tiles are assembled on surrounding water cells with adjacency-aware orientation
- document the contour placement rules and adjacency expectations in the spritesheet construction guide

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68ce98f458ac832289c5fcd7a9153c2d