### PR TITLE
Improve Explorateur IA modal behavior on mobile

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -3445,15 +3445,33 @@ function Modal({
   title: string;
   children: ReactNode;
 }) {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const node = scrollContainerRef.current;
+    if (node) {
+      node.scrollTop = 0;
+    }
+  }, [open]);
+
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative z-10 max-w-4xl w-full rounded-2xl bg-white shadow-xl border border-slate-200">
-        <div className="flex items-center justify-between px-5 py-3 border-b">
+    <div
+      ref={scrollContainerRef}
+      className="fixed inset-0 z-40 flex items-start justify-center overflow-y-auto bg-black/50 p-4 sm:p-6 md:items-center"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-4xl rounded-2xl border border-slate-200 bg-white shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b px-5 py-3">
           <h3 className="text-lg font-semibold">{title}</h3>
           <button
-            className="px-3 py-1 rounded-lg bg-slate-100 hover:bg-slate-200"
+            className="rounded-lg bg-slate-100 px-3 py-1 hover:bg-slate-200"
             onClick={onClose}
             aria-label="Fermer"
           >


### PR DESCRIPTION
## Summary
- make activity modals scrollable with a backdrop that works on narrow screens
- reset the modal scroll position when opening so the top of the challenge is visible

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1e8cedc848322a573c9556acd93fc