### PR TITLE
Connect clarity map step to AI plan execution

### DIFF
--- a/frontend/tests/step-sequence/ClarityMapStep.test.tsx
+++ b/frontend/tests/step-sequence/ClarityMapStep.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   STEP_COMPONENT_REGISTRY,
@@ -14,8 +14,27 @@ import {
 import { START_POSITION } from "../../src/modules/clarity";
 import type { GridCoord } from "../../src/modules/clarity";
 
+const encoder = new TextEncoder();
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: async () => ({ done: true, value: encoder.encode("") }),
+          }),
+        },
+      } as unknown as Response)
+    )
+  );
+});
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("ClarityMapStep", () => {


### PR DESCRIPTION
## Summary
- extend the clarity map step payload to include AI plan metadata and sanitizers
- trigger plan generation via useClarityPlanExecution with automatic publishing and replay controls
- stub fetch in the ClarityMapStep tests to keep unit tests deterministic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52a573fbc8322a6ac32bdfca11c8e