### PR TITLE
feat: add terrain objects catalog and placement

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -755,7 +755,11 @@ function recomputeWorldMetadata(worldTiles: TerrainTile[][]) {
       if (!tile) {
         continue;
       }
-      tile.cliffConnections = connections.length > 0 ? connections : undefined;
+      const hasConnections = connections.length > 0;
+      if (hasConnections && !tileHasLowerTerrain(tile) && tile.object) {
+        tile.object = undefined;
+      }
+      tile.cliffConnections = hasConnections ? connections : undefined;
     }
   }
 
@@ -2171,6 +2175,18 @@ function generateWorld(seed: number = WORLD_SEED): GeneratedWorld {
         continue;
       }
       if (tile.base === TILE_KIND.WATER || tile.overlay === TILE_KIND.PATH) {
+        tile.object = undefined;
+        continue;
+      }
+      const tileIsLower = tileHasLowerTerrain(tile);
+      const hasCliffNeighbor =
+        !tileIsLower &&
+        computeCliffConnections(
+          x,
+          y,
+          (tx, ty) => tileHasLowerTerrain(tiles[ty]?.[tx] ?? null)
+        ).size > 0;
+      if (hasCliffNeighbor) {
         tile.object = undefined;
         continue;
       }


### PR DESCRIPTION
## Summary
- define terrain object metadata types and catalog alongside object pools per terrain
- add deterministic terrain object placement during world generation
- render optional terrain objects when drawing tiles

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d17bfb94488322a31af05d2f78a0f7