### PR TITLE
Fix SimulationChatStep chat bubble container class

### DIFF
--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -893,7 +893,6 @@ export function SimulationChatStep({
                 title="À toi de jouer"
                 roleLabel={roleLabels.user}
                 bubbleClassName="bg-white text-[color:var(--brand-black)] border border-[color:var(--brand-red)]/20 shadow-xl md:max-w-none"
-                containerClassName="w
                 containerClassName="w-full"
                 chipClassName="bg-[color:var(--brand-red)]/15 text-[color:var(--brand-red)]"
               >


### PR DESCRIPTION
## Summary
- fix the SimulationChatStep stage form ChatBubble to use a single containerClassName string

## Testing
- `npm run build` *(fails: missing dependency hls.js referenced by VideoStep.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ddfc3a748322a1662d24f19cc5e7