### PR TITLE
feat: add YouTube support to video step

### DIFF
--- a/frontend/src/modules/step-sequence/modules/VideoStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/VideoStep.tsx
@@ -14,7 +14,7 @@ import type Hls from "hls.js";
 import type { StepComponentProps } from "../types";
 import { StepSequenceContext } from "../types";
 
-export type VideoSourceType = "mp4" | "hls";
+export type VideoSourceType = "mp4" | "hls" | "youtube";
 
 export interface VideoSource {
   type: VideoSourceType;
@@ -58,7 +58,12 @@ function sanitizeSources(sources: unknown): VideoSource[] {
       }
       const source = item as Partial<VideoSource>;
       const url = typeof source.url === "string" ? source.url.trim() : "";
-      const type = source.type === "hls" ? "hls" : "mp4";
+      const type: VideoSourceType =
+        source.type === "hls"
+          ? "hls"
+          : source.type === "youtube"
+          ? "youtube"
+          : "mp4";
       if (!url) {
         return undefined;
       }
@@ -95,6 +100,61 @@ function sanitizeCaptions(captions: unknown): VideoCaption[] {
       } satisfies VideoCaption;
     })
     .filter((item): item is VideoCaption => Boolean(item));
+}
+
+function extractYouTubeVideoId(url: string): string | null {
+  if (!url) {
+    return null;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    return null;
+  }
+
+  const host = parsedUrl.hostname
+    .replace(/^www\./u, "")
+    .replace(/^m\./u, "")
+    .toLowerCase();
+
+  let videoId = "";
+  if (host === "youtu.be") {
+    videoId = parsedUrl.pathname.replace(/^\//u, "").split("/")[0] ?? "";
+  } else if (host === "youtube.com" || host === "youtube-nocookie.com") {
+    if (parsedUrl.pathname === "/watch") {
+      videoId = parsedUrl.searchParams.get("v") ?? "";
+    } else if (parsedUrl.pathname.startsWith("/embed/")) {
+      videoId = parsedUrl.pathname.split("/")[2] ?? "";
+    } else if (parsedUrl.pathname.startsWith("/shorts/")) {
+      videoId = parsedUrl.pathname.split("/")[2] ?? "";
+    } else if (parsedUrl.pathname.startsWith("/live/")) {
+      videoId = parsedUrl.pathname.split("/")[2] ?? "";
+    }
+  }
+
+  const trimmedId = videoId.trim();
+  if (!trimmedId) {
+    return null;
+  }
+
+  if (!/^[a-zA-Z0-9_-]{6,}$/u.test(trimmedId)) {
+    return null;
+  }
+
+  return trimmedId;
+}
+
+function getYouTubeEmbedUrl(url: string): string | null {
+  const videoId = extractYouTubeVideoId(url);
+  if (!videoId) {
+    return null;
+  }
+
+  const embedUrl = new URL(`https://www.youtube.com/embed/${videoId}`);
+  embedUrl.searchParams.set("rel", "0");
+  return embedUrl.toString();
 }
 
 function formatExpectedDuration(duration?: number): string | null {
@@ -175,6 +235,15 @@ export function VideoStep({
     () => content.sources.filter((source) => source.type === "mp4"),
     [content.sources]
   );
+  const youtubeSource = useMemo(
+    () => content.sources.find((source) => source.type === "youtube"),
+    [content.sources]
+  );
+  const youtubeSourceUrl = youtubeSource?.url ?? "";
+  const youtubeEmbedUrl = useMemo(
+    () => getYouTubeEmbedUrl(youtubeSourceUrl),
+    [youtubeSourceUrl]
+  );
   const mp4Signature = useMemo(
     () => mp4Sources.map((source) => source.url).join("|"),
     [mp4Sources]
@@ -189,6 +258,10 @@ export function VideoStep({
   );
 
   useEffect(() => {
+    if (youtubeEmbedUrl) {
+      return undefined;
+    }
+
     const video = videoRef.current;
     if (!video) {
       return undefined;
@@ -250,9 +323,14 @@ export function VideoStep({
         video.load();
       }
     };
-  }, [hlsSource, mp4Signature]);
+  }, [hlsSource, mp4Signature, youtubeEmbedUrl]);
 
   useEffect(() => {
+    if (youtubeEmbedUrl) {
+      setAutoplayFailed(false);
+      return;
+    }
+
     const video = videoRef.current;
     if (!video || isEditModeFromContext) {
       return;
@@ -314,13 +392,19 @@ export function VideoStep({
     isEditModeFromContext,
     mp4Sources.length,
     sourceSignature,
+    youtubeEmbedUrl,
   ]);
 
   useEffect(() => {
+    if (youtubeEmbedUrl) {
+      setAutoplayFailed(false);
+      return;
+    }
+
     if (!isActive || isEditModeFromContext) {
       setAutoplayFailed(false);
     }
-  }, [isActive, isEditModeFromContext, sourceSignature]);
+  }, [isActive, isEditModeFromContext, sourceSignature, youtubeEmbedUrl]);
 
   useEffect(() => {
     return () => {
@@ -395,11 +479,28 @@ export function VideoStep({
     [effectiveOnAdvance]
   );
 
+  const mp4SourceValue = useMemo(() => mp4Sources[0]?.url ?? "", [mp4Sources]);
+  const hlsSourceValue = hlsSource?.url ?? "";
+  const youtubeSourceValue = youtubeSource?.url ?? "";
+  const hasVideoElementSource =
+    !youtubeEmbedUrl && (mp4Sources.length > 0 || Boolean(hlsSource));
+  const isAutoAdvanceSupported = !youtubeEmbedUrl;
+  const showYouTubeError = Boolean(youtubeSource) && !youtubeEmbedUrl;
+
   const handleVideoEnded = useCallback(() => {
-    if (!isEditModeFromContext && content.autoAdvanceOnEnd) {
+    if (
+      !isEditModeFromContext &&
+      content.autoAdvanceOnEnd &&
+      isAutoAdvanceSupported
+    ) {
       effectiveOnAdvance();
     }
-  }, [content.autoAdvanceOnEnd, effectiveOnAdvance, isEditModeFromContext]);
+  }, [
+    content.autoAdvanceOnEnd,
+    effectiveOnAdvance,
+    isAutoAdvanceSupported,
+    isEditModeFromContext,
+  ]);
 
   const handleVideoPlay = useCallback(() => {
     setAutoplayFailed(false);
@@ -409,9 +510,6 @@ export function VideoStep({
     () => formatExpectedDuration(content.expectedDuration),
     [content.expectedDuration]
   );
-
-  const mp4SourceValue = useMemo(() => mp4Sources[0]?.url ?? "", [mp4Sources]);
-  const hlsSourceValue = hlsSource?.url ?? "";
 
   return (
     <div className="space-y-6">
@@ -425,7 +523,17 @@ export function VideoStep({
           ) : null}
         </header>
         <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
-          {content.sources.length ? (
+          {youtubeEmbedUrl ? (
+            <div className="relative aspect-video w-full overflow-hidden rounded-md bg-black">
+              <iframe
+                className="absolute left-0 top-0 h-full w-full"
+                src={youtubeEmbedUrl}
+                title="Vidéo YouTube"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+              />
+            </div>
+          ) : hasVideoElementSource ? (
             <video
               ref={videoRef}
               className="h-auto w-full rounded-md bg-black"
@@ -452,11 +560,13 @@ export function VideoStep({
             </video>
           ) : (
             <div className="rounded-md border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
-              Ajoutez une source vidéo pour commencer la lecture.
+              {showYouTubeError
+                ? "Impossible d’interpréter l’URL YouTube fournie. Vérifiez qu’elle est correcte."
+                : "Ajoutez une source vidéo pour commencer la lecture."}
             </div>
           )}
         </div>
-        {autoplayFailed ? (
+        {autoplayFailed && !youtubeEmbedUrl ? (
           <div className="flex items-center gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
             <span>
               La lecture automatique est bloquée par le navigateur.
@@ -487,6 +597,18 @@ export function VideoStep({
             />
           </label>
           <label className="block space-y-1 text-sm">
+            <span className="font-medium text-slate-700">URL YouTube</span>
+            <input
+              className="w-full rounded-md border border-slate-300 p-2"
+              placeholder="https://www.youtube.com/watch?v=abcdefghijk"
+              value={youtubeSourceValue}
+              onChange={handleSourceChange("youtube")}
+            />
+            <span className="block text-xs text-slate-500">
+              Les liens « watch », youtu.be, shorts ou embed sont pris en charge.
+            </span>
+          </label>
+          <label className="block space-y-1 text-sm">
             <span className="font-medium text-slate-700">URL HLS</span>
             <input
               className="w-full rounded-md border border-slate-300 p-2"
@@ -509,9 +631,15 @@ export function VideoStep({
               type="checkbox"
               checked={content.autoAdvanceOnEnd ?? false}
               onChange={handleAutoAdvanceChange}
+              disabled={!isAutoAdvanceSupported}
             />
             <span>Passer automatiquement à l’étape suivante en fin de vidéo</span>
           </label>
+          {!isAutoAdvanceSupported ? (
+            <p className="text-xs text-slate-500">
+              L’avance automatique n’est pas disponible pour les vidéos YouTube.
+            </p>
+          ) : null}
           <label className="block space-y-1 text-sm">
             <span className="font-medium text-slate-700">
               Durée attendue (secondes)


### PR DESCRIPTION
## Summary
- add a YouTube source type to the video module and normalize supported URLs
- render embedded YouTube players while keeping the existing mp4/hls flow intact
- update the editor controls with a YouTube field and disable auto-advance when unsupported

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e1dd69048322948a971111a0921b