### PR TITLE
Add test environment configuration and documentation

### DIFF
--- a/AFENTS.md
+++ b/AFENTS.md
@@ -1,0 +1,25 @@
+# Tests frontend FormationIA
+
+Ce dépôt fournit un fichier d'environnement dédié aux tests Vite/Vitest pour le frontend.
+
+## Préparation
+
+1. Installez les dépendances JavaScript :
+   ```bash
+   cd frontend
+   npm install
+   ```
+2. Le fichier `frontend/.env.test` est chargé automatiquement par Vitest. Il configure l'URL du backend (`VITE_API_BASE_URL`),
+   une clé API factice (`VITE_API_AUTH_KEY`) et les identifiants de démonstration (`VITE_LOGIN_USERNAME` / `VITE_LOGIN_PASSWORD`).
+   Vous pouvez l'adapter si votre backend tourne sur une autre adresse.
+
+## Lancer la suite de tests
+
+Depuis le dossier `frontend`, exécutez l'une des commandes suivantes :
+
+```bash
+npm test          # exécute Vitest en mode run via le script package.json
+npx vitest run    # lance directement Vitest avec les mêmes variables d'environnement
+```
+
+Les deux commandes consomment automatiquement les variables définies dans `.env.test`, ce qui évite d'exposer des secrets dans le dépôt tout en offrant un comportement reproductible.

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,0 +1,8 @@
+# Variables d'environnement utilisées par Vitest lorsque vous lancez `npm test`
+# Ces valeurs pointent vers l'API locale exposée par le backend FastAPI.
+VITE_API_BASE_URL=http://localhost:8001
+# Clé simulée : gardez les véritables secrets hors du dépôt.
+VITE_API_AUTH_KEY=test-token
+# Identifiants démo alignés sur ceux documentés dans README.md
+VITE_LOGIN_USERNAME=test
+VITE_LOGIN_PASSWORD=Telecom2025$


### PR DESCRIPTION
## Summary
- add a Vitest-specific `.env.test` file for the frontend with safe defaults
- document how to run the test suite using this environment in `AFENTS.md`

## Testing
- `npm test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68d1ee2b3a248322877d931d61870b1a