### PR TITLE
feat: add composite step orchestration

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -15,7 +15,12 @@ import { useAdminAuth } from "../providers/AdminAuthProvider";
 import ClarityPath from "../pages/ClarityPath";
 import ClarteDabord from "../pages/ClarteDabord";
 import PromptDojo from "../pages/PromptDojo";
-import { StepSequenceActivity, type StepDefinition } from "../modules/step-sequence";
+import {
+  StepSequenceActivity,
+  isCompositeStepDefinition,
+  resolveStepComponentKey,
+  type StepDefinition,
+} from "../modules/step-sequence";
 import type { ModelConfig } from "../config";
 const LazyExplorateurIA = lazy(() => import("../pages/ExplorateurIA"));
 
@@ -596,11 +601,24 @@ function stepDefinitionsEqual(
   a: StepDefinition,
   b: StepDefinition
 ): boolean {
-  return (
-    a.id === b.id &&
-    a.component === b.component &&
-    configsEqual(a.config, b.config)
-  );
+  if (a.id !== b.id) {
+    return false;
+  }
+
+  const componentA = resolveStepComponentKey(a);
+  const componentB = resolveStepComponentKey(b);
+  if (componentA !== componentB) {
+    return false;
+  }
+
+  if (isCompositeStepDefinition(a) || isCompositeStepDefinition(b)) {
+    if (!isCompositeStepDefinition(a) || !isCompositeStepDefinition(b)) {
+      return false;
+    }
+    return configsEqual(a.composite, b.composite);
+  }
+
+  return configsEqual(a.config, b.config);
 }
 
 function diffStepSequence(

--- a/frontend/src/modules/step-sequence/README.md
+++ b/frontend/src/modules/step-sequence/README.md
@@ -55,6 +55,37 @@ function ConfirmationStep() {
 }
 ```
 
+## Étapes composites
+
+Le composant `composite` permet d’orchestrer plusieurs modules d’étape au sein d’une même vue tout en agrégant leurs `payloads`.
+
+```tsx
+import type { CompositeStepConfig } from "@/modules/step-sequence";
+
+const recapConfig: CompositeStepConfig = {
+  modules: [
+    { id: "context", component: "rich-content" },
+    { id: "feedback", component: "form", slot: "sidebar" },
+  ],
+};
+
+const steps = [
+  { id: "recap", composite: recapConfig },
+];
+```
+
+Chaque entrée de `modules[]` doit fournir un `id` unique et la clé `component` enregistrée dans le registre. Les propriétés optionnelles sont :
+
+- `slot`: positionne le module dans la mise en page (`"main"` par défaut, `"sidebar"` pour la colonne latérale, `"footer"` pour un bloc plein largeur sous le contenu principal).
+- `config`: configuration spécifique transmise au sous-module concerné.
+
+Le composite expose aux sous-modules un contexte StepSequence complet, mais intercepte leurs appels `onAdvance` afin de stocker les `payloads` localement (sous la forme `{ [moduleId]: payload }`).
+
+Deux comportements sont possibles pour finaliser l’étape :
+
+- `autoAdvance: true` : l’étape est validée automatiquement lorsque tous les sous-modules ont déclenché `onAdvance`.
+- par défaut, un bouton « Continuer » est affiché et fusionne les `payloads` des modules avant de quitter l’étape.
+
 ## Activité clé en main
 
 Le module expose également un composant `StepSequenceActivity` utilisable via le registre global des activités. Il attend une configuration de métadonnées respectant la forme suivante :

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -48,6 +48,9 @@ export {
 
 export * from "./modules";
 
+export { isCompositeStepDefinition, resolveStepComponentKey } from "./types";
+export type { CompositeStepConfig, CompositeStepModuleDefinition } from "./types";
+
 export type {
   StepSequenceActivityConfig,
   StepSequenceActivityProps,

--- a/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
@@ -1,0 +1,272 @@
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { getStepComponent } from "../registry";
+import { StepSequenceContext, isCompositeStepDefinition } from "../types";
+import type {
+  CompositeStepConfig,
+  CompositeStepModuleDefinition,
+  StepComponentProps,
+  StepDefinition,
+  StepSequenceContextValue,
+} from "../types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCompositeConfig(value: unknown): value is CompositeStepConfig {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (!Array.isArray((value as CompositeStepConfig).modules)) {
+    return false;
+  }
+  return (value as CompositeStepConfig).modules.every((module) => {
+    if (!module || typeof module !== "object") {
+      return false;
+    }
+    const typed = module as CompositeStepModuleDefinition;
+    return typeof typed.id === "string" && typeof typed.component === "string";
+  });
+}
+
+function pickInitialPayloads(
+  modules: CompositeStepModuleDefinition[],
+  payload: unknown
+): Record<string, unknown> {
+  if (!isRecord(payload)) {
+    return {};
+  }
+  const typedPayload = payload as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  modules.forEach((module) => {
+    if (Object.prototype.hasOwnProperty.call(typedPayload, module.id)) {
+      result[module.id] = typedPayload[module.id];
+    }
+  });
+  return result;
+}
+
+export function CompositeStep({
+  definition,
+  config,
+  payload,
+  isActive,
+  isEditMode,
+  onAdvance,
+  onUpdateConfig,
+}: StepComponentProps): JSX.Element | null {
+  const parentContext = useContext(StepSequenceContext);
+
+  const compositeConfig = useMemo(() => {
+    if (isCompositeConfig(config)) {
+      return config;
+    }
+    if (isCompositeStepDefinition(definition) && isCompositeConfig(definition.composite)) {
+      return definition.composite;
+    }
+    return undefined;
+  }, [config, definition]);
+
+  if (!compositeConfig) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Composite step "${definition.id}" is missing a valid configuration.`
+      );
+    }
+    return null;
+  }
+
+  const modules = compositeConfig.modules ?? [];
+  const [modulePayloads, setModulePayloads] = useState<Record<string, unknown>>(
+    () => pickInitialPayloads(modules, payload)
+  );
+
+  useEffect(() => {
+    setModulePayloads(pickInitialPayloads(modules, payload));
+  }, [modules, payload]);
+
+  const effectiveIsEditMode = parentContext?.isEditMode ?? isEditMode;
+
+  const handleModuleAdvance = useCallback(
+    (moduleId: string, modulePayload?: unknown) => {
+      setModulePayloads((previous) => ({
+        ...previous,
+        [moduleId]: modulePayload,
+      }));
+    },
+    []
+  );
+
+  const updateModuleConfig = useCallback(
+    (moduleId: string, nextModuleConfig: unknown) => {
+      if (!compositeConfig) {
+        return;
+      }
+      const nextConfig: CompositeStepConfig = {
+        ...compositeConfig,
+        modules: compositeConfig.modules.map((module) =>
+          module.id === moduleId ? { ...module, config: nextModuleConfig } : module
+        ),
+      };
+      onUpdateConfig(nextConfig);
+    },
+    [compositeConfig, onUpdateConfig]
+  );
+
+  const allModulesCompleted = useMemo(
+    () =>
+      modules.every((module) =>
+        Object.prototype.hasOwnProperty.call(modulePayloads, module.id)
+      ),
+    [modulePayloads, modules]
+  );
+
+  const autoAdvance = compositeConfig.autoAdvance ?? false;
+
+  useEffect(() => {
+    if (!autoAdvance || !isActive) {
+      return;
+    }
+    if (modules.length === 0 || allModulesCompleted) {
+      onAdvance(modulePayloads);
+    }
+  }, [autoAdvance, allModulesCompleted, isActive, modulePayloads, modules, onAdvance]);
+
+  const renderedModules = useMemo(() => {
+    return modules.map((module) => {
+      const StepComponent = getStepComponent(module.component);
+      if (!StepComponent) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `Composite step cannot resolve module "${module.component}".`
+          );
+        }
+        return { module, element: null } as const;
+      }
+
+      const moduleDefinition: StepDefinition = {
+        id: module.id,
+        component: module.component,
+        config: module.config,
+      };
+
+      const childContext: StepSequenceContextValue = parentContext
+        ? {
+            ...parentContext,
+            payloads: {
+              ...parentContext.payloads,
+              [module.id]: modulePayloads[module.id],
+            },
+            onAdvance: (childPayload?: unknown) =>
+              handleModuleAdvance(module.id, childPayload),
+            onUpdateConfig: (nextConfig: unknown) =>
+              updateModuleConfig(module.id, nextConfig),
+          }
+        : {
+            stepIndex: 0,
+            stepCount: modules.length,
+            steps: modules.map((item) => ({
+              id: item.id,
+              component: item.component,
+              config: item.config,
+            })),
+            payloads: { [module.id]: modulePayloads[module.id] },
+            isEditMode: effectiveIsEditMode,
+            onAdvance: (childPayload?: unknown) =>
+              handleModuleAdvance(module.id, childPayload),
+            onUpdateConfig: (nextConfig: unknown) =>
+              updateModuleConfig(module.id, nextConfig),
+            goToStep: () => {},
+            activityContext: null,
+          };
+
+      const moduleProps: StepComponentProps = {
+        definition: moduleDefinition,
+        config: module.config,
+        payload: modulePayloads[module.id],
+        isActive,
+        isEditMode: effectiveIsEditMode,
+        onAdvance: (childPayload?: unknown) =>
+          handleModuleAdvance(module.id, childPayload),
+        onUpdateConfig: (nextConfig: unknown) =>
+          updateModuleConfig(module.id, nextConfig),
+      };
+
+      return {
+        module,
+        element: (
+          <StepSequenceContext.Provider
+            key={module.id}
+            value={childContext}
+          >
+            <StepComponent {...moduleProps} />
+          </StepSequenceContext.Provider>
+        ),
+      } as const;
+    });
+  }, [
+    effectiveIsEditMode,
+    handleModuleAdvance,
+    isActive,
+    modules,
+    modulePayloads,
+    parentContext,
+    updateModuleConfig,
+  ]);
+
+  const partitioned = useMemo(() => {
+    const main: JSX.Element[] = [];
+    const sidebar: JSX.Element[] = [];
+    const footer: JSX.Element[] = [];
+    renderedModules.forEach(({ module, element }) => {
+      if (!element) return;
+      if (module.slot === "sidebar") {
+        sidebar.push(element);
+      } else if (module.slot === "footer") {
+        footer.push(element);
+      } else {
+        main.push(element);
+      }
+    });
+    return { main, sidebar, footer };
+  }, [renderedModules]);
+
+  const continueLabel = compositeConfig.continueLabel ?? "Continuer";
+
+  return (
+    <div className="space-y-6">
+      {partitioned.sidebar.length > 0 ? (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+          <div className="space-y-6">{partitioned.main}</div>
+          <aside className="space-y-6">{partitioned.sidebar}</aside>
+        </div>
+      ) : (
+        <div className="space-y-6">{partitioned.main}</div>
+      )}
+      {partitioned.footer.length > 0 ? (
+        <div className="space-y-6">{partitioned.footer}</div>
+      ) : null}
+      {!autoAdvance && modules.length > 0 ? (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => onAdvance(modulePayloads)}
+            disabled={!allModulesCompleted}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-[color:var(--brand-black)] px-5 py-2 text-sm font-semibold text-white transition hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {continueLabel}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/modules/step-sequence/modules/index.ts
+++ b/frontend/src/modules/step-sequence/modules/index.ts
@@ -1,5 +1,6 @@
 import { registerStepComponent } from "../registry";
 
+import { CompositeStep } from "./CompositeStep";
 import { FormStep } from "./FormStep";
 import { RichContentStep } from "./RichContentStep";
 import { SimulationChatStep } from "./SimulationChatStep";
@@ -36,6 +37,7 @@ import type {
   VideoSourceType,
 } from "./VideoStep";
 
+registerStepComponent("composite", CompositeStep);
 registerStepComponent("form", FormStep);
 registerStepComponent("rich-content", RichContentStep);
 registerStepComponent("simulation-chat", SimulationChatStep);
@@ -51,6 +53,8 @@ registerStepComponent("prompt-evaluation", PromptEvaluationStep);
  * @property sidebar Bloc optionnel situé dans la colonne latérale (astuces ou checklist).
  * @property onChange Callback déclenché en mode édition à chaque modification des champs.
  */
+export type { CompositeStepConfig, CompositeStepModuleDefinition } from "../types";
+export { CompositeStep };
 export type { FormStepConfig, FormStepValidationFn };
 export {
   FormStep,

--- a/frontend/src/modules/step-sequence/types.ts
+++ b/frontend/src/modules/step-sequence/types.ts
@@ -1,10 +1,55 @@
 import { createContext } from "react";
 import type { ComponentType } from "react";
 
-export interface StepDefinition {
+export interface CompositeStepModuleDefinition {
+  id: string;
+  component: string;
+  slot?: string;
+  config?: unknown;
+}
+
+export interface CompositeStepConfig {
+  modules: CompositeStepModuleDefinition[];
+  autoAdvance?: boolean;
+  continueLabel?: string;
+}
+
+export interface ComponentStepDefinition {
   id: string;
   component: string;
   config?: unknown;
+  composite?: never;
+}
+
+export interface CompositeStepDefinition {
+  id: string;
+  component?: string;
+  config?: unknown;
+  composite: CompositeStepConfig;
+}
+
+export type StepDefinition =
+  | ComponentStepDefinition
+  | CompositeStepDefinition;
+
+export function isCompositeStepDefinition(
+  step: StepDefinition
+): step is CompositeStepDefinition {
+  return (
+    typeof step === "object" &&
+    step !== null &&
+    "composite" in step &&
+    typeof step.composite !== "undefined"
+  );
+}
+
+export function resolveStepComponentKey(
+  step: StepDefinition
+): string | undefined {
+  if (isCompositeStepDefinition(step)) {
+    return step.component ?? "composite";
+  }
+  return step.component;
 }
 
 export interface StepComponentProps {

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -26,6 +26,9 @@ import {
   getStepComponent,
   STEP_COMPONENT_REGISTRY,
   StepSequenceContext,
+  isCompositeStepDefinition,
+  resolveStepComponentKey,
+  type CompositeStepConfig,
   type StepDefinition,
 } from "../modules/step-sequence";
 import "../modules/step-sequence/modules";
@@ -37,6 +40,7 @@ const ADMIN_ROLES = ["admin", "superadmin", "administrator"];
 const STEP_SEQUENCE_COMPONENT_KEY = "step-sequence";
 
 const STEP_TYPE_LABELS: Record<string, string> = {
+  composite: "Étape composite",
   form: "Formulaire",
   "rich-content": "Contenu riche",
   video: "Vidéo",
@@ -140,7 +144,11 @@ function StepSequenceStepCard({
   onChangeType,
   onUpdateConfig,
 }: StepSequenceStepCardProps): JSX.Element {
-  const StepComponent = useMemo(() => getStepComponent(step.component), [step.component]);
+  const componentKey = resolveStepComponentKey(step);
+  const StepComponent = useMemo(
+    () => (componentKey ? getStepComponent(componentKey) : undefined),
+    [componentKey]
+  );
 
   const handleTypeChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
@@ -159,11 +167,16 @@ function StepSequenceStepCard({
   const contextValue = useMemo(
     () => ({
       stepIndex: 0,
+      stepCount: 1,
+      steps: [step],
+      payloads: {},
       isEditMode: true,
       onAdvance: NOOP,
       onUpdateConfig: handleConfigUpdate,
+      goToStep: () => {},
+      activityContext: null,
     }),
-    [handleConfigUpdate]
+    [handleConfigUpdate, step]
   );
 
   return (
@@ -204,7 +217,7 @@ function StepSequenceStepCard({
         <label className="flex flex-col gap-1 text-xs font-semibold text-orange-700">
           Type d'étape
           <select
-            value={step.component}
+            value={componentKey ?? ""}
             onChange={handleTypeChange}
             className="rounded-lg border border-orange-200 px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-orange-400 focus:outline-none"
           >
@@ -220,7 +233,7 @@ function StepSequenceStepCard({
             <StepSequenceContext.Provider value={contextValue}>
               <StepComponent
                 definition={step}
-                config={step.config}
+                config={isCompositeStepDefinition(step) ? step.composite : step.config}
                 payload={undefined}
                 isActive
                 isEditMode
@@ -230,7 +243,7 @@ function StepSequenceStepCard({
             </StepSequenceContext.Provider>
           ) : (
             <p className="text-sm text-orange-700">
-              Aucun composant enregistré pour « {step.component} ».
+              Aucun composant enregistré pour « {componentKey ?? "inconnu"} ».
             </p>
           )}
         </div>
@@ -718,12 +731,20 @@ function ActivitySelector(): JSX.Element {
           while (existingIds.has(stepId)) {
             stepId = generateUniqueId("step");
           }
+          const nextStep: StepDefinition =
+            component === "composite"
+              ? {
+                  id: stepId,
+                  component,
+                  composite: { modules: [] },
+                }
+              : {
+                  id: stepId,
+                  component,
+                };
           const nextSteps: StepDefinition[] = [
             ...baseSteps.map((step) => ({ ...step })),
-            {
-              id: stepId,
-              component,
-            },
+            nextStep,
           ];
           return {
             ...activity,
@@ -809,8 +830,18 @@ function ActivitySelector(): JSX.Element {
               return { ...step };
             }
             updated = true;
+            if (component === "composite") {
+              const existingComposite = isCompositeStepDefinition(step)
+                ? step.composite
+                : undefined;
+              return {
+                id: step.id,
+                component,
+                composite: existingComposite ?? { modules: [] },
+              };
+            }
             return {
-              ...step,
+              id: step.id,
               component,
               config: undefined,
             };
@@ -844,6 +875,12 @@ function ActivitySelector(): JSX.Element {
               return { ...step };
             }
             updated = true;
+            if (isCompositeStepDefinition(step)) {
+              return {
+                ...step,
+                composite: (config as CompositeStepConfig) ?? { modules: [] },
+              };
+            }
             return {
               ...step,
               config,

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -1,4 +1,7 @@
-import type { StepDefinition } from "../../../../modules/step-sequence";
+import {
+  isCompositeStepDefinition,
+  type StepDefinition,
+} from "../../../../modules/step-sequence";
 
 import {
   DEFAULT_CLARTE_QUIZ_CONFIG,
@@ -29,6 +32,12 @@ function cloneConfig<T>(value: T): T {
 }
 
 function cloneStep(step: StepDefinition): StepDefinition {
+  if (isCompositeStepDefinition(step)) {
+    return {
+      ...step,
+      composite: cloneConfig(step.composite),
+    };
+  }
   return {
     ...step,
     config: step.config ? cloneConfig(step.config) : undefined,

--- a/frontend/tests/step-sequence/CompositeStep.test.tsx
+++ b/frontend/tests/step-sequence/CompositeStep.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, beforeEach, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { StepSequenceRenderer } from "../../src/modules/step-sequence/StepSequenceRenderer";
+import {
+  STEP_COMPONENT_REGISTRY,
+  registerStepComponent,
+} from "../../src/modules/step-sequence/registry";
+import { CompositeStep } from "../../src/modules/step-sequence/modules/CompositeStep";
+import type { StepComponentProps } from "../../src/modules/step-sequence/types";
+
+describe("CompositeStep", () => {
+  beforeEach(() => {
+    Object.keys(STEP_COMPONENT_REGISTRY).forEach((key) => {
+      delete STEP_COMPONENT_REGISTRY[key];
+    });
+    registerStepComponent("composite", CompositeStep);
+  });
+
+  function createTestModule(
+    label: string,
+    payload: unknown
+  ): (props: StepComponentProps) => JSX.Element {
+    return function TestModule({ onAdvance }: StepComponentProps) {
+      return (
+        <button type="button" onClick={() => onAdvance(payload)}>
+          {label}
+        </button>
+      );
+    };
+  }
+
+  it("renders child modules and aggregates their payloads", () => {
+    registerStepComponent("module-a", createTestModule("Module A", { ready: true }));
+    registerStepComponent("module-b", createTestModule("Module B", { done: true }));
+
+    const handleComplete = vi.fn();
+
+    render(
+      <StepSequenceRenderer
+        steps={[
+          {
+            id: "composite-step",
+            composite: {
+              modules: [
+                { id: "module-a", component: "module-a" },
+                { id: "module-b", component: "module-b" },
+              ],
+            },
+          },
+        ]}
+        onComplete={handleComplete}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Module A" }));
+    fireEvent.click(screen.getByRole("button", { name: "Module B" }));
+
+    const continueButton = screen.getByRole("button", { name: "Continuer" });
+    expect(continueButton).toHaveProperty("disabled", false);
+
+    fireEvent.click(continueButton);
+
+    expect(handleComplete).toHaveBeenCalledTimes(1);
+    expect(handleComplete).toHaveBeenCalledWith({
+      "composite-step": {
+        "module-a": { ready: true },
+        "module-b": { done: true },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend step sequence types and renderer to support composite step definitions
- add a CompositeStep module that hosts sub-modules, merges their payloads and optionally auto-advances
- update editors, activity integration and documentation, and cover the new flow with a Vitest scenario

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33d6171b88322aaeefc65f2be4911