### PR TITLE
Support step sequence configuration overrides

### DIFF
--- a/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
@@ -10,6 +10,7 @@ export type StepSequenceActivityConfig = {
 
 export type StepSequenceActivityProps = ActivityProps & {
   steps?: StepDefinition[];
+  stepSequence?: StepDefinition[];
   metadata?: StepSequenceActivityConfig | null;
   onComplete?: (payloads: Record<string, unknown>) => void;
 };
@@ -28,6 +29,7 @@ const isStepDefinitionArray = (
 
 export function StepSequenceActivity({
   steps,
+  stepSequence,
   metadata,
   isEditMode = false,
   onComplete,
@@ -37,11 +39,14 @@ export function StepSequenceActivity({
     if (isStepDefinitionArray(steps)) {
       return steps;
     }
+    if (isStepDefinitionArray(stepSequence)) {
+      return stepSequence;
+    }
     if (isStepDefinitionArray(metadataSteps)) {
       return metadataSteps;
     }
     return [] as StepDefinition[];
-  }, [metadataSteps, steps]);
+  }, [metadataSteps, stepSequence, steps]);
 
   const handleComplete = useCallback(
     (payloads: Record<string, unknown>) => {

--- a/frontend/tests/config/stepSequence.activities.test.ts
+++ b/frontend/tests/config/stepSequence.activities.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ACTIVITY_CATALOG,
+  resolveActivityDefinition,
+  serializeActivityDefinition,
+  type ActivityConfigEntry,
+  type ActivityDefinition,
+} from "../../src/config/activities";
+import type { StepDefinition } from "../../src/modules/step-sequence";
+
+const TEST_ACTIVITY_ID = "step-sequence-spec";
+
+const defaultSteps: StepDefinition[] = [
+  { id: "intro", component: "introduction", config: { order: 0 } },
+  { id: "practice", component: "practice", config: { order: 1 } },
+];
+
+beforeEach(() => {
+  ACTIVITY_CATALOG[TEST_ACTIVITY_ID] = {
+    componentKey: "step-sequence",
+    path: "/activities/spec",
+    defaults: {
+      enabled: true,
+      header: { eyebrow: "", title: "Spec" },
+      layout: { contentClassName: "" },
+      card: {
+        title: "Spec",
+        description: "",
+        highlights: [],
+        cta: { label: "", to: "#" },
+      },
+      stepSequence: defaultSteps,
+    },
+  };
+});
+
+afterEach(() => {
+  delete ACTIVITY_CATALOG[TEST_ACTIVITY_ID];
+});
+
+describe("Step sequence activities", () => {
+  it("merges saved steps with catalog defaults", () => {
+    const entry: ActivityConfigEntry = {
+      id: TEST_ACTIVITY_ID,
+      overrides: {
+        stepSequence: [
+          { id: "practice", component: "practice", config: { order: 1, score: 5 } },
+          { id: "bonus", component: "bonus" },
+        ],
+      },
+    };
+
+    const definition = resolveActivityDefinition(entry);
+
+    expect(definition.stepSequence).toEqual([
+      { id: "intro", component: "introduction", config: { order: 0 } },
+      { id: "practice", component: "practice", config: { order: 1, score: 5 } },
+      { id: "bonus", component: "bonus" },
+    ]);
+  });
+
+  it("serializes changes to the step sequence", () => {
+    const baseDefinition = resolveActivityDefinition({ id: TEST_ACTIVITY_ID });
+    const updatedSteps: StepDefinition[] = [
+      { ...baseDefinition.stepSequence![0] },
+      { id: "practice", component: "practice", config: { order: 1, mode: "advanced" } },
+      { id: "summary", component: "summary" },
+    ];
+
+    const updatedDefinition: ActivityDefinition = {
+      ...baseDefinition,
+      stepSequence: updatedSteps,
+    };
+
+    const serialized = serializeActivityDefinition(updatedDefinition);
+
+    expect(serialized.overrides?.stepSequence).toEqual(updatedSteps);
+  });
+});

--- a/frontend/tests/step-sequence/StepSequenceActivity.test.tsx
+++ b/frontend/tests/step-sequence/StepSequenceActivity.test.tsx
@@ -84,6 +84,28 @@ describe("StepSequenceActivity", () => {
     expect(onComplete).toHaveBeenCalledWith({ status: "done" });
   });
 
+  it("prefers the stepSequence prop when provided", () => {
+    const props = createBaseProps();
+    const fallbackSteps: StepDefinition[] = [
+      { id: "metadata", component: "metadata" },
+    ];
+    const sequenceSteps: StepDefinition[] = [
+      { id: "sequence", component: "sequence" },
+    ];
+
+    render(
+      <StepSequenceActivity
+        {...props}
+        stepSequence={sequenceSteps}
+        metadata={{ steps: fallbackSteps }}
+      />
+    );
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+    const [{ steps: receivedSteps }] = renderSpy.mock.calls[0];
+    expect(receivedSteps).toBe(sequenceSteps);
+  });
+
   it("falls back to metadata steps when none are provided in props", () => {
     const props = createBaseProps();
     const metadataSteps: StepDefinition[] = [


### PR DESCRIPTION
## Summary
- extend activity configuration and serialization to handle optional step sequences
- deliver the resolved step sequences to step-sequence activities and favor them in the renderer
- add unit tests covering step sequence resolution, serialization, and prop precedence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d27da614888322a57abb4e7cd27dbc