### PR TITLE
feat: support StepSequence editing in activity selector

### DIFF
--- a/frontend/tests/pages/ActivitySelector.spec.tsx
+++ b/frontend/tests/pages/ActivitySelector.spec.tsx
@@ -1,0 +1,94 @@
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getProgressMock = vi.fn();
+const getConfigMock = vi.fn();
+const saveMock = vi.fn();
+const setEditModeMock = vi.fn();
+
+vi.mock("../../src/api", () => ({
+  getProgress: getProgressMock,
+  activities: {
+    getConfig: getConfigMock,
+  },
+  admin: {
+    activities: {
+      save: saveMock,
+    },
+  },
+}));
+
+vi.mock("../../src/providers/AdminAuthProvider", () => ({
+  useAdminAuth: () => ({
+    status: "authenticated",
+    user: { roles: ["admin"] },
+    isEditMode: true,
+    setEditMode: setEditModeMock,
+    token: "test-token",
+  }),
+}));
+
+vi.mock("../../src/hooks/useLTI", () => ({
+  useLTI: () => ({ context: null, isLTISession: false, loading: false }),
+}));
+
+import ActivitySelector from "../../src/pages/ActivitySelector";
+import "../../src/modules/step-sequence/modules";
+
+describe("ActivitySelector StepSequence designer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProgressMock.mockResolvedValue({ activities: {} });
+    getConfigMock.mockResolvedValue({ activities: [], activitySelectorHeader: null });
+    saveMock.mockResolvedValue(undefined);
+  });
+
+  it("allows creating a StepSequence activity and editing its steps", async () => {
+    render(
+      <MemoryRouter>
+        <ActivitySelector />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(getConfigMock).toHaveBeenCalled());
+
+    const addButton = await screen.findByRole("button", { name: /Ajouter une activité/i });
+    fireEvent.click(addButton);
+
+    const shortcutButton = await screen.findByRole("button", {
+      name: /Nouvelle activité StepSequence/i,
+    });
+    fireEvent.click(shortcutButton);
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    const sequenceRegion = await screen.findByRole("region", {
+      name: /Séquence d'étapes pour Nouvelle séquence StepSequence/i,
+    });
+
+    const initialHeadings = within(sequenceRegion).getAllByRole("heading", { name: /Étape/ });
+    expect(initialHeadings).toHaveLength(2);
+
+    const introTitleInput = within(sequenceRegion).getByPlaceholderText("Titre de l'étape");
+    fireEvent.change(introTitleInput, {
+      target: { value: "Bienvenue dans la séquence" },
+    });
+
+    await waitFor(() =>
+      expect(
+        within(sequenceRegion).getByDisplayValue("Bienvenue dans la séquence")
+      ).toBeInTheDocument()
+    );
+
+    const addStepButton = within(sequenceRegion).getByRole("button", {
+      name: /Ajouter une étape/i,
+    });
+    fireEvent.click(addStepButton);
+
+    await waitFor(() => {
+      const headings = within(sequenceRegion).getAllByRole("heading", { name: /Étape/ });
+      expect(headings).toHaveLength(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a StepSequence editor to the activity selector so admins can manage steps, types, and configs inline
- provide a StepSequence shortcut in the add-activity modal that seeds a default intro and form sequence
- cover the new workflow with a UI-focused ActivitySelector spec exercising creation and step updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d27f5139ec8322b1af58bd430ad5b9