### PR TITLE
Refactor Explorateur IA progression to step sequences

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -97,6 +97,7 @@ export interface ActivityProps {
   isEditMode?: boolean;
   enabled?: boolean;
   stepSequence?: StepDefinition[];
+  setStepSequence?: (steps: StepDefinition[] | undefined) => void;
 }
 
 export const COMPONENT_REGISTRY = {
@@ -983,6 +984,16 @@ export function buildActivityElement(
       []
     );
 
+    const handleUpdateStepSequence = useCallback(
+      (steps: StepDefinition[] | undefined) => {
+        setCurrentDefinition((prev) => ({
+          ...prev,
+          stepSequence: steps ? cloneStepSequence(steps) : undefined,
+        }));
+      },
+      []
+    );
+
     const handleSaveActivity = useCallback(async () => {
       const headerOverrides = extractHeaderOverrides(overrides);
       const layoutOverrides = extractLayoutOverrides(overrides);
@@ -1086,6 +1097,7 @@ export function buildActivityElement(
             isEditMode={isEditMode}
             enabled={currentDefinition.enabled !== false}
             stepSequence={currentDefinition.stepSequence}
+            setStepSequence={handleUpdateStepSequence}
           />
         ) : (
           <div className="space-y-4 rounded-3xl border border-red-200 bg-red-50 p-6 text-red-800">

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -2,7 +2,10 @@ import { useContext } from "react";
 
 import { getStepComponent, registerStepComponent, STEP_COMPONENT_REGISTRY } from "./registry";
 import { StepSequenceRenderer } from "./StepSequenceRenderer";
-import type { StepSequenceRendererProps } from "./StepSequenceRenderer";
+import type {
+  StepSequenceRenderWrapperProps,
+  StepSequenceRendererProps,
+} from "./StepSequenceRenderer";
 import { StepSequenceActivity } from "./StepSequenceActivity";
 import type {
   StepSequenceActivityConfig,
@@ -53,4 +56,5 @@ export type {
   StepRegistry,
   StepSequenceContextValue,
   StepSequenceRendererProps,
+  StepSequenceRenderWrapperProps,
 };

--- a/frontend/src/pages/explorateurIA/export.ts
+++ b/frontend/src/pages/explorateurIA/export.ts
@@ -1,0 +1,99 @@
+import { cloneProgress, type ExplorateurProgress } from "./progress";
+import { QUARTER_ORDER, type QuarterId } from "./types";
+
+export interface QuarterExportEntry {
+  id: QuarterId;
+  done: boolean;
+  payloads: Record<string, unknown>;
+  details: Record<string, unknown>;
+}
+
+export interface ExplorateurExportData {
+  activity: string;
+  generatedAt: string;
+  completionRate: number;
+  visited: QuarterId[];
+  quarters: Record<QuarterId, QuarterExportEntry>;
+}
+
+function toNullable<T>(value: T | undefined): T | null {
+  return value === undefined ? null : value;
+}
+
+function sanitizePayloads(value: Record<string, unknown>): Record<string, unknown> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  return { ...value };
+}
+
+function computeCompletionRate(progress: ExplorateurProgress): number {
+  const completedCount = QUARTER_ORDER.reduce((total, quarter) => {
+    const isDone = progress[quarter]?.done ?? false;
+    return total + (isDone ? 1 : 0);
+  }, 0);
+  return Math.round((completedCount / QUARTER_ORDER.length) * 100);
+}
+
+export function createExplorateurExport(
+  progress: ExplorateurProgress
+): ExplorateurExportData {
+  const cloned = cloneProgress(progress);
+
+  const quarters: Record<QuarterId, QuarterExportEntry> = {
+    clarte: {
+      id: "clarte",
+      done: cloned.clarte.done,
+      payloads: sanitizePayloads(cloned.clarte.payloads),
+      details: {
+        score: cloned.clarte.score,
+        selectedOptionId: toNullable(cloned.clarte.selectedOptionId),
+        explanation: toNullable(cloned.clarte.explanation),
+      },
+    },
+    creation: {
+      id: "creation",
+      done: cloned.creation.done,
+      payloads: sanitizePayloads(cloned.creation.payloads),
+      details: {
+        spec: cloned.creation.spec ?? null,
+        reflection: cloned.creation.reflection ?? null,
+      },
+    },
+    decision: {
+      id: "decision",
+      done: cloned.decision.done,
+      payloads: sanitizePayloads(cloned.decision.payloads),
+      details: {
+        path: cloned.decision.path ?? null,
+        visitedSteps: cloned.decision.visitedSteps ?? null,
+      },
+    },
+    ethique: {
+      id: "ethique",
+      done: cloned.ethique.done,
+      payloads: sanitizePayloads(cloned.ethique.payloads),
+      details: {
+        averageScore: cloned.ethique.averageScore,
+        answers: cloned.ethique.answers,
+        commitment: cloned.ethique.commitment ?? null,
+      },
+    },
+    mairie: {
+      id: "mairie",
+      done: cloned.mairie.done,
+      payloads: sanitizePayloads(cloned.mairie.payloads),
+      details: {
+        reflection: cloned.mairie.reflection ?? null,
+      },
+    },
+  };
+
+  return {
+    activity: "Explorateur IA",
+    generatedAt: new Date().toISOString(),
+    completionRate: computeCompletionRate(cloned),
+    visited: [...cloned.visited],
+    quarters,
+  };
+}

--- a/frontend/src/pages/explorateurIA/modules/ClarteQuizModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/ClarteQuizModule.tsx
@@ -1,0 +1,402 @@
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
+
+import type { ExplorateurIAModuleConfig, ExplorateurIAModuleProps } from "./registry";
+import { registerExplorateurIAModule } from "./registry";
+
+const combineClasses = (
+  ...values: Array<string | false | null | undefined>
+): string => values.filter(Boolean).join(" ");
+
+export interface ClarteQuizOptionConfig {
+  id: string;
+  label: string;
+  explanation: string;
+  score: number;
+}
+
+export interface ClarteQuizModuleConfig extends ExplorateurIAModuleConfig {
+  type: "clarte-quiz";
+  title?: string;
+  question: string;
+  options: ClarteQuizOptionConfig[];
+  validateLabel?: string;
+}
+
+export interface ClarteQuizResult {
+  selectedOptionId: string;
+  score: number;
+  explanation: string;
+}
+
+const DEFAULT_OPTIONS: ClarteQuizOptionConfig[] = [
+  {
+    id: "A",
+    label: "Écris un plan.",
+    explanation: "Trop vague : objectifs, sections, longueur… manquent.",
+    score: 0,
+  },
+  {
+    id: "B",
+    label:
+      "Donne un plan en 5 sections sur l'énergie solaire pour débutants, avec titres et 2 sous-points chacun.",
+    explanation: "Précis, contraint et adapté au public cible.",
+    score: 100,
+  },
+  {
+    id: "C",
+    label: "Plan énergie solaire?",
+    explanation: "Formulation télégraphique, ambiguë.",
+    score: 10,
+  },
+];
+
+export const DEFAULT_CLARTE_QUIZ_CONFIG: ClarteQuizModuleConfig = {
+  type: "clarte-quiz",
+  title: "Choisissez la consigne la plus claire",
+  question: "Quel est le meilleur énoncé pour obtenir un plan clair?",
+  options: DEFAULT_OPTIONS,
+  validateLabel: "Valider",
+};
+
+function sanitizeQuizConfig(
+  config: unknown
+): ClarteQuizModuleConfig {
+  if (!config || typeof config !== "object") {
+    return { ...DEFAULT_CLARTE_QUIZ_CONFIG };
+  }
+  const base = config as Partial<ClarteQuizModuleConfig>;
+  const rawOptions = Array.isArray(base.options) ? base.options : [];
+  const options: ClarteQuizOptionConfig[] = rawOptions.length
+    ? rawOptions.map((option, index) => ({
+        id:
+          typeof option?.id === "string" && option.id.trim()
+            ? option.id.trim()
+            : String.fromCharCode(65 + index),
+        label:
+          typeof option?.label === "string"
+            ? option.label
+            : DEFAULT_OPTIONS[index % DEFAULT_OPTIONS.length].label,
+        explanation:
+          typeof option?.explanation === "string"
+            ? option.explanation
+            : DEFAULT_OPTIONS[index % DEFAULT_OPTIONS.length].explanation,
+        score:
+          typeof option?.score === "number"
+            ? option.score
+            : DEFAULT_OPTIONS[index % DEFAULT_OPTIONS.length].score,
+      }))
+    : DEFAULT_OPTIONS;
+
+  return {
+    type: "clarte-quiz",
+    title:
+      typeof base.title === "string"
+        ? base.title
+        : DEFAULT_CLARTE_QUIZ_CONFIG.title,
+    question:
+      typeof base.question === "string"
+        ? base.question
+        : DEFAULT_CLARTE_QUIZ_CONFIG.question,
+    validateLabel:
+      typeof base.validateLabel === "string"
+        ? base.validateLabel
+        : DEFAULT_CLARTE_QUIZ_CONFIG.validateLabel,
+    options,
+  };
+}
+
+function updateOption(
+  options: ClarteQuizOptionConfig[],
+  index: number,
+  patch: Partial<ClarteQuizOptionConfig>
+): ClarteQuizOptionConfig[] {
+  return options.map((option, optionIndex) =>
+    optionIndex === index ? { ...option, ...patch } : option
+  );
+}
+
+function ClarteQuizModule({
+  config,
+  onUpdateConfig,
+  onAdvance,
+  payload,
+  isEditMode,
+}: ExplorateurIAModuleProps) {
+  const typedConfig = useMemo(() => sanitizeQuizConfig(config), [config]);
+  const [selectedId, setSelectedId] = useState<string | null>(() => {
+    const previous = payload as ClarteQuizResult | undefined;
+    return previous?.selectedOptionId ?? null;
+  });
+
+  const selectedOption = useMemo(
+    () => typedConfig.options.find((option) => option.id === selectedId) ?? null,
+    [typedConfig.options, selectedId]
+  );
+
+  const handleSelect = useCallback((id: string) => {
+    setSelectedId(id);
+  }, []);
+
+  const handleValidate = useCallback(() => {
+    if (!selectedOption) {
+      return;
+    }
+    const result: ClarteQuizResult = {
+      selectedOptionId: selectedOption.id,
+      score: selectedOption.score,
+      explanation: selectedOption.explanation,
+    };
+    onAdvance(result);
+  }, [onAdvance, selectedOption]);
+
+  const handleConfigChange = useCallback(
+    (patch: Partial<ClarteQuizModuleConfig>) => {
+      const nextConfig = sanitizeQuizConfig({ ...typedConfig, ...patch });
+      onUpdateConfig(nextConfig);
+    },
+    [onUpdateConfig, typedConfig]
+  );
+
+  const handleOptionChange = useCallback(
+    (index: number, field: keyof ClarteQuizOptionConfig, value: string | number) => {
+      if (field === "score" && typeof value === "string") {
+        const numeric = Number.parseInt(value, 10);
+        handleConfigChange({
+          options: updateOption(typedConfig.options, index, {
+            score: Number.isNaN(numeric) ? 0 : Math.max(0, Math.min(100, numeric)),
+          }),
+        });
+        return;
+      }
+      handleConfigChange({
+        options: updateOption(typedConfig.options, index, {
+          [field]: value,
+        } as Partial<ClarteQuizOptionConfig>),
+      });
+    },
+    [handleConfigChange, typedConfig.options]
+  );
+
+  const handleAddOption = useCallback(() => {
+    const index = typedConfig.options.length;
+    handleConfigChange({
+      options: [
+        ...typedConfig.options,
+        {
+          id: String.fromCharCode(65 + index),
+          label: "Nouvelle option",
+          explanation: "Décrivez l'impact pédagogique de cette option.",
+          score: 50,
+        },
+      ],
+    });
+  }, [handleConfigChange, typedConfig.options]);
+
+  const handleRemoveOption = useCallback(
+    (index: number) => {
+      if (typedConfig.options.length <= 1) {
+        return;
+      }
+      const next = typedConfig.options.filter((_, optionIndex) => optionIndex !== index);
+      handleConfigChange({ options: next });
+    },
+    [handleConfigChange, typedConfig.options]
+  );
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Titre</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.title ?? ""}
+              onChange={(event) =>
+                handleConfigChange({ title: event.target.value })
+              }
+              placeholder="Titre pédagogique"
+            />
+          </label>
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Question</span>
+            <textarea
+              className="h-24 w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.question}
+              onChange={(event) =>
+                handleConfigChange({ question: event.target.value })
+              }
+            />
+          </label>
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Texte du bouton</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.validateLabel ?? ""}
+              onChange={(event) =>
+                handleConfigChange({ validateLabel: event.target.value })
+              }
+              placeholder="Valider"
+            />
+          </label>
+        </div>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-slate-700">Options</h3>
+            <button
+              type="button"
+              onClick={handleAddOption}
+              className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100"
+            >
+              Ajouter une option
+            </button>
+          </div>
+          <div className="space-y-3">
+            {typedConfig.options.map((option, index) => (
+              <div
+                key={option.id || index}
+                className="rounded-2xl border border-slate-200 p-4 shadow-sm"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <label className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                      <span>ID</span>
+                      <input
+                        className="w-16 rounded-md border border-slate-300 p-1 text-center"
+                        value={option.id}
+                        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                          handleOptionChange(index, "id", event.target.value)
+                        }
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                      <span>Score</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        className="w-20 rounded-md border border-slate-300 p-1 text-center"
+                        value={option.score}
+                        onChange={(event) =>
+                          handleOptionChange(index, "score", event.target.value)
+                        }
+                      />
+                    </label>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveOption(index)}
+                    className="text-xs font-semibold text-red-600 hover:text-red-700"
+                    aria-label={`Supprimer l'option ${option.id}`}
+                  >
+                    Supprimer
+                  </button>
+                </div>
+                <label className="mt-3 block space-y-1 text-sm">
+                  <span className="font-medium text-slate-700">Intitulé</span>
+                  <input
+                    className="w-full rounded-md border border-slate-300 p-2"
+                    value={option.label}
+                    onChange={(event) =>
+                      handleOptionChange(index, "label", event.target.value)
+                    }
+                  />
+                </label>
+                <label className="mt-3 block space-y-1 text-sm">
+                  <span className="font-medium text-slate-700">Feedback</span>
+                  <textarea
+                    className="h-20 w-full rounded-md border border-slate-300 p-2"
+                    value={option.explanation}
+                    onChange={(event) =>
+                      handleOptionChange(
+                        index,
+                        "explanation",
+                        event.target.value
+                      )
+                    }
+                  />
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-4">
+        <header className="space-y-1">
+          {typedConfig.title ? (
+            <h2 className="text-lg font-semibold text-slate-900">
+              {typedConfig.title}
+            </h2>
+          ) : null}
+          <p className="text-sm text-slate-600">{typedConfig.question}</p>
+        </header>
+        <div className="space-y-2">
+          {typedConfig.options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => handleSelect(option.id)}
+              className={combineClasses(
+                "w-full rounded-xl border p-3 text-left text-sm shadow-sm transition",
+                selectedId === option.id
+                  ? "border-emerald-300 bg-emerald-50"
+                  : "border-slate-200 bg-white hover:bg-slate-50"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {option.id}
+                </span>
+                <span className="text-slate-700">{option.label}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+      <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="text-sm font-semibold text-slate-700">Impact pédagogique</h3>
+        {selectedOption ? (
+          <>
+            <p className="text-sm text-slate-600">{selectedOption.explanation}</p>
+            <div className="flex items-center gap-3">
+              <span className="text-sm font-medium text-slate-700">Score</span>
+              <div className="flex-1 rounded-full bg-slate-200">
+                <div
+                  className="h-2 rounded-full bg-emerald-500 transition-all"
+                  style={{ width: `${selectedOption.score}%` }}
+                />
+              </div>
+              <span className="w-12 text-right text-sm font-semibold tabular-nums text-emerald-600">
+                {selectedOption.score}
+              </span>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-slate-500">
+            Sélectionnez une option pour afficher le retour.
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={!selectedOption}
+          className={combineClasses(
+            "rounded-xl px-4 py-2 text-sm font-semibold text-white transition",
+            selectedOption
+              ? "bg-emerald-600 hover:bg-emerald-700"
+              : "bg-emerald-400/60 cursor-not-allowed"
+          )}
+        >
+          {typedConfig.validateLabel ?? "Valider"}
+        </button>
+      </section>
+    </div>
+  );
+}
+
+registerExplorateurIAModule("clarte-quiz", ClarteQuizModule);

--- a/frontend/src/pages/explorateurIA/modules/CreationBuilderModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/CreationBuilderModule.tsx
@@ -1,0 +1,458 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+} from "react";
+
+import type { ExplorateurIAModuleConfig, ExplorateurIAModuleProps } from "./registry";
+import { registerExplorateurIAModule } from "./registry";
+
+const combineClasses = (
+  ...values: Array<string | false | null | undefined>
+): string => values.filter(Boolean).join(" ");
+
+export interface CreationSpec {
+  action: string | null;
+  media: string | null;
+  style: string | null;
+  theme: string | null;
+}
+
+export interface CreationPoolConfig {
+  action: string[];
+  media: string[];
+  style: string[];
+  theme: string[];
+}
+
+export interface CreationBuilderModuleConfig extends ExplorateurIAModuleConfig {
+  type: "creation-builder";
+  title?: string;
+  instructions?: string;
+  pools: CreationPoolConfig;
+  submitLabel?: string;
+}
+
+const DEFAULT_POOL: CreationPoolConfig = {
+  action: ["créer", "rédiger", "composer"],
+  media: ["affiche", "article", "capsule audio"],
+  style: ["cartoon", "académique", "minimaliste"],
+  theme: ["énergie", "ville intelligente", "biodiversité"],
+};
+
+export const DEFAULT_CREATION_BUILDER_CONFIG: CreationBuilderModuleConfig = {
+  type: "creation-builder",
+  title: "Assemblez votre défi de création",
+  instructions:
+    "Choisissez un verbe d'action, un média, un style et un thème pour générer une consigne personnalisée.",
+  pools: DEFAULT_POOL,
+  submitLabel: "Valider ma consigne",
+};
+
+function sanitizePool(pool: Partial<CreationPoolConfig> | undefined): CreationPoolConfig {
+  return {
+    action: Array.isArray(pool?.action) && pool?.action.length
+      ? pool.action.map((entry) => String(entry))
+      : [...DEFAULT_POOL.action],
+    media: Array.isArray(pool?.media) && pool?.media.length
+      ? pool.media.map((entry) => String(entry))
+      : [...DEFAULT_POOL.media],
+    style: Array.isArray(pool?.style) && pool?.style.length
+      ? pool.style.map((entry) => String(entry))
+      : [...DEFAULT_POOL.style],
+    theme: Array.isArray(pool?.theme) && pool?.theme.length
+      ? pool.theme.map((entry) => String(entry))
+      : [...DEFAULT_POOL.theme],
+  };
+}
+
+function sanitizeCreationConfig(
+  config: unknown
+): CreationBuilderModuleConfig {
+  if (!config || typeof config !== "object") {
+    return { ...DEFAULT_CREATION_BUILDER_CONFIG };
+  }
+  const base = config as Partial<CreationBuilderModuleConfig>;
+  return {
+    type: "creation-builder",
+    title:
+      typeof base.title === "string"
+        ? base.title
+        : DEFAULT_CREATION_BUILDER_CONFIG.title,
+    instructions:
+      typeof base.instructions === "string"
+        ? base.instructions
+        : DEFAULT_CREATION_BUILDER_CONFIG.instructions,
+    submitLabel:
+      typeof base.submitLabel === "string"
+        ? base.submitLabel
+        : DEFAULT_CREATION_BUILDER_CONFIG.submitLabel,
+    pools: sanitizePool(base.pools),
+  };
+}
+
+function createInitialSpec(payload: unknown): CreationSpec {
+  if (payload && typeof payload === "object") {
+    const raw = payload as CreationSpec;
+    return {
+      action: typeof raw.action === "string" ? raw.action : null,
+      media: typeof raw.media === "string" ? raw.media : null,
+      style: typeof raw.style === "string" ? raw.style : null,
+      theme: typeof raw.theme === "string" ? raw.theme : null,
+    };
+  }
+  return { action: null, media: null, style: null, theme: null };
+}
+
+function CreationBuilderModule({
+  config,
+  payload,
+  onAdvance,
+  isEditMode,
+  onUpdateConfig,
+}: ExplorateurIAModuleProps) {
+  const typedConfig = useMemo(() => sanitizeCreationConfig(config), [config]);
+  const initialSpec = useMemo(() => createInitialSpec(payload), [payload]);
+  const [spec, setSpec] = useState<CreationSpec>(initialSpec);
+  const [previewKey, setPreviewKey] = useState(0);
+
+  useEffect(() => {
+    setSpec(initialSpec);
+  }, [initialSpec]);
+
+  const ready = spec.action && spec.media && spec.style && spec.theme;
+
+  const handleSetField = useCallback(
+    (key: keyof CreationSpec, value: string | null) => {
+      setSpec((current) => ({ ...current, [key]: value }));
+    },
+    []
+  );
+
+  const handleDrop = useCallback(
+    (key: keyof CreationSpec, value: string) => {
+      handleSetField(key, value);
+    },
+    [handleSetField]
+  );
+
+  const handleValidate = useCallback(() => {
+    if (!ready) {
+      return;
+    }
+    onAdvance({ ...spec });
+  }, [onAdvance, ready, spec]);
+
+  const handleShuffle = useCallback(() => {
+    const pools = typedConfig.pools;
+    const pick = (items: string[]) =>
+      items[Math.floor(Math.random() * items.length)] ?? null;
+    setSpec({
+      action: pick(pools.action),
+      media: pick(pools.media),
+      style: pick(pools.style),
+      theme: pick(pools.theme),
+    });
+    setPreviewKey((value) => value + 1);
+  }, [typedConfig.pools]);
+
+  const handleResetSpec = useCallback(() => {
+    setSpec({ action: null, media: null, style: null, theme: null });
+  }, []);
+
+  const handlePoolChange = useCallback(
+    (field: keyof CreationPoolConfig, value: string) => {
+      const entries = value
+        .split(/\r?\n/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+      onUpdateConfig({
+        ...typedConfig,
+        pools: {
+          ...typedConfig.pools,
+          [field]: entries.length ? entries : typedConfig.pools[field],
+        },
+      });
+    },
+    [onUpdateConfig, typedConfig]
+  );
+
+  const handleInstructionsChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onUpdateConfig({ ...typedConfig, instructions: event.target.value });
+    },
+    [onUpdateConfig, typedConfig]
+  );
+
+  const handleTitleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onUpdateConfig({ ...typedConfig, title: event.target.value });
+    },
+    [onUpdateConfig, typedConfig]
+  );
+
+  const handleSubmitLabelChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      onUpdateConfig({ ...typedConfig, submitLabel: event.target.value });
+    },
+    [onUpdateConfig, typedConfig]
+  );
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Titre</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.title ?? ""}
+              onChange={handleTitleChange}
+              placeholder="Titre pédagogique"
+            />
+          </label>
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Texte du bouton</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.submitLabel ?? ""}
+              onChange={handleSubmitLabelChange}
+              placeholder="Valider ma consigne"
+            />
+          </label>
+        </div>
+        <label className="block space-y-1 text-sm">
+          <span className="font-medium text-slate-700">Instructions</span>
+          <textarea
+            className="h-24 w-full rounded-md border border-slate-300 p-2"
+            value={typedConfig.instructions ?? ""}
+            onChange={handleInstructionsChange}
+            placeholder="Décrivez les attentes de l'étape."
+          />
+        </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          {(Object.keys(typedConfig.pools) as Array<keyof CreationPoolConfig>).map(
+            (key) => (
+              <label key={key} className="block space-y-1 text-sm">
+                <span className="font-medium text-slate-700">
+                  {key}
+                </span>
+                <textarea
+                  className="h-32 w-full rounded-md border border-slate-300 p-2 font-mono text-xs"
+                  value={typedConfig.pools[key].join("\n")}
+                  onChange={(event) => handlePoolChange(key, event.target.value)}
+                  placeholder="Une valeur par ligne"
+                />
+              </label>
+            )
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  const pools = typedConfig.pools;
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_280px]">
+      <section className="space-y-4">
+        {typedConfig.title ? (
+          <h2 className="text-lg font-semibold text-slate-900">{typedConfig.title}</h2>
+        ) : null}
+        {typedConfig.instructions ? (
+          <p className="text-sm text-slate-600">{typedConfig.instructions}</p>
+        ) : null}
+        <div className="grid gap-4 sm:grid-cols-2">
+          {(Object.keys(pools) as Array<keyof CreationPoolConfig>).map((slot) => (
+            <div key={slot} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+                {slot}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {pools[slot].map((item) => (
+                  <DraggablePill
+                    key={`${slot}-${item}`}
+                    label={item}
+                    onPick={() => handleSetField(slot, item)}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <DropSlot
+            label="Action"
+            value={spec.action ?? undefined}
+            onSelect={(value) => handleDrop("action", value)}
+            onClear={() => handleSetField("action", null)}
+          />
+          <DropSlot
+            label="Média"
+            value={spec.media ?? undefined}
+            onSelect={(value) => handleDrop("media", value)}
+            onClear={() => handleSetField("media", null)}
+          />
+          <DropSlot
+            label="Style"
+            value={spec.style ?? undefined}
+            onSelect={(value) => handleDrop("style", value)}
+            onClear={() => handleSetField("style", null)}
+          />
+          <DropSlot
+            label="Thème"
+            value={spec.theme ?? undefined}
+            onSelect={(value) => handleDrop("theme", value)}
+            onClear={() => handleSetField("theme", null)}
+          />
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleShuffle}
+            className="rounded-full border border-slate-300 px-3 py-1 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Mélanger
+          </button>
+          <button
+            type="button"
+            onClick={handleResetSpec}
+            className="rounded-full border border-slate-300 px-3 py-1 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+          >
+            Réinitialiser
+          </button>
+        </div>
+      </section>
+      <aside className="space-y-4">
+        <CreationPreview spec={spec} key={previewKey} />
+        <button
+          type="button"
+          onClick={handleValidate}
+          disabled={!ready}
+          className={combineClasses(
+            "w-full rounded-xl px-4 py-2 text-sm font-semibold text-white transition",
+            ready
+              ? "bg-emerald-600 hover:bg-emerald-700"
+              : "bg-emerald-400/60 cursor-not-allowed"
+          )}
+        >
+          {typedConfig.submitLabel ?? "Valider"}
+        </button>
+      </aside>
+    </div>
+  );
+}
+
+function DraggablePill({
+  label,
+  onPick,
+}: {
+  label: string;
+  onPick: () => void;
+}) {
+  const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    event.dataTransfer.setData("text/plain", label);
+  };
+  return (
+    <button
+      type="button"
+      draggable
+      onDragStart={handleDragStart}
+      onClick={onPick}
+      className="rounded-full border border-slate-200 bg-white px-3 py-1 text-sm shadow-sm hover:bg-emerald-50"
+    >
+      {label}
+    </button>
+  );
+}
+
+function DropSlot({
+  label,
+  value,
+  onSelect,
+  onClear,
+}: {
+  label: string;
+  value?: string;
+  onSelect: (value: string) => void;
+  onClear: () => void;
+}) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsOver(false);
+    const dropped = event.dataTransfer.getData("text/plain");
+    if (dropped) {
+      onSelect(dropped);
+    }
+  };
+
+  return (
+    <div
+      onDragOver={(event) => {
+        event.preventDefault();
+        setIsOver(true);
+      }}
+      onDragLeave={() => setIsOver(false)}
+      onDrop={handleDrop}
+      className={combineClasses(
+        "min-h-[72px] rounded-2xl border border-dashed border-slate-300 bg-white p-4",
+        isOver && "border-emerald-400 bg-emerald-50"
+      )}
+    >
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+        {label}
+      </div>
+      {value ? (
+        <div className="mt-2 flex items-center justify-between">
+          <span className="rounded-full bg-emerald-100 px-3 py-1 text-sm font-semibold text-emerald-700">
+            {value}
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-sm text-slate-500 hover:text-slate-700"
+            aria-label={`Retirer ${value}`}
+          >
+            ✕
+          </button>
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-slate-400">Glissez un élément ici.</p>
+      )}
+    </div>
+  );
+}
+
+function CreationPreview({ spec }: { spec: CreationSpec }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Prévisualisation
+      </div>
+      <div className="mt-3 space-y-2 text-sm text-slate-700">
+        <p>
+          {spec.action ? (
+            <strong>{spec.action}</strong>
+          ) : (
+            <span className="text-slate-400">[action]</span>
+          )}{" "}
+          {spec.media ? spec.media : <span className="text-slate-400">[média]</span>}
+          , dans un style {" "}
+          {spec.style ? spec.style : <span className="text-slate-400">[style]</span>}
+          {" "} sur le thème {" "}
+          {spec.theme ? spec.theme : <span className="text-slate-400">[thème]</span>}.
+        </p>
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-xs text-slate-500">
+          Ajustez chaque paramètre pour personnaliser la consigne à votre contexte.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+registerExplorateurIAModule("creation-builder", CreationBuilderModule);

--- a/frontend/src/pages/explorateurIA/modules/DecisionPathModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/DecisionPathModule.tsx
@@ -1,0 +1,431 @@
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
+
+import type { ExplorateurIAModuleConfig, ExplorateurIAModuleProps } from "./registry";
+import { registerExplorateurIAModule } from "./registry";
+
+export interface DecisionPathOptionConfig {
+  id: string;
+  title: string;
+  impact: string;
+  next: string | null;
+}
+
+export interface DecisionPathStepConfig {
+  id: string;
+  prompt: string;
+  options: DecisionPathOptionConfig[];
+}
+
+export interface DecisionPathModuleConfig extends ExplorateurIAModuleConfig {
+  type: "decision-path";
+  title?: string;
+  introduction?: string;
+  steps: DecisionPathStepConfig[];
+}
+
+export interface DecisionPathResult {
+  selectedOptions: string[];
+  visitedSteps: string[];
+}
+
+const DEFAULT_STEPS: DecisionPathStepConfig[] = [
+  {
+    id: "announce",
+    prompt: "Votre équipe doit annoncer un nouveau projet. Quelle stratégie choisissez-vous ?",
+    options: [
+      {
+        id: "A",
+        title: "Annonce rapide",
+        impact: "+ vitesse / – profondeur",
+        next: "follow-up",
+      },
+      {
+        id: "B",
+        title: "Annonce équilibrée",
+        impact: "+ clarté / – temps",
+        next: "follow-up",
+      },
+      {
+        id: "C",
+        title: "Annonce personnalisée",
+        impact: "+ pertinence / – effort",
+        next: "follow-up",
+      },
+    ],
+  },
+  {
+    id: "follow-up",
+    prompt: "Le public réagit vivement. Quelle action de suivi priorisez-vous ?",
+    options: [
+      {
+        id: "A",
+        title: "FAQ automatisée",
+        impact: "+ échelle / – nuance",
+        next: null,
+      },
+      {
+        id: "B",
+        title: "Atelier interactif",
+        impact: "+ engagement / – logistique",
+        next: null,
+      },
+      {
+        id: "C",
+        title: "Messages ciblés",
+        impact: "+ efficacité / – données",
+        next: null,
+      },
+    ],
+  },
+];
+
+export const DEFAULT_DECISION_PATH_CONFIG: DecisionPathModuleConfig = {
+  type: "decision-path",
+  title: "Tracez votre parcours de décision",
+  introduction:
+    "Chaque choix révèle des compromis différents. Expérimentez plusieurs trajectoires pour comparer les impacts.",
+  steps: DEFAULT_STEPS,
+};
+
+function sanitizeSteps(steps: DecisionPathStepConfig[] | undefined): DecisionPathStepConfig[] {
+  if (!Array.isArray(steps) || steps.length === 0) {
+    return DEFAULT_STEPS.map((step) => ({
+      ...step,
+      options: step.options.map((option) => ({ ...option })),
+    }));
+  }
+  return steps.map((step, index) => ({
+    id: typeof step.id === "string" ? step.id : `step-${index + 1}`,
+    prompt:
+      typeof step.prompt === "string"
+        ? step.prompt
+        : DEFAULT_STEPS[index % DEFAULT_STEPS.length].prompt,
+    options: Array.isArray(step.options) && step.options.length
+      ? step.options.map((option, optionIndex) => ({
+          id:
+            typeof option?.id === "string" && option.id.trim()
+              ? option.id.trim()
+              : String.fromCharCode(65 + optionIndex),
+          title:
+            typeof option?.title === "string"
+              ? option.title
+              : DEFAULT_STEPS[index % DEFAULT_STEPS.length].options[
+                  optionIndex % DEFAULT_STEPS[index % DEFAULT_STEPS.length].options.length
+                ].title,
+          impact:
+            typeof option?.impact === "string"
+              ? option.impact
+              : DEFAULT_STEPS[index % DEFAULT_STEPS.length].options[
+                  optionIndex % DEFAULT_STEPS[index % DEFAULT_STEPS.length].options.length
+                ].impact,
+          next:
+            typeof option?.next === "string" && option.next.trim()
+              ? option.next.trim()
+              : null,
+        }))
+      : DEFAULT_STEPS[index % DEFAULT_STEPS.length].options.map((option) => ({
+          ...option,
+        })),
+  }));
+}
+
+function sanitizeDecisionConfig(config: unknown): DecisionPathModuleConfig {
+  if (!config || typeof config !== "object") {
+    return { ...DEFAULT_DECISION_PATH_CONFIG };
+  }
+  const base = config as Partial<DecisionPathModuleConfig>;
+  return {
+    type: "decision-path",
+    title:
+      typeof base.title === "string"
+        ? base.title
+        : DEFAULT_DECISION_PATH_CONFIG.title,
+    introduction:
+      typeof base.introduction === "string"
+        ? base.introduction
+        : DEFAULT_DECISION_PATH_CONFIG.introduction,
+    steps: sanitizeSteps(base.steps),
+  };
+}
+
+function DecisionPathModule({
+  config,
+  payload,
+  onAdvance,
+  isEditMode,
+  onUpdateConfig,
+}: ExplorateurIAModuleProps) {
+  const typedConfig = useMemo(() => sanitizeDecisionConfig(config), [config]);
+  const steps = typedConfig.steps;
+  const [currentStepId, setCurrentStepId] = useState(() => steps[0]?.id ?? "");
+  const [path, setPath] = useState<string[]>(() => {
+    if (payload && typeof payload === "object") {
+      const result = payload as DecisionPathResult;
+      return Array.isArray(result.selectedOptions) ? [...result.selectedOptions] : [];
+    }
+    return [];
+  });
+
+  const [visited, setVisited] = useState<string[]>(() => {
+    if (payload && typeof payload === "object") {
+      const result = payload as DecisionPathResult;
+      return Array.isArray(result.visitedSteps) ? [...result.visitedSteps] : [];
+    }
+    return [];
+  });
+
+  const currentStep = useMemo(
+    () => steps.find((step) => step.id === currentStepId) ?? steps[0],
+    [currentStepId, steps]
+  );
+
+  const handleChoice = useCallback(
+    (option: DecisionPathOptionConfig) => {
+      if (!currentStep) {
+        return;
+      }
+      setPath((prev) => [...prev, option.id]);
+      setVisited((prev) => [...prev, currentStep.id]);
+      if (option.next) {
+        setCurrentStepId(option.next);
+        return;
+      }
+      const result: DecisionPathResult = {
+        selectedOptions: [...path, option.id],
+        visitedSteps: [...visited, currentStep.id],
+      };
+      onAdvance(result);
+    },
+    [currentStep, onAdvance, path, visited]
+  );
+
+  const handleReset = useCallback(() => {
+    setPath([]);
+    setVisited([]);
+    setCurrentStepId(steps[0]?.id ?? "");
+  }, [steps]);
+
+  const handleStepPromptChange = useCallback(
+    (index: number, value: string) => {
+      const nextSteps = steps.map((step, stepIndex) =>
+        stepIndex === index ? { ...step, prompt: value } : step
+      );
+      onUpdateConfig({ ...typedConfig, steps: nextSteps });
+    },
+    [onUpdateConfig, steps, typedConfig]
+  );
+
+  const handleOptionChange = useCallback(
+    (
+      stepIndex: number,
+      optionIndex: number,
+      field: keyof DecisionPathOptionConfig,
+      value: string
+    ) => {
+      const nextSteps = steps.map((step, index) => {
+        if (index !== stepIndex) return step;
+        const nextOptions = step.options.map((option, optIndex) => {
+          if (optIndex !== optionIndex) return option;
+          if (field === "next") {
+            return { ...option, next: value === "" ? null : value };
+          }
+          return { ...option, [field]: value };
+        });
+        return { ...step, options: nextOptions };
+      });
+      onUpdateConfig({ ...typedConfig, steps: nextSteps });
+    },
+    [onUpdateConfig, steps, typedConfig]
+  );
+
+  const stepIdOptions = steps.map((step) => step.id);
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Titre</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.title ?? ""}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onUpdateConfig({ ...typedConfig, title: event.target.value })
+              }
+            />
+          </label>
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Introduction</span>
+            <textarea
+              className="h-24 w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.introduction ?? ""}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                onUpdateConfig({
+                  ...typedConfig,
+                  introduction: event.target.value,
+                })
+              }
+            />
+          </label>
+        </div>
+        <div className="space-y-4">
+          {steps.map((step, index) => (
+            <div
+              key={step.id}
+              className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-slate-700">
+                  Étape {index + 1} — {step.id}
+                </h3>
+              </div>
+              <label className="block space-y-1 text-sm">
+                <span className="font-medium text-slate-700">Prompt</span>
+                <textarea
+                  className="h-20 w-full rounded-md border border-slate-300 p-2"
+                  value={step.prompt}
+                  onChange={(event) =>
+                    handleStepPromptChange(index, event.target.value)
+                  }
+                />
+              </label>
+              <div className="space-y-3">
+                {step.options.map((option, optionIndex) => (
+                  <div
+                    key={option.id}
+                    className="rounded-xl border border-slate-200 p-3"
+                  >
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <label className="block space-y-1 text-sm">
+                        <span className="font-medium text-slate-600">Identifiant</span>
+                        <input
+                          className="w-full rounded-md border border-slate-300 p-2"
+                          value={option.id}
+                          onChange={(event) =>
+                            handleOptionChange(
+                              index,
+                              optionIndex,
+                              "id",
+                              event.target.value
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="block space-y-1 text-sm">
+                        <span className="font-medium text-slate-600">Étape suivante</span>
+                        <select
+                          className="w-full rounded-md border border-slate-300 p-2"
+                          value={option.next ?? ""}
+                          onChange={(event) =>
+                            handleOptionChange(
+                              index,
+                              optionIndex,
+                              "next",
+                              event.target.value
+                            )
+                          }
+                        >
+                          <option value="">Fin du parcours</option>
+                          {stepIdOptions.map((stepId) => (
+                            <option key={stepId} value={stepId}>
+                              {stepId}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                    <label className="mt-3 block space-y-1 text-sm">
+                      <span className="font-medium text-slate-600">Titre</span>
+                      <input
+                        className="w-full rounded-md border border-slate-300 p-2"
+                        value={option.title}
+                        onChange={(event) =>
+                          handleOptionChange(
+                            index,
+                            optionIndex,
+                            "title",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </label>
+                    <label className="mt-3 block space-y-1 text-sm">
+                      <span className="font-medium text-slate-600">Impact</span>
+                      <textarea
+                        className="h-20 w-full rounded-md border border-slate-300 p-2"
+                        value={option.impact}
+                        onChange={(event) =>
+                          handleOptionChange(
+                            index,
+                            optionIndex,
+                            "impact",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </label>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!currentStep) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        Aucune étape configurée pour ce parcours.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {typedConfig.title ? (
+        <h2 className="text-lg font-semibold text-slate-900">{typedConfig.title}</h2>
+      ) : null}
+      {typedConfig.introduction ? (
+        <p className="text-sm text-slate-600">{typedConfig.introduction}</p>
+      ) : null}
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Étape {steps.findIndex((step) => step.id === currentStep.id) + 1} / {steps.length}
+        </div>
+        <p className="mt-2 text-base text-slate-700">{currentStep.prompt}</p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {currentStep.options.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => handleChoice(option)}
+            className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50"
+          >
+            <div className="text-sm font-semibold text-slate-800">{option.title}</div>
+            <p className="mt-2 text-xs text-slate-600">{option.impact}</p>
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-500">
+        <div>
+          Trajectoire actuelle :
+          <span className="ml-2 font-semibold text-slate-700">
+            {path.length ? path.join(" → ") : "Aucune sélection"}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100"
+        >
+          Recommencer
+        </button>
+      </div>
+    </div>
+  );
+}
+
+registerExplorateurIAModule("decision-path", DecisionPathModule);

--- a/frontend/src/pages/explorateurIA/modules/EthicsDilemmasModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/EthicsDilemmasModule.tsx
@@ -1,0 +1,460 @@
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
+
+import type { ExplorateurIAModuleConfig, ExplorateurIAModuleProps } from "./registry";
+import { registerExplorateurIAModule } from "./registry";
+
+export interface EthicsDilemmaOptionConfig {
+  id: string;
+  label: string;
+  feedback: string;
+  score: number;
+}
+
+export interface EthicsDilemmaConfig {
+  id: string;
+  scenario: string;
+  options: EthicsDilemmaOptionConfig[];
+}
+
+export interface EthicsDilemmasModuleConfig extends ExplorateurIAModuleConfig {
+  type: "ethics-dilemmas";
+  title?: string;
+  introduction?: string;
+  dilemmas: EthicsDilemmaConfig[];
+  concludeLabel?: string;
+}
+
+export interface EthicsDilemmasResult {
+  averageScore: number;
+  answers: Array<{ dilemmaId: string; optionId: string; score: number }>;
+}
+
+const DEFAULT_DILEMMAS: EthicsDilemmaConfig[] = [
+  {
+    id: "bias",
+    scenario: "Un outil génère un résumé contenant des stéréotypes.",
+    options: [
+      {
+        id: "ignore",
+        label: "Ignorer",
+        feedback: "Risque d'amplifier le biais et de diffuser une erreur.",
+        score: 0,
+      },
+      {
+        id: "correct",
+        label: "Corriger et justifier",
+        feedback: "Bonne pratique: signalez et corrigez les biais.",
+        score: 100,
+      },
+      {
+        id: "question",
+        label: "Demander des explications",
+        feedback: "Utile, mais sans correction le risque demeure.",
+        score: 60,
+      },
+    ],
+  },
+  {
+    id: "sensitive",
+    scenario: "Un modèle révèle des données sensibles dans un exemple.",
+    options: [
+      {
+        id: "ignore",
+        label: "Ignorer",
+        feedback: "Non conforme à la protection des données.",
+        score: 0,
+      },
+      {
+        id: "remove",
+        label: "Supprimer et anonymiser",
+        feedback: "Conforme aux bonnes pratiques.",
+        score: 100,
+      },
+      {
+        id: "ask",
+        label: "Demander justification",
+        feedback: "Insuffisant sans retrait immédiat.",
+        score: 40,
+      },
+    ],
+  },
+];
+
+export const DEFAULT_ETHICS_DILEMMAS_CONFIG: EthicsDilemmasModuleConfig = {
+  type: "ethics-dilemmas",
+  title: "Réagissez à des dilemmes éthiques",
+  introduction:
+    "Choisissez la meilleure réponse pour limiter les dérives et renforcer la responsabilité.",
+  dilemmas: DEFAULT_DILEMMAS,
+  concludeLabel: "Voir mon score",
+};
+
+function sanitizeDilemmas(
+  dilemmas: EthicsDilemmaConfig[] | undefined
+): EthicsDilemmaConfig[] {
+  if (!Array.isArray(dilemmas) || dilemmas.length === 0) {
+    return DEFAULT_DILEMMAS.map((dilemma) => ({
+      ...dilemma,
+      options: dilemma.options.map((option) => ({ ...option })),
+    }));
+  }
+  return dilemmas.map((dilemma, index) => ({
+    id: typeof dilemma.id === "string" ? dilemma.id : `dilemma-${index + 1}`,
+    scenario:
+      typeof dilemma.scenario === "string"
+        ? dilemma.scenario
+        : DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].scenario,
+    options:
+      Array.isArray(dilemma.options) && dilemma.options.length
+        ? dilemma.options.map((option, optionIndex) => ({
+            id:
+              typeof option?.id === "string" && option.id.trim()
+                ? option.id.trim()
+                : `${index + 1}-${optionIndex + 1}`,
+            label:
+              typeof option?.label === "string"
+                ? option.label
+                : DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options[
+                    optionIndex % DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options.length
+                  ].label,
+            feedback:
+              typeof option?.feedback === "string"
+                ? option.feedback
+                : DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options[
+                    optionIndex % DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options.length
+                  ].feedback,
+            score:
+              typeof option?.score === "number"
+                ? option.score
+                : DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options[
+                    optionIndex % DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options.length
+                  ].score,
+          }))
+        : DEFAULT_DILEMMAS[index % DEFAULT_DILEMMAS.length].options.map((option) => ({
+            ...option,
+          })),
+  }));
+}
+
+function sanitizeEthicsConfig(config: unknown): EthicsDilemmasModuleConfig {
+  if (!config || typeof config !== "object") {
+    return { ...DEFAULT_ETHICS_DILEMMAS_CONFIG };
+  }
+  const base = config as Partial<EthicsDilemmasModuleConfig>;
+  return {
+    type: "ethics-dilemmas",
+    title:
+      typeof base.title === "string"
+        ? base.title
+        : DEFAULT_ETHICS_DILEMMAS_CONFIG.title,
+    introduction:
+      typeof base.introduction === "string"
+        ? base.introduction
+        : DEFAULT_ETHICS_DILEMMAS_CONFIG.introduction,
+    concludeLabel:
+      typeof base.concludeLabel === "string"
+        ? base.concludeLabel
+        : DEFAULT_ETHICS_DILEMMAS_CONFIG.concludeLabel,
+    dilemmas: sanitizeDilemmas(base.dilemmas),
+  };
+}
+
+function EthicsDilemmasModule({
+  config,
+  payload,
+  onAdvance,
+  isEditMode,
+  onUpdateConfig,
+}: ExplorateurIAModuleProps) {
+  const typedConfig = useMemo(() => sanitizeEthicsConfig(config), [config]);
+  const dilemmas = typedConfig.dilemmas;
+  const [index, setIndex] = useState(0);
+  const [answers, setAnswers] = useState<EthicsDilemmasResult["answers"]>(() => {
+    if (payload && typeof payload === "object") {
+      const result = payload as EthicsDilemmasResult;
+      if (Array.isArray(result.answers)) {
+        return [...result.answers];
+      }
+    }
+    return [];
+  });
+
+  const current = dilemmas[index] ?? dilemmas[dilemmas.length - 1];
+
+  const handleSelect = useCallback(
+    (option: EthicsDilemmaOptionConfig) => {
+      const nextAnswers = [...answers, {
+        dilemmaId: current.id,
+        optionId: option.id,
+        score: option.score,
+      }];
+      if (index + 1 >= dilemmas.length) {
+        const average =
+          nextAnswers.reduce((total, entry) => total + entry.score, 0) /
+          nextAnswers.length;
+        onAdvance({
+          answers: nextAnswers,
+          averageScore: Math.round(average),
+        });
+        setAnswers(nextAnswers);
+        return;
+      }
+      setAnswers(nextAnswers);
+      setIndex(index + 1);
+    },
+    [answers, current.id, dilemmas.length, index, onAdvance]
+  );
+
+  const handleReset = useCallback(() => {
+    setIndex(0);
+    setAnswers([]);
+  }, []);
+
+  const handleUpdateDilemma = useCallback(
+    (dilemmaIndex: number, patch: Partial<EthicsDilemmaConfig>) => {
+      const nextDilemmas = dilemmas.map((dilemma, index) =>
+        index === dilemmaIndex ? { ...dilemma, ...patch } : dilemma
+      );
+      onUpdateConfig({ ...typedConfig, dilemmas: nextDilemmas });
+    },
+    [dilemmas, onUpdateConfig, typedConfig]
+  );
+
+  const handleOptionChange = useCallback(
+    (
+      dilemmaIndex: number,
+      optionIndex: number,
+      field: keyof EthicsDilemmaOptionConfig,
+      value: string
+    ) => {
+      const nextDilemmas = dilemmas.map((dilemma, index) => {
+        if (index !== dilemmaIndex) return dilemma;
+        const nextOptions = dilemma.options.map((option, optIndex) => {
+          if (optIndex !== optionIndex) return option;
+          if (field === "score") {
+            const parsed = Number.parseInt(value, 10);
+            return {
+              ...option,
+              score: Number.isNaN(parsed) ? 0 : Math.max(0, Math.min(100, parsed)),
+            };
+          }
+          return { ...option, [field]: value };
+        });
+        return { ...dilemma, options: nextOptions };
+      });
+      onUpdateConfig({ ...typedConfig, dilemmas: nextDilemmas });
+    },
+    [dilemmas, onUpdateConfig, typedConfig]
+  );
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Titre</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.title ?? ""}
+              onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                onUpdateConfig({ ...typedConfig, title: event.target.value })
+              }
+            />
+          </label>
+          <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">Introduction</span>
+            <textarea
+              className="h-24 w-full rounded-md border border-slate-300 p-2"
+              value={typedConfig.introduction ?? ""}
+              onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                onUpdateConfig({
+                  ...typedConfig,
+                  introduction: event.target.value,
+                })
+              }
+            />
+          </label>
+        </div>
+        <label className="block space-y-1 text-sm">
+          <span className="font-medium text-slate-700">Texte du bouton final</span>
+          <input
+            className="w-full rounded-md border border-slate-300 p-2"
+            value={typedConfig.concludeLabel ?? ""}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onUpdateConfig({ ...typedConfig, concludeLabel: event.target.value })
+            }
+          />
+        </label>
+        <div className="space-y-4">
+          {dilemmas.map((dilemma, dilemmaIndex) => (
+            <div
+              key={dilemma.id}
+              className="space-y-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-slate-700">
+                  Dilemme {dilemmaIndex + 1} — {dilemma.id}
+                </h3>
+              </div>
+              <label className="block space-y-1 text-sm">
+                <span className="font-medium text-slate-700">Identifiant</span>
+                <input
+                  className="w-full rounded-md border border-slate-300 p-2"
+                  value={dilemma.id}
+                  onChange={(event) =>
+                    handleUpdateDilemma(dilemmaIndex, { id: event.target.value })
+                  }
+                />
+              </label>
+              <label className="block space-y-1 text-sm">
+                <span className="font-medium text-slate-700">Scénario</span>
+                <textarea
+                  className="h-24 w-full rounded-md border border-slate-300 p-2"
+                  value={dilemma.scenario}
+                  onChange={(event) =>
+                    handleUpdateDilemma(dilemmaIndex, {
+                      scenario: event.target.value,
+                    })
+                  }
+                />
+              </label>
+              <div className="space-y-3">
+                {dilemma.options.map((option, optionIndex) => (
+                  <div
+                    key={option.id}
+                    className="rounded-xl border border-slate-200 p-3"
+                  >
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <label className="block space-y-1 text-sm">
+                        <span className="font-medium text-slate-600">Identifiant</span>
+                        <input
+                          className="w-full rounded-md border border-slate-300 p-2"
+                          value={option.id}
+                          onChange={(event) =>
+                            handleOptionChange(
+                              dilemmaIndex,
+                              optionIndex,
+                              "id",
+                              event.target.value
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="block space-y-1 text-sm">
+                        <span className="font-medium text-slate-600">Libellé</span>
+                        <input
+                          className="w-full rounded-md border border-slate-300 p-2"
+                          value={option.label}
+                          onChange={(event) =>
+                            handleOptionChange(
+                              dilemmaIndex,
+                              optionIndex,
+                              "label",
+                              event.target.value
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="block space-y-1 text-sm">
+                        <span className="font-medium text-slate-600">Score</span>
+                        <input
+                          type="number"
+                          min={0}
+                          max={100}
+                          className="w-full rounded-md border border-slate-300 p-2"
+                          value={option.score}
+                          onChange={(event) =>
+                            handleOptionChange(
+                              dilemmaIndex,
+                              optionIndex,
+                              "score",
+                              event.target.value
+                            )
+                          }
+                        />
+                      </label>
+                    </div>
+                    <label className="mt-3 block space-y-1 text-sm">
+                      <span className="font-medium text-slate-600">Feedback</span>
+                      <textarea
+                        className="h-20 w-full rounded-md border border-slate-300 p-2"
+                        value={option.feedback}
+                        onChange={(event) =>
+                          handleOptionChange(
+                            dilemmaIndex,
+                            optionIndex,
+                            "feedback",
+                            event.target.value
+                          )
+                        }
+                      />
+                    </label>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!current) {
+    return null;
+  }
+
+  const score = answers.reduce((total, entry) => total + entry.score, 0);
+  const average = answers.length ? Math.round(score / answers.length) : 0;
+
+  return (
+    <div className="space-y-4">
+      {typedConfig.title ? (
+        <h2 className="text-lg font-semibold text-slate-900">{typedConfig.title}</h2>
+      ) : null}
+      {typedConfig.introduction ? (
+        <p className="text-sm text-slate-600">{typedConfig.introduction}</p>
+      ) : null}
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex items-baseline justify-between text-xs text-slate-500">
+          <span>
+            Situation {index + 1} / {dilemmas.length}
+          </span>
+          <span className="font-semibold text-emerald-600">
+            Score moyen : {average}
+          </span>
+        </div>
+        <p className="mt-2 text-base text-slate-700">{current.scenario}</p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        {current.options.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => handleSelect(option)}
+            className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50"
+          >
+            <div className="text-sm font-semibold text-slate-800">{option.label}</div>
+            <p className="mt-2 text-xs text-slate-600">{option.feedback}</p>
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between text-xs text-slate-500">
+        <div>
+          Réponses données :
+          <span className="ml-2 font-semibold text-slate-700">
+            {answers.length} / {dilemmas.length}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-full border border-slate-300 px-3 py-1 font-semibold text-slate-600 hover:bg-slate-100"
+        >
+          Recommencer
+        </button>
+      </div>
+    </div>
+  );
+}
+
+registerExplorateurIAModule("ethics-dilemmas", EthicsDilemmasModule);

--- a/frontend/src/pages/explorateurIA/modules/index.ts
+++ b/frontend/src/pages/explorateurIA/modules/index.ts
@@ -1,0 +1,5 @@
+export * from "./registry";
+export * from "./ClarteQuizModule";
+export * from "./CreationBuilderModule";
+export * from "./DecisionPathModule";
+export * from "./EthicsDilemmasModule";

--- a/frontend/src/pages/explorateurIA/modules/registry.tsx
+++ b/frontend/src/pages/explorateurIA/modules/registry.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import type { ComponentType } from "react";
+
+import {
+  registerStepComponent,
+  type StepComponentProps,
+} from "../../../modules/step-sequence";
+
+export interface ExplorateurIAModuleConfig {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ExplorateurIAModuleProps
+  extends Omit<StepComponentProps, "config" | "onUpdateConfig"> {
+  config: ExplorateurIAModuleConfig;
+  onUpdateConfig: (config: ExplorateurIAModuleConfig) => void;
+}
+
+type ExplorateurIAModuleComponent = ComponentType<ExplorateurIAModuleProps>;
+
+const MODULE_REGISTRY = new Map<string, ExplorateurIAModuleComponent>();
+
+export function registerExplorateurIAModule(
+  type: string,
+  component: ExplorateurIAModuleComponent
+): void {
+  MODULE_REGISTRY.set(type, component);
+}
+
+function getExplorateurIAModule(
+  type: string
+): ExplorateurIAModuleComponent | undefined {
+  return MODULE_REGISTRY.get(type);
+}
+
+function sanitizeModuleConfig(
+  config: unknown,
+  fallbackType: string
+): ExplorateurIAModuleConfig {
+  if (config && typeof config === "object") {
+    const typed = config as Record<string, unknown>;
+    const nextType =
+      typeof typed.type === "string" && typed.type.length > 0
+        ? typed.type
+        : fallbackType;
+    return { ...typed, type: nextType } as ExplorateurIAModuleConfig;
+  }
+  return { type: fallbackType };
+}
+
+function ExplorateurIACustomStep(props: StepComponentProps): JSX.Element | null {
+  const { definition, config, onUpdateConfig, ...rest } = props;
+  const moduleType =
+    (config && typeof config === "object" && (config as { type?: string }).type) ||
+    "unknown";
+
+  const sanitizedConfig = useMemo(
+    () => sanitizeModuleConfig(config, moduleType),
+    [config, moduleType]
+  );
+
+  const ModuleComponent = getExplorateurIAModule(sanitizedConfig.type);
+
+  const handleUpdate = (next: ExplorateurIAModuleConfig) => {
+    const nextConfig: ExplorateurIAModuleConfig = {
+      ...next,
+      type: next.type || sanitizedConfig.type,
+    };
+    onUpdateConfig?.(nextConfig);
+  };
+
+  if (!ModuleComponent) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Explorateur IA: aucun module personnalisé enregistré pour "${sanitizedConfig.type}".`
+      );
+    }
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        Module personnalisé « {sanitizedConfig.type} » introuvable.
+      </div>
+    );
+  }
+
+  return (
+    <ModuleComponent
+      {...rest}
+      definition={definition}
+      config={sanitizedConfig}
+      onUpdateConfig={handleUpdate}
+    />
+  );
+}
+
+registerStepComponent("custom", ExplorateurIACustomStep);

--- a/frontend/src/pages/explorateurIA/progress.ts
+++ b/frontend/src/pages/explorateurIA/progress.ts
@@ -1,0 +1,281 @@
+import type { StageAnswer } from "../../api";
+
+import type { CreationSpec } from "./modules/CreationBuilderModule";
+import type { DecisionPathResult } from "./modules/DecisionPathModule";
+import type { EthicsDilemmasResult } from "./modules/EthicsDilemmasModule";
+import type { QuarterId } from "./types";
+
+export type ClarteQuizResult = {
+  score: number;
+  selectedOptionId?: string;
+  explanation?: string;
+};
+
+export interface QuarterProgressBase {
+  done: boolean;
+  payloads: Record<string, unknown>;
+}
+
+export interface ClarteProgress extends QuarterProgressBase {
+  score: number;
+  selectedOptionId?: string;
+  explanation?: string;
+}
+
+export interface CreationProgress extends QuarterProgressBase {
+  spec?: CreationSpec;
+  reflection?: StageAnswer;
+}
+
+export interface DecisionProgress extends QuarterProgressBase {
+  path?: DecisionPathResult["selectedOptions"];
+  visitedSteps?: DecisionPathResult["visitedSteps"];
+}
+
+export type EthicsAnswer = EthicsDilemmasResult["answers"][number];
+
+export interface EthicsProgress extends QuarterProgressBase {
+  averageScore: number;
+  answers: EthicsAnswer[];
+  commitment?: StageAnswer;
+}
+
+export interface MairieProgress extends QuarterProgressBase {
+  reflection?: StageAnswer;
+}
+
+export interface ExplorateurProgress {
+  clarte: ClarteProgress;
+  creation: CreationProgress;
+  decision: DecisionProgress;
+  ethique: EthicsProgress;
+  mairie: MairieProgress;
+  visited: QuarterId[];
+}
+
+export function createInitialProgress(): ExplorateurProgress {
+  return {
+    clarte: { done: false, score: 0, payloads: {} },
+    creation: { done: false, payloads: {} },
+    decision: { done: false, payloads: {} },
+    ethique: { done: false, averageScore: 0, answers: [], payloads: {} },
+    mairie: { done: false, payloads: {} },
+    visited: [],
+  };
+}
+
+function cloneValue<T>(value: T): T {
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn("Explorateur IA: structuredClone failed", error);
+      }
+    }
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn("Explorateur IA: unable to clone value", error);
+    }
+    return value;
+  }
+}
+
+function sanitizePayloadMap(
+  payloads: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (!payloads || typeof payloads !== "object") {
+    return {};
+  }
+  const clone = cloneValue(payloads);
+  if (!clone || typeof clone !== "object") {
+    return {};
+  }
+  return { ...(clone as Record<string, unknown>) };
+}
+
+function isStageAnswer(value: unknown): value is StageAnswer {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isClarteQuizResult(value: unknown): value is ClarteQuizResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as ClarteQuizResult;
+  return (
+    typeof candidate.score === "number" &&
+    (candidate.selectedOptionId === undefined ||
+      typeof candidate.selectedOptionId === "string") &&
+    (candidate.explanation === undefined ||
+      typeof candidate.explanation === "string")
+  );
+}
+
+function isCreationSpec(value: unknown): value is CreationSpec {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as CreationSpec;
+  return (
+    (candidate.action === null || typeof candidate.action === "string") &&
+    (candidate.media === null || typeof candidate.media === "string") &&
+    (candidate.style === null || typeof candidate.style === "string") &&
+    (candidate.theme === null || typeof candidate.theme === "string")
+  );
+}
+
+function isDecisionPathResult(value: unknown): value is DecisionPathResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as DecisionPathResult;
+  return (
+    Array.isArray(candidate.selectedOptions) &&
+    Array.isArray(candidate.visitedSteps)
+  );
+}
+
+function isEthicsDilemmasResult(value: unknown): value is EthicsDilemmasResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as EthicsDilemmasResult;
+  return (
+    Array.isArray(candidate.answers) &&
+    typeof candidate.averageScore === "number"
+  );
+}
+
+export type QuarterPayloadMap = Record<string, unknown>;
+
+export function updateClarteProgress(
+  previous: ClarteProgress,
+  payloads: QuarterPayloadMap | undefined
+): ClarteProgress {
+  const sanitized = sanitizePayloadMap(payloads);
+  const quizPayload = sanitized["clarte:quiz"];
+  const quizResult = isClarteQuizResult(quizPayload)
+    ? quizPayload
+    : undefined;
+  return {
+    done: true,
+    payloads: sanitized,
+    score: quizResult?.score ?? previous.score ?? 0,
+    selectedOptionId: quizResult?.selectedOptionId ?? previous.selectedOptionId,
+    explanation: quizResult?.explanation ?? previous.explanation,
+  };
+}
+
+export function updateCreationProgress(
+  previous: CreationProgress,
+  payloads: QuarterPayloadMap | undefined
+): CreationProgress {
+  const sanitized = sanitizePayloadMap(payloads);
+  const specPayload = sanitized["creation:builder"];
+  const reflectionPayload = sanitized["creation:reflection"];
+  return {
+    done: true,
+    payloads: sanitized,
+    spec: isCreationSpec(specPayload) ? specPayload : previous.spec,
+    reflection: isStageAnswer(reflectionPayload)
+      ? (reflectionPayload as StageAnswer)
+      : previous.reflection,
+  };
+}
+
+export function updateDecisionProgress(
+  previous: DecisionProgress,
+  payloads: QuarterPayloadMap | undefined
+): DecisionProgress {
+  const sanitized = sanitizePayloadMap(payloads);
+  const pathPayload = sanitized["decision:path"];
+  const result = isDecisionPathResult(pathPayload) ? pathPayload : undefined;
+  return {
+    done: true,
+    payloads: sanitized,
+    path: result?.selectedOptions ?? previous.path,
+    visitedSteps: result?.visitedSteps ?? previous.visitedSteps,
+  };
+}
+
+export function updateEthicsProgress(
+  previous: EthicsProgress,
+  payloads: QuarterPayloadMap | undefined
+): EthicsProgress {
+  const sanitized = sanitizePayloadMap(payloads);
+  const dilemmasPayload = sanitized["ethique:dilemmas"];
+  const result = isEthicsDilemmasResult(dilemmasPayload)
+    ? dilemmasPayload
+    : undefined;
+  const commitmentPayload = sanitized["ethique:commitment"];
+  return {
+    done: true,
+    payloads: sanitized,
+    averageScore: result?.averageScore ?? previous.averageScore ?? 0,
+    answers: result?.answers ?? previous.answers ?? [],
+    commitment: isStageAnswer(commitmentPayload)
+      ? (commitmentPayload as StageAnswer)
+      : previous.commitment,
+  };
+}
+
+export function updateMairieProgress(
+  previous: MairieProgress,
+  payloads: QuarterPayloadMap | undefined
+): MairieProgress {
+  const sanitized = sanitizePayloadMap(payloads);
+  const feedbackPayload = sanitized["mairie:feedback"];
+  return {
+    done: true,
+    payloads: sanitized,
+    reflection: isStageAnswer(feedbackPayload)
+      ? (feedbackPayload as StageAnswer)
+      : previous.reflection,
+  };
+}
+
+export function cloneProgress(progress: ExplorateurProgress): ExplorateurProgress {
+  return {
+    clarte: { ...progress.clarte, payloads: cloneValue(progress.clarte.payloads) },
+    creation: {
+      ...progress.creation,
+      payloads: cloneValue(progress.creation.payloads),
+      spec: progress.creation.spec
+        ? cloneValue(progress.creation.spec)
+        : progress.creation.spec,
+      reflection: progress.creation.reflection
+        ? cloneValue(progress.creation.reflection)
+        : progress.creation.reflection,
+    },
+    decision: {
+      ...progress.decision,
+      payloads: cloneValue(progress.decision.payloads),
+      path: progress.decision.path ? [...progress.decision.path] : undefined,
+      visitedSteps: progress.decision.visitedSteps
+        ? [...progress.decision.visitedSteps]
+        : undefined,
+    },
+    ethique: {
+      ...progress.ethique,
+      payloads: cloneValue(progress.ethique.payloads),
+      answers: progress.ethique.answers.map((answer) => ({ ...answer })),
+      commitment: progress.ethique.commitment
+        ? cloneValue(progress.ethique.commitment)
+        : progress.ethique.commitment,
+    },
+    mairie: {
+      ...progress.mairie,
+      payloads: cloneValue(progress.mairie.payloads),
+      reflection: progress.mairie.reflection
+        ? cloneValue(progress.mairie.reflection)
+        : progress.mairie.reflection,
+    },
+    visited: [...progress.visited],
+  };
+}

--- a/frontend/src/pages/explorateurIA/types.ts
+++ b/frontend/src/pages/explorateurIA/types.ts
@@ -1,0 +1,13 @@
+export type QuarterId = "clarte" | "creation" | "decision" | "ethique" | "mairie";
+
+export const QUARTER_ORDER: QuarterId[] = [
+  "clarte",
+  "creation",
+  "decision",
+  "ethique",
+  "mairie",
+];
+
+export function isQuarterId(value: unknown): value is QuarterId {
+  return typeof value === "string" && (QUARTER_ORDER as string[]).includes(value);
+}

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -1,0 +1,275 @@
+import type { StepDefinition } from "../../../../modules/step-sequence";
+
+import {
+  DEFAULT_CLARTE_QUIZ_CONFIG,
+  DEFAULT_CREATION_BUILDER_CONFIG,
+  DEFAULT_DECISION_PATH_CONFIG,
+  DEFAULT_ETHICS_DILEMMAS_CONFIG,
+} from "../../modules";
+import { QUARTER_ORDER, isQuarterId, type QuarterId } from "../../types";
+
+export type QuarterSteps = Record<QuarterId, StepDefinition[]>;
+
+function cloneConfig<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn("Unable to clone step configuration", error);
+    }
+    return value;
+  }
+}
+
+function cloneStep(step: StepDefinition): StepDefinition {
+  return {
+    ...step,
+    config: step.config ? cloneConfig(step.config) : undefined,
+  };
+}
+
+const CLARTE_STEPS: StepDefinition[] = [
+  {
+    id: "clarte:intro",
+    component: "rich-content",
+    config: {
+      title: "Bienvenue au quartier Clarté",
+      body: "Explorez ce qui rend une consigne précise et actionnable avant de tester vos choix.",
+      sidebar: {
+        type: "tips",
+        title: "Checklist clarté",
+        tips: [
+          "Préciser le résultat attendu",
+          "Indiquer le format et la longueur",
+          "Contextualiser pour le public cible",
+        ],
+      },
+    },
+  },
+  {
+    id: "clarte:video",
+    component: "video",
+    config: {
+      sources: [
+        {
+          type: "mp4",
+          url: "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+        },
+      ],
+      expectedDuration: 45,
+      autoAdvanceOnEnd: false,
+      poster:
+        "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=800&q=80",
+    },
+  },
+  {
+    id: "clarte:quiz",
+    component: "custom",
+    config: DEFAULT_CLARTE_QUIZ_CONFIG,
+  },
+];
+
+const CREATION_STEPS: StepDefinition[] = [
+  {
+    id: "creation:intro",
+    component: "rich-content",
+    config: {
+      title: "Quartier Création",
+      body: "Assemblez une consigne sur-mesure en combinant action, média, style et thème.",
+      sidebar: {
+        type: "checklist",
+        title: "Étapes",
+        items: [
+          { id: "select-action", label: "Sélectionner un verbe d'action", checked: false },
+          { id: "select-media", label: "Choisir un média adapté", checked: false },
+          { id: "select-style", label: "Définir le ton et le style", checked: false },
+          { id: "select-theme", label: "Associer un thème", checked: false },
+        ],
+      },
+    },
+  },
+  {
+    id: "creation:builder",
+    component: "custom",
+    config: DEFAULT_CREATION_BUILDER_CONFIG,
+  },
+  {
+    id: "creation:reflection",
+    component: "form",
+    config: {
+      submitLabel: "Enregistrer ma synthèse",
+      fields: [
+        {
+          id: "audience",
+          type: "textarea_with_counter",
+          label: "Décrivez le public cible",
+          minWords: 10,
+          maxWords: 80,
+        },
+        {
+          id: "outcome",
+          type: "bulleted_list",
+          label: "Quels livrables attendez-vous ?",
+          minBullets: 2,
+          maxBullets: 4,
+          maxWordsPerBullet: 12,
+        },
+      ],
+    },
+  },
+];
+
+const DECISION_STEPS: StepDefinition[] = [
+  {
+    id: "decision:intro",
+    component: "rich-content",
+    config: {
+      title: "Quartier Décision",
+      body: "Expérimentez différentes stratégies et observez leurs compromis pour mener votre projet.",
+    },
+  },
+  {
+    id: "decision:path",
+    component: "custom",
+    config: DEFAULT_DECISION_PATH_CONFIG,
+  },
+];
+
+const ETHIQUE_STEPS: StepDefinition[] = [
+  {
+    id: "ethique:intro",
+    component: "rich-content",
+    config: {
+      title: "Quartier Éthique",
+      body: "Chaque scénario illustre une dérive potentielle. Sélectionnez la réponse qui protège au mieux les usagers.",
+    },
+  },
+  {
+    id: "ethique:dilemmas",
+    component: "custom",
+    config: DEFAULT_ETHICS_DILEMMAS_CONFIG,
+  },
+  {
+    id: "ethique:commitment",
+    component: "form",
+    config: {
+      submitLabel: "Formuler mon engagement",
+      allowEmpty: false,
+      fields: [
+        {
+          id: "guardrail",
+          type: "two_bullets",
+          label: "Quelles pratiques mettrez-vous en place pour limiter les biais ?",
+          maxWordsPerBullet: 16,
+        },
+      ],
+    },
+  },
+];
+
+const MAIRIE_STEPS: StepDefinition[] = [
+  {
+    id: "mairie:intro",
+    component: "rich-content",
+    config: {
+      title: "Mairie — Synthèse",
+      body: "Rassemblez vos apprentissages et préparez l'export de votre badge Explorateur IA.",
+    },
+  },
+  {
+    id: "mairie:feedback",
+    component: "form",
+    config: {
+      submitLabel: "Valider mon bilan",
+      allowEmpty: false,
+      fields: [
+        {
+          id: "takeaway",
+          type: "textarea_with_counter",
+          label: "Quelle pratique garderez-vous en priorité ?",
+          minWords: 12,
+          maxWords: 120,
+        },
+        {
+          id: "confidence",
+          type: "reference_line",
+          label: "Niveau de confiance actuel (0-100%)",
+        },
+      ],
+    },
+  },
+];
+
+export const WORLD1_QUARTER_STEPS: QuarterSteps = {
+  clarte: CLARTE_STEPS.map(cloneStep),
+  creation: CREATION_STEPS.map(cloneStep),
+  decision: DECISION_STEPS.map(cloneStep),
+  ethique: ETHIQUE_STEPS.map(cloneStep),
+  mairie: MAIRIE_STEPS.map(cloneStep),
+};
+
+export function flattenQuarterSteps(map: QuarterSteps): StepDefinition[] {
+  const result: StepDefinition[] = [];
+  for (const quarter of QUARTER_ORDER) {
+    const steps = map[quarter] ?? [];
+    for (const step of steps) {
+      result.push(cloneStep(step));
+    }
+  }
+  return result;
+}
+
+export function getQuarterFromStepId(stepId: string): QuarterId | null {
+  if (!stepId) {
+    return null;
+  }
+  const [prefix] = stepId.split(":");
+  return isQuarterId(prefix) ? prefix : null;
+}
+
+export function expandQuarterSteps(
+  stepSequence: StepDefinition[] | undefined,
+  fallback: QuarterSteps = WORLD1_QUARTER_STEPS
+): QuarterSteps {
+  const result: Partial<QuarterSteps> = {};
+
+  const overridesByQuarter = new Map<QuarterId, Map<string, StepDefinition>>();
+  if (Array.isArray(stepSequence)) {
+    for (const definition of stepSequence) {
+      const quarter = getQuarterFromStepId(definition.id);
+      if (!quarter) {
+        continue;
+      }
+      const overrides = overridesByQuarter.get(quarter) ?? new Map();
+      overrides.set(definition.id, cloneStep(definition));
+      overridesByQuarter.set(quarter, overrides);
+    }
+  }
+
+  for (const quarter of QUARTER_ORDER) {
+    const baseSteps = fallback[quarter] ?? [];
+    const overrides = overridesByQuarter.get(quarter);
+    const merged: StepDefinition[] = baseSteps.map((step) =>
+      overrides?.get(step.id) ?? cloneStep(step)
+    );
+
+    if (overrides) {
+      for (const [id, definition] of overrides) {
+        if (!merged.some((step) => step.id === id)) {
+          merged.push(cloneStep(definition));
+        }
+      }
+    }
+
+    result[quarter] = merged;
+  }
+
+  return result as QuarterSteps;
+}

--- a/frontend/tests/pages/ExplorateurIA.spec.tsx
+++ b/frontend/tests/pages/ExplorateurIA.spec.tsx
@@ -1,0 +1,150 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+
+vi.mock("../../src/pages/explorateurIA/audio/chiptuneTheme", () => ({
+  createChiptuneTheme: () => ({
+    isSupported: false,
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    dispose: vi.fn(),
+  }),
+}));
+
+vi.mock("../../src/api", () => ({
+  updateActivityProgress: vi.fn().mockResolvedValue(undefined),
+}));
+
+import ExplorateurIA from "../../src/pages/ExplorateurIA";
+import type { ActivityProps } from "../../src/config/activities";
+
+const defaultActivityProps: ActivityProps = {
+  activityId: "explorateur-ia",
+  completionId: "explorateur-ia",
+  header: { eyebrow: "", title: "Explorateur IA" },
+  card: {
+    title: "Explorateur IA",
+    description: "",
+    highlights: [],
+    cta: { label: "", to: "" },
+  },
+  layout: { activityId: "explorateur-ia" },
+  layoutOverrides: {},
+  setLayoutOverrides: vi.fn(),
+  resetLayoutOverrides: vi.fn(),
+  navigateToActivities: vi.fn(),
+  isEditMode: false,
+  enabled: true,
+  stepSequence: undefined,
+  setStepSequence: vi.fn(),
+};
+
+const matchMediaMock = vi.fn().mockImplementation(() => ({
+  matches: false,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: matchMediaMock,
+    });
+  }
+  if (!("ResizeObserver" in window)) {
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    Object.defineProperty(window, "ResizeObserver", {
+      writable: true,
+      value: ResizeObserverStub,
+    });
+  }
+  vi.spyOn(window.URL, "revokeObjectURL").mockImplementation(() => {});
+  vi.spyOn(window.URL, "createObjectURL").mockImplementation(() => "blob:mock");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderExplorateurIA(props?: Partial<ActivityProps>) {
+  const mergedProps: ActivityProps = {
+    ...defaultActivityProps,
+    ...props,
+  } as ActivityProps;
+  return render(<ExplorateurIA {...mergedProps} />);
+}
+
+describe("Explorateur IA", () => {
+  it("permet de compléter le quartier Clarté et d'exporter les données", async () => {
+    const storedBlobs: Blob[] = [];
+    (window.URL.createObjectURL as unknown as vi.Mock).mockImplementation((blob: Blob) => {
+      storedBlobs.push(blob);
+      return "blob:mock";
+    });
+
+    const setStepSequence = vi.fn();
+    renderExplorateurIA({ setStepSequence });
+
+    vi.useFakeTimers();
+
+    const clarteButtons = await screen.findAllByRole("button", {
+      name: /Quartier Clarté/i,
+    });
+    fireEvent.click(clarteButtons[0]);
+
+    let continueButton = await screen.findByRole("button", { name: /Continuer/i });
+    fireEvent.click(continueButton);
+
+    continueButton = await screen.findByRole("button", { name: /Continuer/i });
+    fireEvent.click(continueButton);
+
+    const bestOption = await screen.findByRole("button", {
+      name: /Donne un plan en 5 sections sur l'énergie solaire/i,
+    });
+    fireEvent.click(bestOption);
+
+    const validateButton = await screen.findByRole("button", { name: /Valider/i });
+    fireEvent.click(validateButton);
+
+    vi.runAllTimers();
+    vi.useRealTimers();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /Valider/i })).not.toBeInTheDocument();
+    });
+
+    const progressionPanel = screen.getByText("Progression").closest("div");
+    expect(progressionPanel).not.toBeNull();
+    const progressionItems = within(progressionPanel as HTMLElement).getAllByRole("listitem");
+    const clarteItem = progressionItems.find((item) =>
+      within(item).queryByText(/Quartier Clarté/i)
+    );
+    expect(clarteItem).toBeDefined();
+    expect(within(clarteItem as HTMLElement).getByText("OK")).toBeInTheDocument();
+
+    const jsonButton = screen.getByRole("button", { name: /^JSON$/i });
+    fireEvent.click(jsonButton);
+
+    expect(storedBlobs).toHaveLength(1);
+    const exportText = await storedBlobs[0].text();
+    const exportData = JSON.parse(exportText);
+    expect(exportData.activity).toBe("Explorateur IA");
+    expect(exportData.quarters.clarte.details.score).toBe(100);
+    expect(exportData.quarters.clarte.details.selectedOptionId).toBe("B");
+    expect(exportData.quarters.clarte.payloads["clarte:quiz"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add custom Explorateur IA modules with a registry and world step definitions
- refactor the Explorateur IA activity to render quarter flows via StepSequenceRenderer with updated progress/export handling
- extend the step sequence renderer API and add a UI test covering the Clarté quarter and export

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d280349ef883229ffe89071c66f500