### PR TITLE
Connect clarity map step to AI plan execution

### DIFF
--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -99,14 +99,38 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
 export interface PlanPreviewProps {
   plan: PlanAction[];
   notes: string;
+  tone?: "light" | "dark";
 }
 
-export function PlanPreview({ plan, notes }: PlanPreviewProps): JSX.Element {
+export function PlanPreview({ plan, notes, tone = "light" }: PlanPreviewProps): JSX.Element {
+  const isDark = tone === "dark";
+  const containerClass = isDark
+    ? "rounded-3xl border border-white/40 bg-[color:var(--brand-charcoal)]/30 p-6 shadow-inner"
+    : "rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm";
+  const emptyContainerClass = isDark
+    ? "rounded-3xl border border-white/40 bg-[color:var(--brand-charcoal)]/25 p-6 shadow-inner"
+    : "rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm";
+  const headingClass = isDark
+    ? "text-lg font-semibold text-white"
+    : "text-lg font-semibold text-[color:var(--brand-black)]";
+  const textClass = isDark
+    ? "text-sm text-white/80"
+    : "text-sm text-[color:var(--brand-charcoal)]";
+  const badgeClass = isDark
+    ? "flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/30 bg-white/10 text-xs font-semibold text-white"
+    : "flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-xs font-semibold text-[color:var(--brand-red)]";
+  const noteClass = isDark
+    ? "mt-4 rounded-2xl border border-white/20 bg-black/30 p-3 text-xs text-white/85"
+    : "mt-4 rounded-2xl bg-[color:var(--brand-yellow)]/30 p-3 text-xs text-[color:var(--brand-charcoal)]";
+  const emptyTextClass = isDark
+    ? "mt-2 text-sm text-white/75"
+    : "mt-2 text-sm text-[color:var(--brand-charcoal)]/80";
+
   if (!plan.length && !notes) {
     return (
-      <div className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm">
-        <h3 className="text-lg font-semibold text-[color:var(--brand-black)]">Plan</h3>
-        <p className="mt-2 text-sm text-[color:var(--brand-charcoal)]/80">
+      <div className={emptyContainerClass}>
+        <h3 className={headingClass}>Plan</h3>
+        <p className={emptyTextClass}>
           Le plan validé apparaîtra ici dès que le backend aura converti ta consigne.
         </p>
       </div>
@@ -114,25 +138,19 @@ export function PlanPreview({ plan, notes }: PlanPreviewProps): JSX.Element {
   }
 
   return (
-    <div className="rounded-3xl border border-white/60 bg-white/90 p-6 shadow-sm">
-      <h3 className="text-lg font-semibold text-[color:var(--brand-black)]">Plan validé</h3>
-      <ol className="mt-4 space-y-2 text-sm text-[color:var(--brand-charcoal)]">
+    <div className={containerClass}>
+      <h3 className={headingClass}>Plan validé</h3>
+      <ol className={`mt-4 space-y-2 ${textClass}`}>
         {plan.map((action, index) => (
           <li key={`${action.dir}-${index}`} className="flex items-center gap-3">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-xs font-semibold text-[color:var(--brand-red)]">
-              {index + 1}
-            </span>
+            <span className={badgeClass}>{index + 1}</span>
             <span>
               {DIRECTION_LABELS[action.dir]} · {action.steps} pas
             </span>
           </li>
         ))}
       </ol>
-      {notes && (
-        <p className="mt-4 rounded-2xl bg-[color:var(--brand-yellow)]/30 p-3 text-xs text-[color:var(--brand-charcoal)]">
-          Hypothèse du modèle : {notes}
-        </p>
-      )}
+      {notes && <p className={noteClass}>Hypothèse du modèle : {notes}</p>}
     </div>
   );
 }

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -398,6 +398,7 @@ export function ClarityMapStep({
   const sequenceContext = useContext(StepSequenceContext);
   const activeStepId = sequenceContext?.steps?.[sequenceContext.stepIndex]?.id;
   const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
+  const allowManualSubmit = isEditMode || !shouldAutoPublish;
   const sequencePayloads = sequenceContext?.payloads ?? null;
   const compositeModules = sequenceContext?.compositeModules ?? null;
 
@@ -705,7 +706,7 @@ export function ClarityMapStep({
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      if (shouldAutoPublish) {
+      if (!allowManualSubmit) {
         return;
       }
 
@@ -724,7 +725,7 @@ export function ClarityMapStep({
         void triggerExecution({ force: true }).catch(() => {});
       }
     },
-    [blocked, onAdvance, runId, shouldAutoPublish, target, trimmedInstruction, triggerExecution]
+    [allowManualSubmit, blocked, onAdvance, runId, target, trimmedInstruction, triggerExecution]
   );
 
   useEffect(() => {
@@ -830,13 +831,13 @@ export function ClarityMapStep({
     <form className="space-y-6" onSubmit={handleSubmit}>
       {isEditMode && (
         <div className="space-y-4">
-          <fieldset className="rounded-2xl border border-dashed border-white/40 bg-[color:var(--brand-charcoal)]/20 p-4 text-sm text-white/80">
-            <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-white/70">
+          <fieldset className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-[color:var(--brand-charcoal)]">
+            <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
               Configuration
             </legend>
             <div className="mt-2 grid gap-4 md:grid-cols-2">
               <label className="flex flex-col gap-1">
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                   Obstacles
                 </span>
                 <input
@@ -845,11 +846,11 @@ export function ClarityMapStep({
                   max={MAX_OBSTACLE_COUNT}
                   value={obstacleCount}
                   onChange={handleObstacleCountChange}
-                  className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
                 />
               </label>
               <label className="flex flex-col gap-1">
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                   Étape prompt liée
                 </span>
                 <input
@@ -857,15 +858,15 @@ export function ClarityMapStep({
                   value={normalizedConfig.promptStepId}
                   onChange={handlePromptIdChange}
                   placeholder="ID du module prompt"
-                  className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                  className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
                 />
-                <span className="text-xs text-white/60">
+                <span className="text-xs text-[color:var(--brand-charcoal)]/70">
                   Laisse vide pour relier automatiquement le module prompt du composite.
                 </span>
               </label>
               <div className="grid grid-cols-2 gap-3">
                 <label className="flex flex-col gap-1">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                     Cible X
                   </span>
                   <input
@@ -875,11 +876,11 @@ export function ClarityMapStep({
                     value={targetFromConfig ? targetFromConfig.x : ""}
                     onChange={handleTargetFieldChange("x")}
                     placeholder="auto"
-                    className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                    className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
                   />
                 </label>
                 <label className="flex flex-col gap-1">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                     Cible Y
                   </span>
                   <input
@@ -889,7 +890,7 @@ export function ClarityMapStep({
                     value={targetFromConfig ? targetFromConfig.y : ""}
                     onChange={handleTargetFieldChange("y")}
                     placeholder="auto"
-                    className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                    className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
                   />
                 </label>
               </div>
@@ -898,20 +899,20 @@ export function ClarityMapStep({
                   type="checkbox"
                   checked={normalizedConfig.allowInstructionInput}
                   onChange={handleAllowInputToggle}
-                  className="h-4 w-4 rounded border-white/50 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+                  className="h-4 w-4 rounded border-gray-400 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
                 />
-                <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                   Autoriser la saisie manuelle
                 </span>
               </label>
             </div>
           </fieldset>
-          <div className="rounded-2xl border border-white/30 bg-black/30 p-4 text-xs text-white/80">
+          <div className="rounded-2xl border border-gray-300 bg-gray-50 p-4 text-xs text-[color:var(--brand-charcoal)]">
             <div className="flex items-center justify-between gap-3">
               <span className="font-semibold uppercase tracking-wide">Aperçu structured output</span>
-              <span className="text-[10px] uppercase tracking-[0.2em] text-white/40">Lecture seule</span>
+              <span className="text-[10px] uppercase tracking-[0.2em] text-[color:var(--brand-charcoal)]/60">Lecture seule</span>
             </div>
-            <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-black/40 p-3 text-[11px] leading-relaxed text-white/80">
+            <pre className="mt-3 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-gray-50 p-3 text-[11px] leading-relaxed text-[color:var(--brand-charcoal)]">
               {structuredRequestPreview}
             </pre>
           </div>
@@ -920,21 +921,21 @@ export function ClarityMapStep({
 
       <div className="grid gap-6 lg:grid-cols-[3fr,2fr]">
         <div className="space-y-4">
-          <div className="rounded-3xl border border-white/40 bg-[color:var(--brand-charcoal)]/25 p-4 shadow-inner backdrop-blur">
+          <div className="rounded-3xl border border-gray-300 bg-gray-100 p-4 shadow-inner backdrop-blur">
             <ClarityGrid player={START_POSITION} target={target} blocked={blocked} visited={visited} />
           </div>
           <div className="flex flex-wrap gap-3">
             <button
               type="button"
               onClick={handleShuffleTarget}
-              className="inline-flex items-center justify-center rounded-full border border-white/40 bg-[color:var(--brand-charcoal)]/30 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[color:var(--brand-charcoal)]/45"
+              className="inline-flex items-center justify-center rounded-full border border-gray-300 bg-gray-100 px-4 py-2 text-sm font-semibold text-[color:var(--brand-charcoal)] shadow-sm transition hover:bg-gray-200"
             >
               Nouvelle cible
             </button>
             <button
               type="button"
               onClick={handleShuffleObstacles}
-              className="inline-flex items-center justify-center rounded-full border border-white/40 bg-[color:var(--brand-charcoal)]/30 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[color:var(--brand-charcoal)]/45"
+              className="inline-flex items-center justify-center rounded-full border border-gray-300 bg-gray-100 px-4 py-2 text-sm font-semibold text-[color:var(--brand-charcoal)] shadow-sm transition hover:bg-gray-200"
             >
               Mélanger les obstacles
             </button>
@@ -942,45 +943,45 @@ export function ClarityMapStep({
         </div>
         <div className="space-y-3">
           <label className="flex flex-col gap-2">
-            <span className="text-sm font-semibold text-white/90">{normalizedConfig.instructionLabel}</span>
+            <span className="text-sm font-semibold text-[color:var(--brand-charcoal)]">{normalizedConfig.instructionLabel}</span>
             <textarea
               rows={6}
               value={instruction}
               onChange={(event) => setInstruction(event.target.value)}
               placeholder={normalizedConfig.instructionPlaceholder}
               readOnly={shouldLockInstruction}
-              className={`min-h-[160px] rounded-2xl border border-white/30 px-4 py-3 text-base text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40 ${
+              className={`min-h-[160px] rounded-2xl border border-gray-300 px-4 py-3 text-base text-[color:var(--brand-charcoal)] shadow-sm placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20 ${
                 shouldLockInstruction
-                  ? "bg-[color:var(--brand-charcoal)]/35 text-white/80"
-                  : "bg-[color:var(--brand-charcoal)]/25"
+                  ? "bg-gray-100 text-[color:var(--brand-charcoal)]/80"
+                  : "bg-white"
               }`}
             />
           </label>
           {promptSnapshot !== null && (
-            <p className="text-sm text-white/70">
+            <p className="text-sm text-[color:var(--brand-charcoal)]/80">
               Commande synchronisée depuis le module « {promptSourceLabel || "?"} ».
             </p>
           )}
           {promptSnapshot && (shouldExposePromptSettings || shouldExposeDeveloperMessage) && (
-            <div className="rounded-2xl border border-white/25 bg-black/30 p-4 text-sm text-white/80 shadow-inner">
+            <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4 text-sm text-[color:var(--brand-charcoal)] shadow-inner">
               <div className="flex flex-col gap-3">
                 {shouldExposePromptSettings && (
                   <dl className="grid gap-3 sm:grid-cols-3">
                     <div>
-                      <dt className="text-xs uppercase tracking-wide text-white/50">Modèle</dt>
-                      <dd className="mt-1 font-medium text-white/90">
+                      <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Modèle</dt>
+                      <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                         {planModelOption?.label ?? planModel}
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs uppercase tracking-wide text-white/50">Verbosité</dt>
-                      <dd className="mt-1 font-medium text-white/90">
+                      <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Verbosité</dt>
+                      <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                         {planVerbosityOption?.label ?? planVerbosity}
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs uppercase tracking-wide text-white/50">Raisonnement</dt>
-                      <dd className="mt-1 font-medium text-white/90">
+                      <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Raisonnement</dt>
+                      <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                         {planThinkingOption?.label ?? planThinking}
                       </dd>
                     </div>
@@ -988,10 +989,10 @@ export function ClarityMapStep({
                 )}
                 {shouldExposeDeveloperMessage && (
                   <div>
-                    <p className="text-xs uppercase tracking-wide text-white/50">
+                    <p className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                       Brief développeur transmis au modèle
                     </p>
-                    <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-black/40 p-3 text-xs leading-relaxed text-white/90">
+                    <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-gray-50 p-3 text-xs leading-relaxed text-[color:var(--brand-charcoal)]">
                       {trimmedPlanDeveloperMessage || planDeveloperMessage}
                     </pre>
                   </div>
@@ -999,39 +1000,39 @@ export function ClarityMapStep({
               </div>
             </div>
           )}
-          <div className="rounded-2xl border border-white/30 bg-[color:var(--brand-charcoal)]/35 p-4 text-white/80 shadow-inner">
+          <div className="rounded-2xl border border-gray-300 bg-gray-100 p-4 text-[color:var(--brand-charcoal)] shadow-inner">
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <span className="text-sm font-semibold text-white/90">Plan IA</span>
+              <span className="text-sm font-semibold text-[color:var(--brand-charcoal)]">Plan IA</span>
               <button
                 type="button"
                 onClick={handleExecuteClick}
                 disabled={isLoading || !trimmedInstruction}
                 className={`inline-flex items-center justify-center rounded-full px-4 py-1.5 text-xs font-semibold transition ${
                   isLoading || !trimmedInstruction
-                    ? "cursor-not-allowed border border-white/20 bg-white/10 text-white/60"
-                    : "border border-white/40 bg-[color:var(--brand-red)]/90 text-white hover:bg-[color:var(--brand-red)]"
+                    ? "cursor-not-allowed border border-gray-200 bg-gray-100 text-[color:var(--brand-charcoal)]/60"
+                    : "border border-transparent bg-[color:var(--brand-red)] text-white hover:bg-[color:var(--brand-red-dark)]"
                 }`}
               >
                 {isLoading ? "Analyse en cours…" : shouldAutoPublish ? "Relancer l’IA" : "Tester la consigne"}
               </button>
             </div>
             {resolvedMessage && (
-              <p className="mt-3 text-sm text-white/80">{resolvedMessage}</p>
+              <p className="mt-3 text-sm text-[color:var(--brand-charcoal)]">{resolvedMessage}</p>
             )}
             <div className="mt-3">
-              <PlanPreview plan={resolvedPlan} notes={resolvedNotes} tone="dark" />
+              <PlanPreview plan={resolvedPlan} notes={resolvedNotes} tone="light" />
             </div>
           </div>
         </div>
       </div>
 
       <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-white/70">
-          {shouldAutoPublish
-            ? "Le module carte met à jour son payload automatiquement dans le composite."
-            : "Clique sur “Envoyer la requête” pour transmettre la commande à l’IA."}
+        <p className="text-sm text-[color:var(--brand-charcoal)]/80">
+          {allowManualSubmit
+            ? "Clique sur “Envoyer la requête” pour transmettre la commande à l’IA."
+            : "Le module carte met à jour son payload automatiquement dans le composite."}
         </p>
-        {!shouldAutoPublish && (
+        {allowManualSubmit && (
           <button
             type="submit"
             className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[color:var(--brand-red)]/30 transition hover:bg-[color:var(--brand-red-dark)]"

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
@@ -16,7 +16,18 @@ import {
   type ThinkingChoice,
   type VerbosityChoice,
 } from "../../../../config";
-import type { StepComponentProps } from "../../types";
+import {
+  GRID_SIZE,
+  PlanPreview,
+  START_POSITION,
+  createRandomObstacles,
+  createRandomTarget,
+  createRunId,
+  useClarityPlanExecution,
+  type ClientStats,
+  type GridCoord,
+} from "../../../clarity";
+import type { CompositeStepModuleDefinition, StepComponentProps } from "../../types";
 import { StepSequenceContext } from "../../types";
 
 const MODEL_VALUES = new Set<ModelChoice>(MODEL_OPTIONS.map((option) => option.value));
@@ -181,6 +192,109 @@ function sanitizePayload(
   };
 }
 
+interface MapModuleSnapshot {
+  runId: string | null;
+  target: GridCoord | null;
+  blocked: GridCoord[];
+}
+
+interface MapModuleConfigSnapshot {
+  initialTarget: GridCoord | null;
+  obstacleCount: number;
+}
+
+const MIN_OBSTACLE_COUNT = 0;
+const MAX_OBSTACLE_COUNT = 24;
+const DEFAULT_OBSTACLE_COUNT = 6;
+
+function clampToGrid(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(GRID_SIZE - 1, Math.round(value)));
+}
+
+function sanitizeGridCoord(value: unknown): GridCoord | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const source = value as { x?: unknown; y?: unknown };
+  if (typeof source.x !== "number" || typeof source.y !== "number") {
+    return null;
+  }
+
+  return { x: clampToGrid(source.x), y: clampToGrid(source.y) };
+}
+
+function sanitizeBlockedList(value: unknown, target: GridCoord): GridCoord[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const blocked: GridCoord[] = [];
+  const seen = new Set<string>();
+
+  for (const item of value) {
+    const coord = sanitizeGridCoord(item);
+    if (!coord) {
+      continue;
+    }
+
+    const key = `${coord.x}-${coord.y}`;
+    if (
+      seen.has(key) ||
+      (coord.x === START_POSITION.x && coord.y === START_POSITION.y) ||
+      (coord.x === target.x && coord.y === target.y)
+    ) {
+      continue;
+    }
+
+    seen.add(key);
+    blocked.push(coord);
+  }
+
+  return blocked;
+}
+
+function sanitizeMapModulePayload(value: unknown): MapModuleSnapshot {
+  if (!value || typeof value !== "object") {
+    return { runId: null, target: null, blocked: [] };
+  }
+
+  const source = value as Partial<MapModuleSnapshot> & Record<string, unknown>;
+  const target = sanitizeGridCoord(source.target);
+  const blocked = target ? sanitizeBlockedList(source.blocked, target) : [];
+  const runId =
+    typeof source.runId === "string" && source.runId.trim().length > 0
+      ? source.runId
+      : null;
+
+  return { runId, target, blocked };
+}
+
+function sanitizeObstacleCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_OBSTACLE_COUNT;
+  }
+  return Math.max(
+    MIN_OBSTACLE_COUNT,
+    Math.min(MAX_OBSTACLE_COUNT, Math.round(value))
+  );
+}
+
+function sanitizeMapModuleConfig(value: unknown): MapModuleConfigSnapshot {
+  if (!value || typeof value !== "object") {
+    return { initialTarget: null, obstacleCount: DEFAULT_OBSTACLE_COUNT };
+  }
+
+  const source = value as { initialTarget?: unknown; obstacleCount?: unknown };
+  return {
+    initialTarget: sanitizeGridCoord(source.initialTarget),
+    obstacleCount: sanitizeObstacleCount(source.obstacleCount),
+  };
+}
+
 export function ClarityPromptStep({
   config,
   payload,
@@ -193,12 +307,68 @@ export function ClarityPromptStep({
   const activeStepId = sequenceContext?.steps?.[sequenceContext.stepIndex]?.id;
   const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
   const allowManualSubmit = isEditMode || !shouldAutoPublish;
+  const sequencePayloads = sequenceContext?.payloads ?? null;
+  const compositeModules = sequenceContext?.compositeModules ?? null;
 
   const normalizedConfig = useMemo(() => sanitizeConfig(config), [config]);
   const sanitizedPayload = useMemo(
     () => sanitizePayload(payload, normalizedConfig),
     [payload, normalizedConfig]
   );
+
+  const detectedMapModule = useMemo<CompositeStepModuleDefinition | null>(() => {
+    if (!compositeModules) {
+      return null;
+    }
+
+    const moduleId = definition.id;
+    if (typeof moduleId !== "string" || !moduleId) {
+      return null;
+    }
+
+    for (const modules of Object.values(compositeModules)) {
+      if (!Array.isArray(modules)) {
+        continue;
+      }
+      const belongsToComposite = modules.some((module) => module.id === moduleId);
+      if (!belongsToComposite) {
+        continue;
+      }
+
+      const targetModule = modules.find(
+        (module) => module.component === "clarity-map" && module.id !== moduleId
+      );
+      if (targetModule) {
+        return targetModule;
+      }
+    }
+
+    return null;
+  }, [compositeModules, definition.id]);
+
+  const detectedMapStepId = detectedMapModule?.id ?? "";
+  const mapConfigSnapshot = useMemo(
+    () => sanitizeMapModuleConfig(detectedMapModule?.config),
+    [detectedMapModule]
+  );
+  const mapPayloadSnapshot = useMemo(
+    () =>
+      detectedMapStepId && sequencePayloads
+        ? sanitizeMapModulePayload(sequencePayloads[detectedMapStepId])
+        : { runId: null, target: null, blocked: [] },
+    [detectedMapStepId, sequencePayloads]
+  );
+  const mapSourceLabel = detectedMapModule?.id ?? "";
+
+  const initialTestTarget =
+    mapPayloadSnapshot.target ??
+    mapConfigSnapshot.initialTarget ??
+    createRandomTarget();
+  const initialTestBlocked =
+    mapPayloadSnapshot.target !== null
+      ? mapPayloadSnapshot.blocked
+      : createRandomObstacles(initialTestTarget, mapConfigSnapshot.obstacleCount);
+  const initialTestRunId = mapPayloadSnapshot.runId ?? createRunId();
 
   const [instruction, setInstruction] = useState<string>(sanitizedPayload.instruction);
   const [model, setModel] = useState<ModelChoice>(sanitizedPayload.model);
@@ -211,6 +381,9 @@ export function ClarityPromptStep({
   const [exposeDeveloperMessage, setExposeDeveloperMessage] = useState<boolean>(
     sanitizedPayload.exposeDeveloperMessage
   );
+  const [testTarget, setTestTarget] = useState<GridCoord>(initialTestTarget);
+  const [testBlocked, setTestBlocked] = useState<GridCoord[]>(initialTestBlocked);
+  const [testRunId, setTestRunId] = useState<string>(initialTestRunId);
   const lastPublishedRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -240,6 +413,61 @@ export function ClarityPromptStep({
   useEffect(() => {
     setExposeDeveloperMessage(sanitizedPayload.exposeDeveloperMessage);
   }, [sanitizedPayload.exposeDeveloperMessage]);
+
+  useEffect(() => {
+    if (!mapPayloadSnapshot.target) {
+      return;
+    }
+
+    setTestTarget(mapPayloadSnapshot.target);
+    setTestBlocked(mapPayloadSnapshot.blocked);
+    if (mapPayloadSnapshot.runId) {
+      setTestRunId(mapPayloadSnapshot.runId);
+    }
+  }, [mapPayloadSnapshot.blocked, mapPayloadSnapshot.runId, mapPayloadSnapshot.target]);
+
+  useEffect(() => {
+    if (mapPayloadSnapshot.target || !mapConfigSnapshot.initialTarget) {
+      return;
+    }
+
+    setTestTarget(mapConfigSnapshot.initialTarget);
+    setTestBlocked(
+      createRandomObstacles(
+        mapConfigSnapshot.initialTarget,
+        mapConfigSnapshot.obstacleCount
+      )
+    );
+  }, [
+    mapConfigSnapshot.initialTarget,
+    mapConfigSnapshot.obstacleCount,
+    mapPayloadSnapshot.target,
+  ]);
+
+  useEffect(() => {
+    if (!mapPayloadSnapshot.runId) {
+      return;
+    }
+    setTestRunId(mapPayloadSnapshot.runId);
+  }, [mapPayloadSnapshot.runId]);
+
+  const trimmedInstructionValue = instruction.trim();
+  const trimmedDeveloperMessageValue = developerMessage.trim();
+  const defaultDeveloperMessage = normalizedConfig.developerMessage;
+  const fallbackDeveloperMessage =
+    defaultDeveloperMessage.trim() || defaultDeveloperMessage;
+  const developerMessageForRequest =
+    trimmedDeveloperMessageValue || fallbackDeveloperMessage;
+
+  const {
+    execute,
+    isLoading,
+    message: executionMessage,
+    plan: executionPlan,
+    notes: executionNotes,
+    stats: executionStats,
+    status: executionStatus,
+  } = useClarityPlanExecution();
 
   const buildPayload = useCallback(
     (overrides?: Partial<ClarityPromptStepPayload>): ClarityPromptStepPayload => {
@@ -332,6 +560,48 @@ export function ClarityPromptStep({
     () => THINKING_OPTIONS.find((option) => option.value === thinking),
     [thinking]
   );
+
+  const handleTestExecution = useCallback(() => {
+    if (!trimmedInstructionValue) {
+      return;
+    }
+
+    void execute({
+      instruction: trimmedInstructionValue,
+      goal: testTarget,
+      blocked: testBlocked,
+      runId: testRunId,
+      model,
+      verbosity,
+      thinking,
+      developerMessage: developerMessageForRequest,
+    }).catch(() => {});
+  }, [
+    developerMessageForRequest,
+    execute,
+    model,
+    testBlocked,
+    testRunId,
+    testTarget,
+    thinking,
+    trimmedInstructionValue,
+    verbosity,
+  ]);
+
+  const testContextDescription = useMemo(() => {
+    const baseLabel = `(${testTarget.x}, ${testTarget.y})`;
+    const obstacleCount = testBlocked.length;
+    const obstacleLabel = `${obstacleCount} obstacle${obstacleCount > 1 ? "s" : ""}`;
+    if (mapSourceLabel) {
+      return `Carte liée « ${mapSourceLabel} » · Cible ${baseLabel} · ${obstacleLabel}`;
+    }
+    return `Carte par défaut · Cible ${baseLabel} · ${obstacleLabel}`;
+  }, [mapSourceLabel, testBlocked.length, testTarget.x, testTarget.y]);
+
+  const resolvedExecutionPlan = executionPlan;
+  const resolvedExecutionNotes = executionNotes;
+  const resolvedExecutionMessage = executionMessage;
+  const resolvedExecutionStats = executionStats;
 
   const structuredPreview = useMemo(() => {
     const payloadPreview: Record<string, unknown> = {
@@ -610,6 +880,68 @@ export function ClarityPromptStep({
           </div>
         </div>
       )}
+
+      <div className="rounded-2xl border border-gray-300 bg-gray-100 p-4 text-[color:var(--brand-charcoal)] shadow-inner">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-[color:var(--brand-charcoal)]">
+              Tester la consigne avec l’IA
+            </p>
+            <p className="text-xs text-[color:var(--brand-charcoal)]/70">{testContextDescription}</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleTestExecution}
+            disabled={isLoading || !trimmedInstructionValue}
+            className={`inline-flex items-center justify-center rounded-full px-4 py-1.5 text-xs font-semibold transition ${
+              isLoading || !trimmedInstructionValue
+                ? "cursor-not-allowed border border-gray-200 bg-gray-100 text-[color:var(--brand-charcoal)]/60"
+                : "border border-transparent bg-[color:var(--brand-red)] text-white hover:bg-[color:var(--brand-red-dark)]"
+            }`}
+          >
+            {isLoading
+              ? "Analyse en cours…"
+              : shouldAutoPublish
+                ? "Relancer l’IA"
+                : "Tester la consigne"}
+          </button>
+        </div>
+        {executionStatus !== "idle" && (
+          <span className="mt-3 inline-flex items-center rounded-full border border-gray-300 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+            {executionStatus === "running"
+              ? "Analyse en cours"
+              : executionStatus === "success"
+                ? "Plan validé"
+                : executionStatus === "blocked"
+                  ? "Plan incomplet"
+                  : executionStatus === "error"
+                    ? "Erreur"
+                    : "Prêt"}
+          </span>
+        )}
+        {resolvedExecutionMessage && (
+          <p className="mt-3 text-sm text-[color:var(--brand-charcoal)]">{resolvedExecutionMessage}</p>
+        )}
+        <div className="mt-3">
+          <PlanPreview plan={resolvedExecutionPlan} notes={resolvedExecutionNotes} tone="light" />
+        </div>
+        {resolvedExecutionStats && (
+          <dl className="mt-3 grid gap-3 text-xs text-[color:var(--brand-charcoal)]/70 sm:grid-cols-2">
+            <div>
+              <dt className="font-semibold uppercase tracking-wide text-[10px]">Tentatives</dt>
+              <dd className="mt-1 text-[color:var(--brand-charcoal)]">
+                {resolvedExecutionStats.attempts}
+              </dd>
+            </div>
+            <div>
+              <dt className="font-semibold uppercase tracking-wide text-[10px]">Pas exécutés</dt>
+              <dd className="mt-1 text-[color:var(--brand-charcoal)]">
+                {resolvedExecutionStats.stepsExecuted}
+              </dd>
+            </div>
+          </dl>
+        )}
+      </div>
 
       <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-[color:var(--brand-charcoal)]/80">

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
@@ -8,22 +8,71 @@ import {
   useState,
 } from "react";
 
+import {
+  MODEL_OPTIONS,
+  THINKING_OPTIONS,
+  VERBOSITY_OPTIONS,
+  type ModelChoice,
+  type ThinkingChoice,
+  type VerbosityChoice,
+} from "../../../../config";
 import type { StepComponentProps } from "../../types";
 import { StepSequenceContext } from "../../types";
 
+const MODEL_VALUES = new Set<ModelChoice>(MODEL_OPTIONS.map((option) => option.value));
+const VERBOSITY_VALUES = new Set<VerbosityChoice>(
+  VERBOSITY_OPTIONS.map((option) => option.value)
+);
+const THINKING_VALUES = new Set<ThinkingChoice>(
+  THINKING_OPTIONS.map((option) => option.value)
+);
+
+export const DEFAULT_CLARITY_MODEL: ModelChoice =
+  MODEL_OPTIONS[0]?.value ?? "gpt-5-nano";
+export const DEFAULT_CLARITY_VERBOSITY: VerbosityChoice =
+  VERBOSITY_OPTIONS.find((option) => option.value === "medium")?.value ??
+  VERBOSITY_OPTIONS[0]?.value ??
+  "medium";
+export const DEFAULT_CLARITY_THINKING: ThinkingChoice =
+  THINKING_OPTIONS.find((option) => option.value === "medium")?.value ??
+  THINKING_OPTIONS[0]?.value ??
+  "minimal";
+export const DEFAULT_CLARITY_DEVELOPER_MESSAGE =
+  "Tu es un agent qui transforme une consigne en plan de déplacements sur une grille 10×10.\n" +
+  "Réponds uniquement avec un JSON strict {\"plan\":[{\"dir\":\"left|right|up|down\",\"steps\":int}],\"notes\":\"...\"}.\n" +
+  "Limite les notes à 80 caractères et évite tout texte supplémentaire.";
+
 export interface ClarityPromptStepPayload {
   instruction: string;
+  model: ModelChoice;
+  verbosity: VerbosityChoice;
+  thinking: ThinkingChoice;
+  developerMessage: string;
+  exposeSettings: boolean;
+  exposeDeveloperMessage: boolean;
 }
 
 export interface ClarityPromptStepConfig {
   promptLabel?: string;
   promptPlaceholder?: string;
+  defaultModel?: ModelChoice;
+  defaultVerbosity?: VerbosityChoice;
+  defaultThinking?: ThinkingChoice;
+  defaultDeveloperMessage?: string;
+  exposeSettings?: boolean;
+  exposeDeveloperMessage?: boolean;
   onChange?: (config: ClarityPromptStepConfig) => void;
 }
 
 interface NormalizedPromptConfig {
   promptLabel: string;
   promptPlaceholder: string;
+  model: ModelChoice;
+  verbosity: VerbosityChoice;
+  thinking: ThinkingChoice;
+  developerMessage: string;
+  exposeSettings: boolean;
+  exposeDeveloperMessage: boolean;
   onChange?: (config: ClarityPromptStepConfig) => void;
 }
 
@@ -32,6 +81,12 @@ function sanitizeConfig(config: unknown): NormalizedPromptConfig {
     return {
       promptLabel: "Consigne à transmettre",
       promptPlaceholder: "Décris l'action à effectuer…",
+      model: DEFAULT_CLARITY_MODEL,
+      verbosity: DEFAULT_CLARITY_VERBOSITY,
+      thinking: DEFAULT_CLARITY_THINKING,
+      developerMessage: DEFAULT_CLARITY_DEVELOPER_MESSAGE,
+      exposeSettings: true,
+      exposeDeveloperMessage: false,
     };
   }
 
@@ -44,25 +99,86 @@ function sanitizeConfig(config: unknown): NormalizedPromptConfig {
     typeof raw.promptPlaceholder === "string" && raw.promptPlaceholder.trim()
       ? raw.promptPlaceholder.trim()
       : "Décris l'action à effectuer…";
+  const model =
+    typeof raw.defaultModel === "string" && MODEL_VALUES.has(raw.defaultModel as ModelChoice)
+      ? (raw.defaultModel as ModelChoice)
+      : DEFAULT_CLARITY_MODEL;
+  const verbosity =
+    typeof raw.defaultVerbosity === "string" &&
+    VERBOSITY_VALUES.has(raw.defaultVerbosity as VerbosityChoice)
+      ? (raw.defaultVerbosity as VerbosityChoice)
+      : DEFAULT_CLARITY_VERBOSITY;
+  const thinking =
+    typeof raw.defaultThinking === "string" &&
+    THINKING_VALUES.has(raw.defaultThinking as ThinkingChoice)
+      ? (raw.defaultThinking as ThinkingChoice)
+      : DEFAULT_CLARITY_THINKING;
+  const developerMessage =
+    typeof raw.defaultDeveloperMessage === "string" && raw.defaultDeveloperMessage.trim()
+      ? raw.defaultDeveloperMessage
+      : DEFAULT_CLARITY_DEVELOPER_MESSAGE;
 
   return {
     promptLabel,
     promptPlaceholder,
+    model,
+    verbosity,
+    thinking,
+    developerMessage,
+    exposeSettings: raw.exposeSettings ?? true,
+    exposeDeveloperMessage: raw.exposeDeveloperMessage ?? false,
     onChange: raw.onChange,
   };
 }
 
-function sanitizePayload(payload: unknown): ClarityPromptStepPayload {
+function sanitizePayload(
+  payload: unknown,
+  config: NormalizedPromptConfig
+): ClarityPromptStepPayload {
   if (!payload || typeof payload !== "object") {
-    return { instruction: "" };
+    return {
+      instruction: "",
+      model: config.model,
+      verbosity: config.verbosity,
+      thinking: config.thinking,
+      developerMessage: config.developerMessage,
+      exposeSettings: config.exposeSettings,
+      exposeDeveloperMessage: config.exposeDeveloperMessage,
+    };
   }
 
-  const raw = payload as Partial<ClarityPromptStepPayload>;
-  if (typeof raw.instruction !== "string") {
-    return { instruction: "" };
-  }
+  const raw = payload as Partial<ClarityPromptStepPayload> & Record<string, unknown>;
 
-  return { instruction: raw.instruction };
+  const model =
+    typeof raw.model === "string" && MODEL_VALUES.has(raw.model as ModelChoice)
+      ? (raw.model as ModelChoice)
+      : config.model;
+  const verbosity =
+    typeof raw.verbosity === "string" && VERBOSITY_VALUES.has(raw.verbosity as VerbosityChoice)
+      ? (raw.verbosity as VerbosityChoice)
+      : config.verbosity;
+  const thinking =
+    typeof raw.thinking === "string" && THINKING_VALUES.has(raw.thinking as ThinkingChoice)
+      ? (raw.thinking as ThinkingChoice)
+      : config.thinking;
+  const developerMessage =
+    typeof raw.developerMessage === "string" && raw.developerMessage.trim().length > 0
+      ? raw.developerMessage
+      : config.developerMessage;
+
+  return {
+    instruction: typeof raw.instruction === "string" ? raw.instruction : "",
+    model,
+    verbosity,
+    thinking,
+    developerMessage,
+    exposeSettings:
+      typeof raw.exposeSettings === "boolean" ? raw.exposeSettings : config.exposeSettings,
+    exposeDeveloperMessage:
+      typeof raw.exposeDeveloperMessage === "boolean"
+        ? raw.exposeDeveloperMessage
+        : config.exposeDeveloperMessage,
+  };
 }
 
 export function ClarityPromptStep({
@@ -78,9 +194,22 @@ export function ClarityPromptStep({
   const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
 
   const normalizedConfig = useMemo(() => sanitizeConfig(config), [config]);
-  const sanitizedPayload = useMemo(() => sanitizePayload(payload), [payload]);
+  const sanitizedPayload = useMemo(
+    () => sanitizePayload(payload, normalizedConfig),
+    [payload, normalizedConfig]
+  );
 
   const [instruction, setInstruction] = useState<string>(sanitizedPayload.instruction);
+  const [model, setModel] = useState<ModelChoice>(sanitizedPayload.model);
+  const [verbosity, setVerbosity] = useState<VerbosityChoice>(sanitizedPayload.verbosity);
+  const [thinking, setThinking] = useState<ThinkingChoice>(sanitizedPayload.thinking);
+  const [developerMessage, setDeveloperMessage] = useState<string>(
+    sanitizedPayload.developerMessage
+  );
+  const [exposeSettings, setExposeSettings] = useState<boolean>(sanitizedPayload.exposeSettings);
+  const [exposeDeveloperMessage, setExposeDeveloperMessage] = useState<boolean>(
+    sanitizedPayload.exposeDeveloperMessage
+  );
   const lastPublishedRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -88,13 +217,66 @@ export function ClarityPromptStep({
   }, [sanitizedPayload.instruction]);
 
   useEffect(() => {
+    setModel(sanitizedPayload.model);
+  }, [sanitizedPayload.model]);
+
+  useEffect(() => {
+    setVerbosity(sanitizedPayload.verbosity);
+  }, [sanitizedPayload.verbosity]);
+
+  useEffect(() => {
+    setThinking(sanitizedPayload.thinking);
+  }, [sanitizedPayload.thinking]);
+
+  useEffect(() => {
+    setDeveloperMessage(sanitizedPayload.developerMessage);
+  }, [sanitizedPayload.developerMessage]);
+
+  useEffect(() => {
+    setExposeSettings(sanitizedPayload.exposeSettings);
+  }, [sanitizedPayload.exposeSettings]);
+
+  useEffect(() => {
+    setExposeDeveloperMessage(sanitizedPayload.exposeDeveloperMessage);
+  }, [sanitizedPayload.exposeDeveloperMessage]);
+
+  const buildPayload = useCallback(
+    (overrides?: Partial<ClarityPromptStepPayload>): ClarityPromptStepPayload => {
+      const trimmedInstruction = instruction.trim();
+      const trimmedDeveloperMessage = developerMessage.trim();
+      return {
+        instruction: trimmedInstruction,
+        model,
+        verbosity,
+        thinking,
+        developerMessage:
+          trimmedDeveloperMessage.length > 0
+            ? trimmedDeveloperMessage
+            : normalizedConfig.developerMessage,
+        exposeSettings,
+        exposeDeveloperMessage,
+        ...overrides,
+      };
+    },
+    [
+      developerMessage,
+      exposeDeveloperMessage,
+      exposeSettings,
+      instruction,
+      model,
+      normalizedConfig.developerMessage,
+      thinking,
+      verbosity,
+    ]
+  );
+
+  useEffect(() => {
     if (!shouldAutoPublish) {
       lastPublishedRef.current = null;
       return;
     }
 
-    const trimmed = instruction.trim();
-    const payloadToSend: ClarityPromptStepPayload = { instruction: trimmed };
+    const payloadToSend = buildPayload();
     const serialized = JSON.stringify(payloadToSend);
     if (lastPublishedRef.current === serialized) {
       return;
@@ -102,13 +284,21 @@ export function ClarityPromptStep({
 
     lastPublishedRef.current = serialized;
     onAdvance(payloadToSend);
-  }, [instruction, onAdvance, shouldAutoPublish]);
+  }, [buildPayload, onAdvance, shouldAutoPublish]);
 
   const handleConfigChange = useCallback(
     (patch: Partial<ClarityPromptStepConfig>) => {
       const nextConfig: ClarityPromptStepConfig = {
         promptLabel: patch.promptLabel ?? normalizedConfig.promptLabel,
         promptPlaceholder: patch.promptPlaceholder ?? normalizedConfig.promptPlaceholder,
+        defaultModel: patch.defaultModel ?? normalizedConfig.model,
+        defaultVerbosity: patch.defaultVerbosity ?? normalizedConfig.verbosity,
+        defaultThinking: patch.defaultThinking ?? normalizedConfig.thinking,
+        defaultDeveloperMessage:
+          patch.defaultDeveloperMessage ?? normalizedConfig.developerMessage,
+        exposeSettings: patch.exposeSettings ?? normalizedConfig.exposeSettings,
+        exposeDeveloperMessage:
+          patch.exposeDeveloperMessage ?? normalizedConfig.exposeDeveloperMessage,
       };
 
       normalizedConfig.onChange?.(nextConfig);
@@ -124,41 +314,184 @@ export function ClarityPromptStep({
         return;
       }
 
-      onAdvance({ instruction: instruction.trim() });
+      onAdvance(buildPayload());
     },
-    [instruction, onAdvance, shouldAutoPublish]
+    [buildPayload, onAdvance, shouldAutoPublish]
   );
+
+  const activeModelOption = useMemo(
+    () => MODEL_OPTIONS.find((option) => option.value === model),
+    [model]
+  );
+  const activeVerbosityOption = useMemo(
+    () => VERBOSITY_OPTIONS.find((option) => option.value === verbosity),
+    [verbosity]
+  );
+  const activeThinkingOption = useMemo(
+    () => THINKING_OPTIONS.find((option) => option.value === thinking),
+    [thinking]
+  );
+
+  const structuredPreview = useMemo(() => {
+    const payloadPreview: Record<string, unknown> = {
+      instruction: instruction.trim(),
+      model,
+      verbosity,
+      thinking,
+      exposeSettings,
+      exposeDeveloperMessage,
+    };
+    const trimmedMessage = developerMessage.trim();
+    const fallbackMessage = normalizedConfig.developerMessage.trim();
+    if (trimmedMessage || fallbackMessage) {
+      payloadPreview.developerMessage = trimmedMessage || fallbackMessage;
+    }
+    return JSON.stringify(payloadPreview, null, 2);
+  }, [
+    developerMessage,
+    exposeDeveloperMessage,
+    exposeSettings,
+    instruction,
+    model,
+    normalizedConfig.developerMessage,
+    thinking,
+    verbosity,
+  ]);
 
   return (
     <form className="space-y-6" onSubmit={handleSubmit}>
       {isEditMode && (
-        <fieldset className="rounded-2xl border border-dashed border-white/40 bg-white/40 p-4 text-sm text-[color:var(--brand-charcoal)]">
-          <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+        <fieldset className="rounded-2xl border border-dashed border-white/30 bg-[color:var(--brand-charcoal)]/20 p-4 text-sm text-white/80">
+          <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-white/70">
             Configuration
           </legend>
           <div className="mt-2 grid gap-4 md:grid-cols-2">
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
                 Libellé
               </span>
               <input
                 type="text"
                 value={normalizedConfig.promptLabel}
                 onChange={(event) => handleConfigChange({ promptLabel: event.target.value })}
-                className="rounded-lg border border-white/60 bg-white/80 px-3 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none"
+                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
               />
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
                 Placeholder
               </span>
               <input
                 type="text"
                 value={normalizedConfig.promptPlaceholder}
                 onChange={(event) => handleConfigChange({ promptPlaceholder: event.target.value })}
-                className="rounded-lg border border-white/60 bg-white/80 px-3 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none"
+                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
               />
             </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Modèle par défaut
+              </span>
+              <select
+                value={normalizedConfig.model}
+                onChange={(event) =>
+                  handleConfigChange({ defaultModel: event.target.value as ModelChoice })
+                }
+                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+              >
+                {MODEL_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Verbosité par défaut
+              </span>
+              <select
+                value={normalizedConfig.verbosity}
+                onChange={(event) =>
+                  handleConfigChange({
+                    defaultVerbosity: event.target.value as VerbosityChoice,
+                  })
+                }
+                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+              >
+                {VERBOSITY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Raisonnement par défaut
+              </span>
+              <select
+                value={normalizedConfig.thinking}
+                onChange={(event) =>
+                  handleConfigChange({ defaultThinking: event.target.value as ThinkingChoice })
+                }
+                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+              >
+                {THINKING_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 md:col-span-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Message développeur par défaut
+              </span>
+              <textarea
+                rows={4}
+                value={normalizedConfig.developerMessage}
+                onChange={(event) =>
+                  handleConfigChange({ defaultDeveloperMessage: event.target.value })
+                }
+                className="min-h-[120px] rounded-xl border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+              />
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={normalizedConfig.exposeSettings}
+                onChange={(event) => handleConfigChange({ exposeSettings: event.target.checked })}
+                className="h-4 w-4 rounded border-white/50 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+              />
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Afficher la configuration IA
+              </span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={normalizedConfig.exposeDeveloperMessage}
+                onChange={(event) =>
+                  handleConfigChange({ exposeDeveloperMessage: event.target.checked })
+                }
+                className="h-4 w-4 rounded border-white/50 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+              />
+              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                Montrer le message développeur
+              </span>
+            </label>
+          </div>
+          <div className="mt-4 rounded-xl border border-white/30 bg-black/30 p-4 text-xs">
+            <div className="flex items-center justify-between gap-3 text-white/70">
+              <span className="font-semibold uppercase tracking-wide">Payload partagé</span>
+              <span className="text-[10px] uppercase tracking-[0.2em] text-white/40">
+                Lecture seule
+              </span>
+            </div>
+            <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-black/40 p-3 text-[11px] leading-relaxed text-white/80">
+              {structuredPreview}
+            </pre>
           </div>
         </fieldset>
       )}
@@ -171,22 +504,124 @@ export function ClarityPromptStep({
           value={instruction}
           onChange={(event) => setInstruction(event.target.value)}
           placeholder={normalizedConfig.promptPlaceholder}
-          className="min-h-[120px] rounded-2xl border border-white/30 bg-white/20 px-4 py-3 text-base text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none"
+          className="min-h-[120px] rounded-2xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-4 py-3 text-base text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
         />
       </label>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+            Modèle
+          </span>
+          <select
+            value={model}
+            onChange={(event) => setModel(event.target.value as ModelChoice)}
+            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+          >
+            {MODEL_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+            Verbosité
+          </span>
+          <select
+            value={verbosity}
+            onChange={(event) => setVerbosity(event.target.value as VerbosityChoice)}
+            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+          >
+            {VERBOSITY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+            Raisonnement
+          </span>
+          <select
+            value={thinking}
+            onChange={(event) => setThinking(event.target.value as ThinkingChoice)}
+            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+          >
+            {THINKING_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+          Message développeur transmis au modèle
+        </span>
+        <textarea
+          rows={4}
+          value={developerMessage}
+          onChange={(event) => setDeveloperMessage(event.target.value)}
+          className="min-h-[120px] rounded-2xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-4 py-3 text-sm text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+        />
+      </label>
+
+      {(exposeSettings || exposeDeveloperMessage) && (
+        <div className="rounded-2xl border border-white/25 bg-black/30 p-4 text-sm text-white/80 shadow-inner">
+          <div className="flex flex-col gap-3">
+            {exposeSettings && (
+              <dl className="grid gap-3 sm:grid-cols-3">
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-white/50">Modèle</dt>
+                  <dd className="mt-1 font-medium text-white/90">
+                    {activeModelOption?.label ?? model}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-white/50">Verbosité</dt>
+                  <dd className="mt-1 font-medium text-white/90">
+                    {activeVerbosityOption?.label ?? verbosity}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wide text-white/50">Raisonnement</dt>
+                  <dd className="mt-1 font-medium text-white/90">
+                    {activeThinkingOption?.label ?? thinking}
+                  </dd>
+                </div>
+              </dl>
+            )}
+            {exposeDeveloperMessage && (
+              <div>
+                <p className="text-xs uppercase tracking-wide text-white/50">
+                  Brief développeur visible pour l’apprenant·e
+                </p>
+                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-black/40 p-3 text-xs leading-relaxed text-white/90">
+                  {developerMessage.trim() || normalizedConfig.developerMessage}
+                </pre>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-white/70">
           {shouldAutoPublish
             ? "Les modifications sont partagées automatiquement dans le module composite."
-            : "La consigne sera transmise au module suivant lorsque tu continues."}
+            : "Clique sur “Envoyer la requête” pour transmettre la consigne au module suivant."}
         </p>
         {!shouldAutoPublish && (
           <button
             type="submit"
             className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[color:var(--brand-red)]/30 transition hover:bg-[color:var(--brand-red-dark)]"
           >
-            Continuer
+            Envoyer la requête
           </button>
         )}
       </div>

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
@@ -192,6 +192,7 @@ export function ClarityPromptStep({
   const sequenceContext = useContext(StepSequenceContext);
   const activeStepId = sequenceContext?.steps?.[sequenceContext.stepIndex]?.id;
   const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
+  const allowManualSubmit = isEditMode || !shouldAutoPublish;
 
   const normalizedConfig = useMemo(() => sanitizeConfig(config), [config]);
   const sanitizedPayload = useMemo(
@@ -310,13 +311,13 @@ export function ClarityPromptStep({
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      if (shouldAutoPublish) {
+      if (!allowManualSubmit) {
         return;
       }
 
       onAdvance(buildPayload());
     },
-    [buildPayload, onAdvance, shouldAutoPublish]
+    [allowManualSubmit, buildPayload, onAdvance]
   );
 
   const activeModelOption = useMemo(
@@ -361,35 +362,35 @@ export function ClarityPromptStep({
   return (
     <form className="space-y-6" onSubmit={handleSubmit}>
       {isEditMode && (
-        <fieldset className="rounded-2xl border border-dashed border-white/30 bg-[color:var(--brand-charcoal)]/20 p-4 text-sm text-white/80">
-          <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-white/70">
+        <fieldset className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-[color:var(--brand-charcoal)]">
+          <legend className="px-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
             Configuration
           </legend>
           <div className="mt-2 grid gap-4 md:grid-cols-2">
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Libellé
               </span>
               <input
                 type="text"
                 value={normalizedConfig.promptLabel}
                 onChange={(event) => handleConfigChange({ promptLabel: event.target.value })}
-                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               />
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Placeholder
               </span>
               <input
                 type="text"
                 value={normalizedConfig.promptPlaceholder}
                 onChange={(event) => handleConfigChange({ promptPlaceholder: event.target.value })}
-                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               />
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Modèle par défaut
               </span>
               <select
@@ -397,7 +398,7 @@ export function ClarityPromptStep({
                 onChange={(event) =>
                   handleConfigChange({ defaultModel: event.target.value as ModelChoice })
                 }
-                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               >
                 {MODEL_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -407,7 +408,7 @@ export function ClarityPromptStep({
               </select>
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Verbosité par défaut
               </span>
               <select
@@ -417,7 +418,7 @@ export function ClarityPromptStep({
                     defaultVerbosity: event.target.value as VerbosityChoice,
                   })
                 }
-                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               >
                 {VERBOSITY_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -427,7 +428,7 @@ export function ClarityPromptStep({
               </select>
             </label>
             <label className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Raisonnement par défaut
               </span>
               <select
@@ -435,7 +436,7 @@ export function ClarityPromptStep({
                 onChange={(event) =>
                   handleConfigChange({ defaultThinking: event.target.value as ThinkingChoice })
                 }
-                className="rounded-lg border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               >
                 {THINKING_OPTIONS.map((option) => (
                   <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -445,7 +446,7 @@ export function ClarityPromptStep({
               </select>
             </label>
             <label className="flex flex-col gap-1 md:col-span-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Message développeur par défaut
               </span>
               <textarea
@@ -454,7 +455,7 @@ export function ClarityPromptStep({
                 onChange={(event) =>
                   handleConfigChange({ defaultDeveloperMessage: event.target.value })
                 }
-                className="min-h-[120px] rounded-xl border border-white/40 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+                className="min-h-[120px] rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
               />
             </label>
             <label className="flex items-center gap-2">
@@ -462,9 +463,9 @@ export function ClarityPromptStep({
                 type="checkbox"
                 checked={normalizedConfig.exposeSettings}
                 onChange={(event) => handleConfigChange({ exposeSettings: event.target.checked })}
-                className="h-4 w-4 rounded border-white/50 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+                className="h-4 w-4 rounded border-gray-400 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
               />
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Afficher la configuration IA
               </span>
             </label>
@@ -475,21 +476,21 @@ export function ClarityPromptStep({
                 onChange={(event) =>
                   handleConfigChange({ exposeDeveloperMessage: event.target.checked })
                 }
-                className="h-4 w-4 rounded border-white/50 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
+                className="h-4 w-4 rounded border-gray-400 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
               />
-              <span className="text-xs font-semibold uppercase tracking-wide text-white/60">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                 Montrer le message développeur
               </span>
             </label>
           </div>
-          <div className="mt-4 rounded-xl border border-white/30 bg-black/30 p-4 text-xs">
-            <div className="flex items-center justify-between gap-3 text-white/70">
+          <div className="mt-4 rounded-xl border border-gray-300 bg-gray-50 p-4 text-xs">
+            <div className="flex items-center justify-between gap-3 text-[color:var(--brand-charcoal)]/80">
               <span className="font-semibold uppercase tracking-wide">Payload partagé</span>
-              <span className="text-[10px] uppercase tracking-[0.2em] text-white/40">
+              <span className="text-[10px] uppercase tracking-[0.2em] text-[color:var(--brand-charcoal)]/60">
                 Lecture seule
               </span>
             </div>
-            <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-black/40 p-3 text-[11px] leading-relaxed text-white/80">
+            <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-gray-50 p-3 text-[11px] leading-relaxed text-[color:var(--brand-charcoal)]">
               {structuredPreview}
             </pre>
           </div>
@@ -497,26 +498,26 @@ export function ClarityPromptStep({
       )}
 
       <label className="flex flex-col gap-2">
-        <span className="text-sm font-semibold text-white/90">{normalizedConfig.promptLabel}</span>
+        <span className="text-sm font-semibold text-[color:var(--brand-charcoal)]">{normalizedConfig.promptLabel}</span>
         <textarea
           required
           rows={4}
           value={instruction}
           onChange={(event) => setInstruction(event.target.value)}
           placeholder={normalizedConfig.promptPlaceholder}
-          className="min-h-[120px] rounded-2xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-4 py-3 text-base text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+          className="min-h-[120px] rounded-2xl border border-gray-300 bg-white px-4 py-3 text-base text-[color:var(--brand-charcoal)] shadow-sm placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
         />
       </label>
 
       <div className="grid gap-4 sm:grid-cols-3">
         <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+          <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
             Modèle
           </span>
           <select
             value={model}
             onChange={(event) => setModel(event.target.value as ModelChoice)}
-            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
           >
             {MODEL_OPTIONS.map((option) => (
               <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -526,13 +527,13 @@ export function ClarityPromptStep({
           </select>
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+          <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
             Verbosité
           </span>
           <select
             value={verbosity}
             onChange={(event) => setVerbosity(event.target.value as VerbosityChoice)}
-            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
           >
             {VERBOSITY_OPTIONS.map((option) => (
               <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -542,13 +543,13 @@ export function ClarityPromptStep({
           </select>
         </label>
         <label className="flex flex-col gap-1">
-          <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+          <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
             Raisonnement
           </span>
           <select
             value={thinking}
             onChange={(event) => setThinking(event.target.value as ThinkingChoice)}
-            className="rounded-xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-3 py-2 text-sm text-white focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+            className="rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-[color:var(--brand-charcoal)] focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
           >
             {THINKING_OPTIONS.map((option) => (
               <option key={option.value} value={option.value} className="text-[color:var(--brand-charcoal)]">
@@ -560,37 +561,37 @@ export function ClarityPromptStep({
       </div>
 
       <label className="flex flex-col gap-2">
-        <span className="text-xs font-semibold uppercase tracking-wide text-white/70">
+        <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
           Message développeur transmis au modèle
         </span>
         <textarea
           rows={4}
           value={developerMessage}
           onChange={(event) => setDeveloperMessage(event.target.value)}
-          className="min-h-[120px] rounded-2xl border border-white/30 bg-[color:var(--brand-charcoal)]/40 px-4 py-3 text-sm text-white shadow-sm placeholder:text-white/60 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/40"
+          className="min-h-[120px] rounded-2xl border border-gray-300 bg-white px-4 py-3 text-sm text-[color:var(--brand-charcoal)] shadow-sm placeholder:text-gray-500 focus:border-[color:var(--brand-red)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-red)]/20"
         />
       </label>
 
       {(exposeSettings || exposeDeveloperMessage) && (
-        <div className="rounded-2xl border border-white/25 bg-black/30 p-4 text-sm text-white/80 shadow-inner">
+        <div className="rounded-2xl border border-gray-200 bg-gray-50 p-4 text-sm text-[color:var(--brand-charcoal)] shadow-inner">
           <div className="flex flex-col gap-3">
             {exposeSettings && (
               <dl className="grid gap-3 sm:grid-cols-3">
                 <div>
-                  <dt className="text-xs uppercase tracking-wide text-white/50">Modèle</dt>
-                  <dd className="mt-1 font-medium text-white/90">
+                  <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Modèle</dt>
+                  <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                     {activeModelOption?.label ?? model}
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-xs uppercase tracking-wide text-white/50">Verbosité</dt>
-                  <dd className="mt-1 font-medium text-white/90">
+                  <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Verbosité</dt>
+                  <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                     {activeVerbosityOption?.label ?? verbosity}
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-xs uppercase tracking-wide text-white/50">Raisonnement</dt>
-                  <dd className="mt-1 font-medium text-white/90">
+                  <dt className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">Raisonnement</dt>
+                  <dd className="mt-1 font-medium text-[color:var(--brand-charcoal)]">
                     {activeThinkingOption?.label ?? thinking}
                   </dd>
                 </div>
@@ -598,10 +599,10 @@ export function ClarityPromptStep({
             )}
             {exposeDeveloperMessage && (
               <div>
-                <p className="text-xs uppercase tracking-wide text-white/50">
+                <p className="text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
                   Brief développeur visible pour l’apprenant·e
                 </p>
-                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-black/40 p-3 text-xs leading-relaxed text-white/90">
+                <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-xl bg-gray-50 p-3 text-xs leading-relaxed text-[color:var(--brand-charcoal)]">
                   {developerMessage.trim() || normalizedConfig.developerMessage}
                 </pre>
               </div>
@@ -611,12 +612,12 @@ export function ClarityPromptStep({
       )}
 
       <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-white/70">
-          {shouldAutoPublish
-            ? "Les modifications sont partagées automatiquement dans le module composite."
-            : "Clique sur “Envoyer la requête” pour transmettre la consigne au module suivant."}
+        <p className="text-sm text-[color:var(--brand-charcoal)]/80">
+          {allowManualSubmit
+            ? "Clique sur “Envoyer la requête” pour transmettre la consigne au module suivant."
+            : "Les modifications sont partagées automatiquement dans le module composite."}
         </p>
-        {!shouldAutoPublish && (
+        {allowManualSubmit && (
           <button
             type="submit"
             className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-[color:var(--brand-red)]/30 transition hover:bg-[color:var(--brand-red-dark)]"

--- a/frontend/tests/step-sequence/ClarityMapStep.test.tsx
+++ b/frontend/tests/step-sequence/ClarityMapStep.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   STEP_COMPONENT_REGISTRY,
@@ -14,8 +14,27 @@ import {
 import { START_POSITION } from "../../src/modules/clarity";
 import type { GridCoord } from "../../src/modules/clarity";
 
+const encoder = new TextEncoder();
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: async () => ({ done: true, value: encoder.encode("") }),
+          }),
+        },
+      } as unknown as Response)
+    )
+  );
+});
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("ClarityMapStep", () => {

--- a/frontend/tests/step-sequence/ClarityMapStep.test.tsx
+++ b/frontend/tests/step-sequence/ClarityMapStep.test.tsx
@@ -90,7 +90,7 @@ describe("ClarityMapStep", () => {
     const textarea = screen.getByPlaceholderText(/consigne reçue/i);
     fireEvent.change(textarea, { target: { value: "Avance de 2 cases." } });
 
-    const submitButton = screen.getByRole("button", { name: /continuer/i });
+    const submitButton = screen.getByRole("button", { name: /envoyer la requête/i });
     fireEvent.click(submitButton);
 
     expect(onAdvance).toHaveBeenCalledTimes(1);
@@ -116,7 +116,7 @@ describe("ClarityMapStep", () => {
 
     render(<ClarityMapStep {...props} />);
 
-    const submitButton = screen.getByRole("button", { name: /continuer/i });
+    const submitButton = screen.getByRole("button", { name: /envoyer la requête/i });
     fireEvent.click(submitButton);
 
     const payload = onAdvance.mock.calls[0][0] as {

--- a/frontend/tests/step-sequence/ClarityPromptStep.test.tsx
+++ b/frontend/tests/step-sequence/ClarityPromptStep.test.tsx
@@ -11,6 +11,12 @@ import {
   type ClarityPromptStepConfig,
   type ClarityPromptStepPayload,
 } from "../../src/modules/step-sequence/modules";
+import {
+  DEFAULT_CLARITY_DEVELOPER_MESSAGE,
+  DEFAULT_CLARITY_MODEL,
+  DEFAULT_CLARITY_THINKING,
+  DEFAULT_CLARITY_VERBOSITY,
+} from "../../src/modules/step-sequence/modules/clarity/ClarityPromptStep";
 
 afterEach(() => {
   cleanup();
@@ -75,12 +81,20 @@ describe("ClarityPromptStep", () => {
     const textarea = screen.getByPlaceholderText(/décris l'action/i);
     fireEvent.change(textarea, { target: { value: "Avance vers la droite" } });
 
-    const button = screen.getByRole("button", { name: /continuer/i });
+    const button = screen.getByRole("button", { name: /envoyer la requête/i });
     fireEvent.click(button);
 
     expect(onAdvance).toHaveBeenCalledTimes(1);
     const payload = onAdvance.mock.calls[0][0] as ClarityPromptStepPayload;
-    expect(payload).toEqual({ instruction: "Avance vers la droite" });
+    expect(payload).toEqual({
+      instruction: "Avance vers la droite",
+      model: DEFAULT_CLARITY_MODEL,
+      verbosity: DEFAULT_CLARITY_VERBOSITY,
+      thinking: DEFAULT_CLARITY_THINKING,
+      developerMessage: DEFAULT_CLARITY_DEVELOPER_MESSAGE,
+      exposeSettings: true,
+      exposeDeveloperMessage: false,
+    });
   });
 
   it("publishes updates automatically when rendered inside a composite module", async () => {
@@ -122,6 +136,9 @@ describe("ClarityPromptStep", () => {
     await waitFor(() => {
       const lastCall = onAdvance.mock.calls[onAdvance.mock.calls.length - 1][0] as ClarityPromptStepPayload;
       expect(lastCall.instruction).toBe("Nouvelle consigne");
+      expect(lastCall.model).toBe(DEFAULT_CLARITY_MODEL);
+      expect(lastCall.verbosity).toBe(DEFAULT_CLARITY_VERBOSITY);
+      expect(lastCall.thinking).toBe(DEFAULT_CLARITY_THINKING);
     });
   });
 });


### PR DESCRIPTION
## Summary
- extend the clarity map step payload to include AI plan metadata and sanitizers
- trigger plan generation via useClarityPlanExecution with automatic publishing and replay controls
- stub fetch in the ClarityMapStep tests to keep unit tests deterministic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52a573fbc8322a6ac32bdfca11c8e