### PR TITLE
Refine Explorateur IA island smoothing

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -1375,12 +1375,14 @@ export function computeIslandEdgePlacements(
   return placements;
 }
 
-function smoothIslandShape(island: Set<CoordKey>, passes = 2) {
-  if (island.size === 0 || passes <= 0) {
+function smoothIslandShape(island: Set<CoordKey>) {
+  if (island.size === 0) {
     return;
   }
 
-  for (let pass = 0; pass < passes; pass++) {
+  const maxIterations = Math.max(1, island.size);
+
+  for (let iteration = 0; iteration < maxIterations; iteration++) {
     const toRemove: CoordKey[] = [];
     for (const key of island) {
       const [x, y] = coordFromKey(key);
@@ -1399,7 +1401,7 @@ function smoothIslandShape(island: Set<CoordKey>, passes = 2) {
         toRemove.push(key);
       }
     }
-    if (toRemove.length === 0 || toRemove.length === island.size) {
+    if (toRemove.length === 0 || toRemove.length >= island.size) {
       break;
     }
     for (const key of toRemove) {
@@ -1588,7 +1590,7 @@ function generateWorld(): GeneratedWorld {
 
   const island = generateIslandCells(WORLD_WIDTH, WORLD_HEIGHT, rng);
   fillSmallLakesInIsland(island, WORLD_WIDTH, WORLD_HEIGHT);
-  smoothIslandShape(island, 2);
+  smoothIslandShape(island);
 
   for (const key of island) {
     const [x, y] = coordFromKey(key as CoordKey);


### PR DESCRIPTION
## Summary
- adjust island smoothing to repeatedly trim single-neighbor cells without deleting the full island
- update world generation to rely on the new smoothing behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d072244f4c83228b822ef47171acf6