### PR TITLE
Make Explorateur IA available in StepSequence creation

### DIFF
--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -44,6 +44,8 @@ const STEP_TYPE_LABELS: Record<string, string> = {
   form: "Formulaire",
   "rich-content": "Contenu riche",
   video: "Vidéo",
+  "explorateur-world": "Explorateur IA",
+  custom: "Explorateur IA · Module personnalisé",
   "workshop-context": "Atelier · Contexte",
   "workshop-comparison": "Atelier · Comparaison",
   "workshop-synthesis": "Atelier · Synthèse",

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -1,7 +1,7 @@
 import {
   isCompositeStepDefinition,
   type StepDefinition,
-} from "../../../../modules/step-sequence";
+} from "../../../../modules/step-sequence/types";
 
 import {
   DEFAULT_CLARTE_QUIZ_CONFIG,

--- a/frontend/tests/step-sequence-registry.test.ts
+++ b/frontend/tests/step-sequence-registry.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { STEP_COMPONENT_REGISTRY } from "../src/modules/step-sequence";
+import "../src/modules/step-sequence/modules";
+
+describe("step sequence registry", () => {
+  it("expose le module Explorateur IA", () => {
+    expect(STEP_COMPONENT_REGISTRY["explorateur-world"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- expose the Explorateur IA step sequence module with a clear label in the activity editor
- break the circular dependency in Explorateur IA step definitions by importing utilities from the types module
- add a regression test ensuring the explorateur-world module is registered

## Testing
- npm install
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d545484b4c8322a97d5ffdf8b9c394