### PR TITLE
Add StepSequence activity wrapper and tests

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -16,6 +16,7 @@ import ClarityPath from "../pages/ClarityPath";
 import ClarteDabord from "../pages/ClarteDabord";
 import PromptDojo from "../pages/PromptDojo";
 import WorkshopExperience from "../pages/WorkshopExperience";
+import { StepSequenceActivity } from "../modules/step-sequence";
 const LazyExplorateurIA = lazy(() => import("../pages/ExplorateurIA"));
 
 const ExplorateurIALoader: ComponentType<ActivityProps> = (props) => (
@@ -89,6 +90,7 @@ export const COMPONENT_REGISTRY = {
   "clarity-path": ClarityPath,
   "clarte-dabord": ClarteDabord,
   "explorateur-ia": ExplorateurIALoader,
+  "step-sequence": StepSequenceActivity,
 } as const satisfies Record<string, ComponentType<ActivityProps>>;
 
 export type ActivityComponentKey = keyof typeof COMPONENT_REGISTRY;

--- a/frontend/src/modules/step-sequence/README.md
+++ b/frontend/src/modules/step-sequence/README.md
@@ -54,3 +54,15 @@ function ConfirmationStep() {
   );
 }
 ```
+
+## Activité clé en main
+
+Le module expose également un composant `StepSequenceActivity` utilisable via le registre global des activités. Il attend une configuration de métadonnées respectant la forme suivante :
+
+```ts
+type StepSequenceActivityConfig = {
+  steps: StepDefinition[];
+};
+```
+
+Les étapes peuvent provenir directement des props ou de la clé `steps` de ces métadonnées. Lorsque la dernière étape appelle `onAdvance`, le callback `onComplete` fourni à l’activité est déclenché avec les `payloads` agrégés par identifiant d’étape.

--- a/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from "react";
+
+import type { ActivityProps } from "../../config/activities";
+import { StepSequenceRenderer } from "./StepSequenceRenderer";
+import type { StepDefinition } from "./types";
+
+export type StepSequenceActivityConfig = {
+  steps: StepDefinition[];
+};
+
+export type StepSequenceActivityProps = ActivityProps & {
+  steps?: StepDefinition[];
+  metadata?: StepSequenceActivityConfig | null;
+  onComplete?: (payloads: Record<string, unknown>) => void;
+};
+
+const isStepDefinitionArray = (
+  value: StepDefinition[] | undefined
+): value is StepDefinition[] =>
+  Array.isArray(value) &&
+  value.every(
+    (step) =>
+      step !== null &&
+      typeof step === "object" &&
+      typeof step.id === "string" &&
+      typeof step.component === "string"
+  );
+
+export function StepSequenceActivity({
+  steps,
+  metadata,
+  isEditMode = false,
+  onComplete,
+}: StepSequenceActivityProps): JSX.Element {
+  const metadataSteps = metadata?.steps;
+  const resolvedSteps = useMemo(() => {
+    if (isStepDefinitionArray(steps)) {
+      return steps;
+    }
+    if (isStepDefinitionArray(metadataSteps)) {
+      return metadataSteps;
+    }
+    return [] as StepDefinition[];
+  }, [metadataSteps, steps]);
+
+  const handleComplete = useCallback(
+    (payloads: Record<string, unknown>) => {
+      onComplete?.(payloads);
+    },
+    [onComplete]
+  );
+
+  return (
+    <StepSequenceRenderer
+      steps={resolvedSteps}
+      isEditMode={isEditMode}
+      onComplete={handleComplete}
+    />
+  );
+}

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -3,6 +3,11 @@ import { useContext } from "react";
 import { getStepComponent, registerStepComponent, STEP_COMPONENT_REGISTRY } from "./registry";
 import { StepSequenceRenderer } from "./StepSequenceRenderer";
 import type { StepSequenceRendererProps } from "./StepSequenceRenderer";
+import { StepSequenceActivity } from "./StepSequenceActivity";
+import type {
+  StepSequenceActivityConfig,
+  StepSequenceActivityProps,
+} from "./StepSequenceActivity";
 import {
   StepSequenceContext,
   type StepComponentProps,
@@ -30,6 +35,7 @@ export function useStepSequence(): StepSequenceContextValue {
 }
 
 export {
+  StepSequenceActivity,
   StepSequenceRenderer,
   StepSequenceContext,
   STEP_COMPONENT_REGISTRY,
@@ -38,6 +44,8 @@ export {
 };
 
 export type {
+  StepSequenceActivityConfig,
+  StepSequenceActivityProps,
   StepDefinition,
   StepComponentProps,
   StepRegistry,

--- a/frontend/tests/step-sequence/StepSequenceActivity.test.tsx
+++ b/frontend/tests/step-sequence/StepSequenceActivity.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { StepSequenceRendererProps } from "../../src/modules/step-sequence/StepSequenceRenderer";
+import type { StepDefinition } from "../../src/modules/step-sequence";
+
+const renderSpy = vi.fn();
+
+vi.mock("../../src/modules/step-sequence/StepSequenceRenderer", () => ({
+  StepSequenceRenderer: (props: StepSequenceRendererProps) => {
+    renderSpy(props);
+    return (
+      <div
+        data-testid="step-sequence-renderer"
+        data-edit-mode={props.isEditMode ? "true" : "false"}
+        onClick={() => props.onComplete?.({ status: "done" })}
+      />
+    );
+  },
+}));
+
+// The mock must be declared before importing the component under test.
+import { StepSequenceActivity } from "../../src/modules/step-sequence/StepSequenceActivity";
+
+const createBaseProps = () => ({
+  activityId: "activity-1",
+  completionId: "activity-1",
+  header: { eyebrow: "", title: "" },
+  card: { title: "", description: "", highlights: [], cta: { label: "", to: "#" } },
+  layout: { eyebrow: "", title: "" },
+  layoutOverrides: {},
+  setLayoutOverrides: vi.fn(),
+  resetLayoutOverrides: vi.fn(),
+  navigateToActivities: vi.fn(),
+});
+
+const defaultSteps: StepDefinition[] = [
+  { id: "first-step", component: "first" },
+];
+
+describe("StepSequenceActivity", () => {
+  beforeEach(() => {
+    renderSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("propagates isEditMode to the renderer", () => {
+    const props = createBaseProps();
+
+    render(
+      <StepSequenceActivity
+        {...props}
+        isEditMode
+        steps={defaultSteps}
+      />
+    );
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    const [{ isEditMode: receivedEditMode }] = renderSpy.mock.calls[0];
+    expect(receivedEditMode).toBe(true);
+    expect(
+      screen.getByTestId("step-sequence-renderer").getAttribute("data-edit-mode")
+    ).toBe("true");
+  });
+
+  it("relays onComplete when the renderer signals completion", () => {
+    const props = createBaseProps();
+    const onComplete = vi.fn();
+
+    render(
+      <StepSequenceActivity
+        {...props}
+        steps={defaultSteps}
+        onComplete={onComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("step-sequence-renderer"));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({ status: "done" });
+  });
+
+  it("falls back to metadata steps when none are provided in props", () => {
+    const props = createBaseProps();
+    const metadataSteps: StepDefinition[] = [
+      { id: "meta", component: "meta-step" },
+    ];
+
+    render(
+      <StepSequenceActivity
+        {...props}
+        metadata={{ steps: metadataSteps }}
+      />
+    );
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    const [{ steps }] = renderSpy.mock.calls[0];
+    expect(steps).toBe(metadataSteps);
+  });
+});


### PR DESCRIPTION
## Summary
- add a StepSequenceActivity wrapper that resolves steps from props or metadata and relays completion events
- export the activity, register it in the global component registry, and document the expected metadata config
- add a rendering test covering edit mode propagation and completion callback forwarding

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d26fa4fa24832298f1f833c625e983