### PR TITLE
Expose StepSequence module option for Explorateur IA

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -71,6 +71,7 @@ export const COMPONENT_REGISTRY = {
   "clarity-path": ClarityPath,
   "clarte-dabord": ClarteDabord,
   "explorateur-ia": ExplorateurIA,
+  stepsequence: ExplorateurIA,
 } as const satisfies Record<string, ComponentType<ActivityProps>>;
 
 export type ActivityComponentKey = keyof typeof COMPONENT_REGISTRY;
@@ -222,7 +223,7 @@ export const ACTIVITY_CATALOG: Record<string, ActivityCatalogEntry> = {
     },
   },
   "explorateur-ia": {
-    componentKey: "explorateur-ia",
+    componentKey: "stepsequence",
     path: "/explorateur-ia",
     defaults: {
       completionId: "explorateur-ia",


### PR DESCRIPTION
## Summary
- register the Explorateur IA component under the generic `stepsequence` key for activity creation
- point the catalog entry to the new alias and drop the unintended style pill addition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5368d824c832299b86af490add7ff