### PR TITLE
Allow removing activities from catalog

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -327,8 +327,9 @@ def _normalize_activities_payload(
 
 def _load_activities_config() -> dict[str, Any]:
     """Charge la configuration des activités depuis le fichier ou retourne la configuration par défaut."""
-    if not ACTIVITIES_CONFIG_PATH.exists():
-        return {"activities": []}
+    uses_default_fallback = not ACTIVITIES_CONFIG_PATH.exists()
+    if uses_default_fallback:
+        return {"activities": [], "usesDefaultFallback": True}
 
     try:
         with ACTIVITIES_CONFIG_PATH.open("r", encoding="utf-8") as handle:
@@ -365,7 +366,7 @@ def _load_activities_config() -> dict[str, Any]:
 
     activities = _normalize_activities_payload(activities, error_status=500)
 
-    config: dict[str, Any] = {"activities": activities}
+    config: dict[str, Any] = {"activities": activities, "usesDefaultFallback": uses_default_fallback}
     if activity_selector_header is not None:
         config["activitySelectorHeader"] = activity_selector_header
 
@@ -724,7 +725,7 @@ class ActivityPayload(BaseModel):
 class ActivityConfigRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
 
-    activities: list[ActivityPayload] = Field(..., min_items=1)
+    activities: list[ActivityPayload] = Field(..., min_items=0)
     activity_selector_header: ActivitySelectorHeader | None = Field(
         default=None, alias="activitySelectorHeader"
     )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -343,7 +343,9 @@ export interface ActivityConfig {
   activitySelectorHeader?: ActivitySelectorHeaderConfig;
 }
 
-export interface ActivityConfigResponse extends ActivityConfig {}
+export interface ActivityConfigResponse extends ActivityConfig {
+  usesDefaultFallback?: boolean;
+}
 
 export interface SaveActivityConfigResponse {
   ok: boolean;


### PR DESCRIPTION
## Summary
- allow the activities configuration endpoint to accept empty lists and expose whether the defaults are used
- update the activity selector admin UI to support removing activities and respect saved deletions
- add regression coverage ensuring empty configurations persist through the API

## Testing
- pytest backend/tests/test_admin_activities_config.py
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2e344a1388322ad64193660440261