### PR TITLE
feat: drive explorateur IA quarters from config

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^14.2.1",
         "@types/react": "^18.2.46",
         "@types/react-dom": "^18.2.18",
@@ -26,6 +27,13 @@
         "vite": "^5.2.0",
         "vitest": "^1.6.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1428,6 +1436,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/react": {
       "version": "14.3.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.3.1.tgz",
@@ -2173,6 +2208,13 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2949,6 +2991,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3557,6 +3609,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4271,6 +4333,20 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -4769,6 +4845,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-literal": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^14.2.1",
     "@types/react": "^18.2.46",
     "@types/react-dom": "^18.2.18",

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -17,6 +17,7 @@ import {
   type StepComponentWithMetadata,
   type StepDefinition,
   type StepRegistry,
+  type StepSequenceActivityContextBridge,
   type StepSequenceContextValue,
   type StepSequenceWrapperPreference,
 } from "./types";
@@ -64,4 +65,5 @@ export type {
   StepSequenceRenderWrapperProps,
   StepComponentWithMetadata,
   StepSequenceWrapperPreference,
+  StepSequenceActivityContextBridge,
 };

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -232,7 +232,7 @@ function sanitizeConfig(config: unknown): NormalizedClarityMapConfig {
       obstacleCount: DEFAULT_OBSTACLE_COUNT,
       initialTarget: null,
       promptStepId: "",
-      allowInstructionInput: false,
+      allowInstructionInput: true,
       instructionLabel: "Commande transmise",
       instructionPlaceholder: "La consigne reçue s'affichera ici…",
     };
@@ -246,7 +246,7 @@ function sanitizeConfig(config: unknown): NormalizedClarityMapConfig {
   );
   const initialTarget = sanitizeGridCoord(raw.initialTarget ?? null);
   const promptStepId = typeof raw.promptStepId === "string" ? raw.promptStepId.trim() : "";
-  const allowInstructionInput = raw.allowInstructionInput === true;
+  const allowInstructionInput = raw.allowInstructionInput !== false;
   const instructionLabel =
     typeof raw.instructionLabel === "string" && raw.instructionLabel.trim()
       ? raw.instructionLabel.trim()
@@ -486,7 +486,9 @@ export function ClarityMapStep({
     }
   }, [effectiveStatus]);
 
-  const shouldShowInstructionPanel = Boolean(normalizedConfig.allowInstructionInput);
+  const shouldShowInstructionPanel = Boolean(
+    normalizedConfig.allowInstructionInput && promptInstruction === null
+  );
 
   const blockedSignature = useMemo(
     () => blocked.map((cell) => gridKey(cell)).sort().join("|"),

--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -2403,11 +2403,27 @@ function distributeIndices(total: number, count: number): number[] {
   if (count <= 0) {
     return [];
   }
-  if (count === 1 || total <= 1) {
-    return [0];
+  if (total <= 0) {
+    return Array(count).fill(0);
+  }
+  if (count === 1 || total === 1) {
+    return Array(count).fill(0);
   }
   const step = (total - 1) / (count - 1);
-  return Array.from({ length: count }, (_, index) => Math.round(index * step));
+  return Array.from({ length: count }, (_, index) => {
+    const candidate = Math.round(index * step);
+    if (!Number.isFinite(candidate)) {
+      return 0;
+    }
+    if (candidate <= 0) {
+      return 0;
+    }
+    const max = total - 1;
+    if (candidate >= max) {
+      return max;
+    }
+    return candidate;
+  });
 }
 
 const WORLD_WIDTH = 25;
@@ -2583,10 +2599,6 @@ function assignLandmarksFromPath(path: Coord[]): Record<QuarterId, { x: number; 
       ? currentDerivedData.buildingDisplayOrder
       : DEFAULT_LANDMARK_ASSIGNMENT_ORDER;
 
-  if (path.length < assignmentOrder.length) {
-    return assignments;
-  }
-
   const interiorIndices = path
     .map((_, index) => index)
     .filter((index) => index > 0 && index < path.length - 1);
@@ -2616,6 +2628,9 @@ function assignLandmarksFromPath(path: Coord[]): Record<QuarterId, { x: number; 
         continue;
       }
       const assignment = assignments[stage];
+      if (!assignment) {
+        continue;
+      }
       if (assignment.x === x && assignment.y === y) {
         indexByStage.set(stage, index);
         takenIndices.add(index);

--- a/frontend/src/pages/explorateurIA/config.ts
+++ b/frontend/src/pages/explorateurIA/config.ts
@@ -1,0 +1,335 @@
+import { isQuarterId, type QuarterId } from "./types";
+
+export type RewardStage = Exclude<QuarterId, "mairie">;
+
+export interface ExplorateurIAInventoryConfig {
+  title: string;
+  description: string;
+  hint: string;
+  icon: string;
+}
+
+export interface ExplorateurIAInventoryDefinition
+  extends ExplorateurIAInventoryConfig {
+  stage: RewardStage;
+}
+
+export interface ExplorateurIAQuarterConfig {
+  id: QuarterId;
+  label: string;
+  color: string;
+  buildingNumber?: number | null;
+  isGoal?: boolean;
+  inventory?: ExplorateurIAInventoryConfig | null;
+}
+
+function cloneInventoryConfig(
+  config: ExplorateurIAInventoryConfig | null | undefined
+): ExplorateurIAInventoryConfig | null {
+  if (!config) {
+    return null;
+  }
+  return {
+    title: config.title,
+    description: config.description,
+    hint: config.hint,
+    icon: config.icon,
+  } satisfies ExplorateurIAInventoryConfig;
+}
+
+const DEFAULT_EXPLORATEUR_QUARTERS_BASE: readonly ExplorateurIAQuarterConfig[] = Object.freeze([
+  {
+    id: "clarte",
+    label: "Quartier Clarté",
+    color: "#06d6a0",
+    buildingNumber: 1,
+    isGoal: false,
+    inventory: {
+      title: "Boussole de clarté",
+      description:
+        "Une boussole calibrée pour pointer vers les consignes les plus limpides.",
+      hint: "Réussissez le défi Clarté pour l'ajouter à votre sac.",
+      icon: "🧭",
+    },
+  },
+  {
+    id: "creation",
+    label: "Quartier Création",
+    color: "#118ab2",
+    buildingNumber: 2,
+    isGoal: false,
+    inventory: {
+      title: "Palette synthétique",
+      description:
+        "Un set modulable pour combiner styles, médias et tonalités à la demande.",
+      hint: "Terminez le défi Création pour débloquer cet outil.",
+      icon: "🎨",
+    },
+  },
+  {
+    id: "decision",
+    label: "Quartier Décision",
+    color: "#ef476f",
+    buildingNumber: 3,
+    isGoal: false,
+    inventory: {
+      title: "Balance d'arbitrage",
+      description:
+        "Une balance portative qui révèle instantanément impacts et compromis.",
+      hint: "Gagnez le défi Décision pour la remporter.",
+      icon: "⚖️",
+    },
+  },
+  {
+    id: "ethique",
+    label: "Quartier Éthique",
+    color: "#8338ec",
+    buildingNumber: 4,
+    isGoal: false,
+    inventory: {
+      title: "Lanterne déontique",
+      description:
+        "Une lanterne qui éclaire les zones d'ombre pour garder le cap éthique.",
+      hint: "Relevez le défi Éthique pour la récupérer.",
+      icon: "🕯️",
+    },
+  },
+  {
+    id: "mairie",
+    label: "Mairie (Bilan)",
+    color: "#ffd166",
+    buildingNumber: null,
+    isGoal: true,
+    inventory: null,
+  },
+]);
+
+export const DEFAULT_EXPLORATEUR_QUARTERS: readonly ExplorateurIAQuarterConfig[] =
+  DEFAULT_EXPLORATEUR_QUARTERS_BASE.map((quarter) => ({
+    ...quarter,
+    inventory: cloneInventoryConfig(quarter.inventory),
+  }));
+
+function sanitizeInventoryConfig(
+  value: unknown,
+  fallback: ExplorateurIAInventoryConfig | null
+): ExplorateurIAInventoryConfig | null {
+  if (!value || typeof value !== "object") {
+    return cloneInventoryConfig(fallback);
+  }
+  const base = value as Partial<ExplorateurIAInventoryConfig>;
+  const title =
+    typeof base.title === "string" && base.title.trim().length > 0
+      ? base.title
+      : fallback?.title ?? "";
+  const description =
+    typeof base.description === "string" && base.description.trim().length > 0
+      ? base.description
+      : fallback?.description ?? "";
+  const hint =
+    typeof base.hint === "string" && base.hint.trim().length > 0
+      ? base.hint
+      : fallback?.hint ?? "";
+  const icon =
+    typeof base.icon === "string" && base.icon.trim().length > 0
+      ? base.icon
+      : fallback?.icon ?? "";
+
+  if (!title && !description && !hint && !icon) {
+    return cloneInventoryConfig(fallback);
+  }
+
+  return {
+    title,
+    description,
+    hint,
+    icon,
+  } satisfies ExplorateurIAInventoryConfig;
+}
+
+export function sanitizeQuarterConfigs(
+  value: unknown,
+  fallback: readonly ExplorateurIAQuarterConfig[] = DEFAULT_EXPLORATEUR_QUARTERS
+): ExplorateurIAQuarterConfig[] {
+  const defaultsById = new Map<QuarterId, ExplorateurIAQuarterConfig>();
+  for (const quarter of fallback) {
+    defaultsById.set(quarter.id, quarter);
+  }
+
+  const sanitized: ExplorateurIAQuarterConfig[] = [];
+  const used = new Set<QuarterId>();
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      const candidate = item as Partial<ExplorateurIAQuarterConfig> & {
+        id?: unknown;
+        inventory?: unknown;
+      };
+      if (!isQuarterId(candidate.id)) {
+        continue;
+      }
+      const id = candidate.id;
+      if (used.has(id)) {
+        continue;
+      }
+      const defaults = defaultsById.get(id);
+      const label =
+        typeof candidate.label === "string" && candidate.label.trim().length > 0
+          ? candidate.label
+          : defaults?.label ?? id;
+      const color =
+        typeof candidate.color === "string" && candidate.color.trim().length > 0
+          ? candidate.color
+          : defaults?.color ?? "#ffffff";
+      const isGoal =
+        typeof candidate.isGoal === "boolean"
+          ? candidate.isGoal
+          : defaults?.isGoal ?? false;
+      const buildingNumber = !isGoal
+        ? typeof candidate.buildingNumber === "number" &&
+          Number.isFinite(candidate.buildingNumber)
+          ? Math.trunc(candidate.buildingNumber)
+          : defaults?.buildingNumber ?? null
+        : null;
+
+      const inventory = !isGoal
+        ? sanitizeInventoryConfig(candidate.inventory, defaults?.inventory ?? null)
+        : null;
+
+      sanitized.push({
+        id,
+        label,
+        color,
+        buildingNumber,
+        isGoal,
+        inventory,
+      });
+      used.add(id);
+    }
+  }
+
+  for (const defaults of fallback) {
+    if (used.has(defaults.id)) {
+      continue;
+    }
+    sanitized.push({
+      id: defaults.id,
+      label: defaults.label,
+      color: defaults.color,
+      buildingNumber: defaults.buildingNumber ?? null,
+      isGoal: defaults.isGoal ?? false,
+      inventory: cloneInventoryConfig(defaults.inventory),
+    });
+    used.add(defaults.id);
+  }
+
+  return sanitized;
+}
+
+export interface DerivedQuarterData {
+  quarterOrder: QuarterId[];
+  progressionSequence: RewardStage[];
+  goalIds: QuarterId[];
+  buildingDisplayOrder: QuarterId[];
+  buildingMeta: Record<QuarterId, { label: string; color: string; number?: number }>;
+  inventoryItems: ExplorateurIAInventoryDefinition[];
+}
+
+function cloneBuildingMeta(
+  meta: Record<QuarterId, { label: string; color: string; number?: number }>
+): Record<QuarterId, { label: string; color: string; number?: number }> {
+  const entries = Object.entries(meta) as Array<[
+    QuarterId,
+    { label: string; color: string; number?: number }
+  ]>;
+  return entries.reduce(
+    (acc, [id, value]) => ({
+      ...acc,
+      [id]: {
+        label: value.label,
+        color: value.color,
+        ...(value.number === undefined ? {} : { number: value.number }),
+      },
+    }),
+    {} as Record<QuarterId, { label: string; color: string; number?: number }>
+  );
+}
+
+export function deriveQuarterData(
+  quarters: readonly ExplorateurIAQuarterConfig[]
+): DerivedQuarterData {
+  const quarterOrder = quarters.map((quarter) => quarter.id);
+  const goalIds = quarters.filter((quarter) => quarter.isGoal).map((quarter) => quarter.id);
+  const progressionSequence = quarters
+    .filter((quarter) => !quarter.isGoal)
+    .map((quarter) => quarter.id as RewardStage);
+
+  const buildingDisplayOrder = [...quarters]
+    .sort((a, b) => {
+      const aGoal = Boolean(a.isGoal);
+      const bGoal = Boolean(b.isGoal);
+      if (aGoal && !bGoal) {
+        return -1;
+      }
+      if (!aGoal && bGoal) {
+        return 1;
+      }
+      return quarterOrder.indexOf(a.id) - quarterOrder.indexOf(b.id);
+    })
+    .map((quarter) => quarter.id);
+
+  const buildingMeta = quarters.reduce(
+    (acc, quarter) => {
+      const number =
+        typeof quarter.buildingNumber === "number" && Number.isFinite(quarter.buildingNumber)
+          ? Math.trunc(quarter.buildingNumber)
+          : undefined;
+      acc[quarter.id] = {
+        label: quarter.label,
+        color: quarter.color,
+        ...(number === undefined ? {} : { number }),
+      };
+      return acc;
+    },
+    {} as Record<QuarterId, { label: string; color: string; number?: number }>
+  );
+
+  const inventoryItems: ExplorateurIAInventoryDefinition[] = quarters
+    .filter((quarter) => !quarter.isGoal && quarter.inventory)
+    .map((quarter) => ({
+      stage: quarter.id as RewardStage,
+      title: quarter.inventory!.title,
+      description: quarter.inventory!.description,
+      hint: quarter.inventory!.hint,
+      icon: quarter.inventory!.icon,
+    }));
+
+  return {
+    quarterOrder,
+    progressionSequence,
+    goalIds,
+    buildingDisplayOrder,
+    buildingMeta,
+    inventoryItems,
+  } satisfies DerivedQuarterData;
+}
+
+export const DEFAULT_DERIVED_QUARTERS = deriveQuarterData(
+  DEFAULT_EXPLORATEUR_QUARTERS
+);
+
+export function cloneDerivedQuarterData(
+  data: DerivedQuarterData
+): DerivedQuarterData {
+  return {
+    quarterOrder: [...data.quarterOrder],
+    progressionSequence: [...data.progressionSequence],
+    goalIds: [...data.goalIds],
+    buildingDisplayOrder: [...data.buildingDisplayOrder],
+    buildingMeta: cloneBuildingMeta(data.buildingMeta),
+    inventoryItems: data.inventoryItems.map((item) => ({ ...item })),
+  } satisfies DerivedQuarterData;
+}

--- a/frontend/src/pages/explorateurIA/modules/QuarterBasicsDesignerModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/QuarterBasicsDesignerModule.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useId, useMemo } from "react";
+import type { ChangeEvent } from "react";
+
+import {
+  registerExplorateurIAModule,
+  type ExplorateurIAModuleConfig,
+  type ExplorateurIAModuleProps,
+} from "./registry";
+
+export interface ExplorateurQuarterBasicsConfig extends ExplorateurIAModuleConfig {
+  type: "explorateur-quarter-basics";
+  quarterId: string;
+  label: string;
+  color: string;
+  buildingNumber: number | null;
+  isGoal: boolean;
+}
+
+function sanitizeQuarterBasicsConfig(
+  config: ExplorateurIAModuleConfig
+): ExplorateurQuarterBasicsConfig {
+  const base =
+    config && typeof config === "object"
+      ? (config as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+  const quarterId =
+    typeof base.quarterId === "string" ? base.quarterId : "";
+  const label = typeof base.label === "string" ? base.label : "";
+  const color =
+    typeof base.color === "string" && base.color.trim().length > 0
+      ? base.color
+      : "#06d6a0";
+  const isGoal = Boolean(base.isGoal);
+  const buildingNumber = isGoal
+    ? null
+    : typeof base.buildingNumber === "number" &&
+      Number.isFinite(base.buildingNumber)
+    ? Math.max(1, Math.trunc(base.buildingNumber))
+    : null;
+
+  return {
+    ...base,
+    type: "explorateur-quarter-basics",
+    quarterId,
+    label,
+    color,
+    buildingNumber,
+    isGoal,
+  } satisfies ExplorateurQuarterBasicsConfig;
+}
+
+function formatBuildingNumber(value: number | null): string {
+  if (value === null || Number.isNaN(value)) {
+    return "";
+  }
+  return String(value);
+}
+
+export function ExplorateurQuarterBasicsDesignerModule({
+  config,
+  onUpdateConfig,
+}: ExplorateurIAModuleProps): JSX.Element {
+  const ids = {
+    label: useId(),
+    color: useId(),
+    number: useId(),
+    goal: useId(),
+  };
+
+  const sanitized = useMemo(
+    () => sanitizeQuarterBasicsConfig(config),
+    [config]
+  );
+
+  const emit = useCallback(
+    (patch: Partial<ExplorateurQuarterBasicsConfig>) => {
+      onUpdateConfig({ ...sanitized, ...patch });
+    },
+    [onUpdateConfig, sanitized]
+  );
+
+  const handleLabelChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      emit({ label: event.target.value });
+    },
+    [emit]
+  );
+
+  const handleColorChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      emit({ color: event.target.value });
+    },
+    [emit]
+  );
+
+  const handleBuildingNumberChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const raw = event.target.value;
+      if (!raw || raw.trim().length === 0) {
+        emit({ buildingNumber: null });
+        return;
+      }
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isFinite(parsed)) {
+        emit({ buildingNumber: Math.max(1, Math.trunc(parsed)) });
+      }
+    },
+    [emit]
+  );
+
+  const handleGoalToggle = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextIsGoal = event.target.checked;
+      emit({ isGoal: nextIsGoal, buildingNumber: nextIsGoal ? null : sanitized.buildingNumber });
+    },
+    [emit, sanitized.buildingNumber]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-orange-200 bg-white/80 p-4 shadow-sm">
+        <p className="text-sm text-orange-700">
+          Ajustez les informations principales du quartier
+          {sanitized.quarterId ? (
+            <span className="ml-1 font-semibold text-orange-800">
+              {sanitized.quarterId}
+            </span>
+          ) : null}
+          .
+        </p>
+      </div>
+      <div className="grid gap-5 lg:grid-cols-2">
+        <div className="space-y-2">
+          <label
+            className="block text-sm font-semibold text-orange-800"
+            htmlFor={ids.label}
+          >
+            Nom du quartier
+          </label>
+          <input
+            id={ids.label}
+            type="text"
+            value={sanitized.label}
+            onChange={handleLabelChange}
+            placeholder="Quartier"
+            className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200"
+          />
+        </div>
+        <div className="space-y-2">
+          <label
+            className="block text-sm font-semibold text-orange-800"
+            htmlFor={ids.color}
+          >
+            Couleur principale
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              id={ids.color}
+              type="color"
+              value={sanitized.color}
+              onChange={handleColorChange}
+              className="h-11 w-16 cursor-pointer rounded-xl border border-orange-200 bg-white"
+            />
+            <span className="text-xs font-mono text-orange-700">
+              {sanitized.color}
+            </span>
+          </div>
+        </div>
+        <div className="space-y-2">
+          <label
+            className="block text-sm font-semibold text-orange-800"
+            htmlFor={ids.number}
+          >
+            Numéro du défi
+          </label>
+          <input
+            id={ids.number}
+            type="number"
+            min={1}
+            step={1}
+            value={formatBuildingNumber(sanitized.buildingNumber)}
+            onChange={handleBuildingNumberChange}
+            disabled={sanitized.isGoal}
+            placeholder="1"
+            className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200 disabled:cursor-not-allowed disabled:bg-orange-100 disabled:text-orange-500"
+          />
+          {sanitized.isGoal ? (
+            <p className="text-xs text-orange-600">
+              L'objectif final n'affiche pas de numéro de défi.
+            </p>
+          ) : null}
+        </div>
+        <div className="space-y-2">
+          <label
+            className="flex items-center gap-3 text-sm font-semibold text-orange-800"
+            htmlFor={ids.goal}
+          >
+            <input
+              id={ids.goal}
+              type="checkbox"
+              checked={sanitized.isGoal}
+              onChange={handleGoalToggle}
+              className="h-4 w-4 rounded border-orange-300 text-orange-500 focus:ring-orange-300"
+            />
+            Quartier objectif final
+          </label>
+          <p className="text-xs text-orange-600">
+            Lorsqu'un quartier est marqué comme objectif final, il n'a plus de numéro
+            et ne propose pas de récompense d'inventaire.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+registerExplorateurIAModule(
+  "explorateur-quarter-basics",
+  ExplorateurQuarterBasicsDesignerModule
+);
+

--- a/frontend/src/pages/explorateurIA/modules/QuarterInventoryDesignerModule.tsx
+++ b/frontend/src/pages/explorateurIA/modules/QuarterInventoryDesignerModule.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useId, useMemo } from "react";
+import type { ChangeEvent } from "react";
+
+import {
+  registerExplorateurIAModule,
+  type ExplorateurIAModuleConfig,
+  type ExplorateurIAModuleProps,
+} from "./registry";
+
+export interface ExplorateurQuarterInventoryConfig
+  extends ExplorateurIAModuleConfig {
+  type: "explorateur-quarter-inventory";
+  quarterId: string;
+  enabled: boolean;
+  title: string;
+  description: string;
+  hint: string;
+  icon: string;
+}
+
+function sanitizeQuarterInventoryConfig(
+  config: ExplorateurIAModuleConfig
+): ExplorateurQuarterInventoryConfig {
+  const base =
+    config && typeof config === "object"
+      ? (config as Record<string, unknown>)
+      : ({} as Record<string, unknown>);
+
+  const quarterId =
+    typeof base.quarterId === "string" ? base.quarterId : "";
+  const enabled = Boolean(base.enabled);
+  const title = typeof base.title === "string" ? base.title : "";
+  const description =
+    typeof base.description === "string" ? base.description : "";
+  const hint = typeof base.hint === "string" ? base.hint : "";
+  const icon =
+    typeof base.icon === "string" && base.icon.trim().length > 0
+      ? base.icon
+      : "🎁";
+
+  return {
+    ...base,
+    type: "explorateur-quarter-inventory",
+    quarterId,
+    enabled,
+    title,
+    description,
+    hint,
+    icon,
+  } satisfies ExplorateurQuarterInventoryConfig;
+}
+
+export function ExplorateurQuarterInventoryDesignerModule({
+  config,
+  onUpdateConfig,
+}: ExplorateurIAModuleProps): JSX.Element {
+  const ids = {
+    enabled: useId(),
+    title: useId(),
+    description: useId(),
+    hint: useId(),
+    icon: useId(),
+  };
+
+  const sanitized = useMemo(
+    () => sanitizeQuarterInventoryConfig(config),
+    [config]
+  );
+
+  const emit = useCallback(
+    (patch: Partial<ExplorateurQuarterInventoryConfig>) => {
+      onUpdateConfig({ ...sanitized, ...patch });
+    },
+    [onUpdateConfig, sanitized]
+  );
+
+  const handleToggle = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      emit({ enabled: event.target.checked });
+    },
+    [emit]
+  );
+
+  const handleTitleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      emit({ title: event.target.value });
+    },
+    [emit]
+  );
+
+  const handleDescriptionChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      emit({ description: event.target.value });
+    },
+    [emit]
+  );
+
+  const handleHintChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      emit({ hint: event.target.value });
+    },
+    [emit]
+  );
+
+  const handleIconChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      emit({ icon: event.target.value });
+    },
+    [emit]
+  );
+
+  const disabled = !sanitized.enabled;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-orange-200 bg-white/80 p-4 shadow-sm">
+        <p className="text-sm text-orange-700">
+          Définissez la récompense obtenue en terminant ce quartier.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <label
+          className="flex items-center gap-3 text-sm font-semibold text-orange-800"
+          htmlFor={ids.enabled}
+        >
+          <input
+            id={ids.enabled}
+            type="checkbox"
+            checked={sanitized.enabled}
+            onChange={handleToggle}
+            className="h-4 w-4 rounded border-orange-300 text-orange-500 focus:ring-orange-300"
+          />
+          Activer un objet d'inventaire
+        </label>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="space-y-2">
+            <label
+              className="block text-sm font-semibold text-orange-800"
+              htmlFor={ids.icon}
+            >
+              Icône
+            </label>
+            <input
+              id={ids.icon}
+              type="text"
+              value={sanitized.icon}
+              onChange={handleIconChange}
+              disabled={disabled}
+              placeholder="Emoji ou pictogramme"
+              className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200 disabled:cursor-not-allowed disabled:bg-orange-100 disabled:text-orange-500"
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              className="block text-sm font-semibold text-orange-800"
+              htmlFor={ids.title}
+            >
+              Nom de l'objet
+            </label>
+            <input
+              id={ids.title}
+              type="text"
+              value={sanitized.title}
+              onChange={handleTitleChange}
+              disabled={disabled}
+              placeholder="Nom de la récompense"
+              className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200 disabled:cursor-not-allowed disabled:bg-orange-100 disabled:text-orange-500"
+            />
+          </div>
+          <div className="space-y-2 lg:col-span-2">
+            <label
+              className="block text-sm font-semibold text-orange-800"
+              htmlFor={ids.description}
+            >
+              Description
+            </label>
+            <textarea
+              id={ids.description}
+              value={sanitized.description}
+              onChange={handleDescriptionChange}
+              disabled={disabled}
+              rows={3}
+              placeholder="Décrivez la récompense et son utilité."
+              className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200 disabled:cursor-not-allowed disabled:bg-orange-100 disabled:text-orange-500"
+            />
+          </div>
+          <div className="space-y-2 lg:col-span-2">
+            <label
+              className="block text-sm font-semibold text-orange-800"
+              htmlFor={ids.hint}
+            >
+              Indice pour les joueurs
+            </label>
+            <textarea
+              id={ids.hint}
+              value={sanitized.hint}
+              onChange={handleHintChange}
+              disabled={disabled}
+              rows={2}
+              placeholder="Comment obtenir l'objet ?"
+              className="w-full rounded-xl border border-orange-200 bg-white px-4 py-2 text-sm text-orange-900 shadow-sm focus:border-orange-300 focus:outline-none focus:ring-2 focus:ring-orange-200 disabled:cursor-not-allowed disabled:bg-orange-100 disabled:text-orange-500"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+registerExplorateurIAModule(
+  "explorateur-quarter-inventory",
+  ExplorateurQuarterInventoryDesignerModule
+);
+

--- a/frontend/src/pages/explorateurIA/modules/index.ts
+++ b/frontend/src/pages/explorateurIA/modules/index.ts
@@ -3,3 +3,5 @@ export * from "./ClarteQuizModule";
 export * from "./CreationBuilderModule";
 export * from "./DecisionPathModule";
 export * from "./EthicsDilemmasModule";
+export * from "./QuarterBasicsDesignerModule";
+export * from "./QuarterInventoryDesignerModule";

--- a/frontend/src/pages/explorateurIA/progress.ts
+++ b/frontend/src/pages/explorateurIA/progress.ts
@@ -50,6 +50,7 @@ export interface ExplorateurProgress {
   decision: DecisionProgress;
   ethique: EthicsProgress;
   mairie: MairieProgress;
+  extras: Record<QuarterId, QuarterProgressBase>;
   visited: QuarterId[];
 }
 
@@ -60,6 +61,7 @@ export function createInitialProgress(): ExplorateurProgress {
     decision: { done: false, payloads: {} },
     ethique: { done: false, averageScore: 0, answers: [], payloads: {} },
     mairie: { done: false, payloads: {} },
+    extras: {},
     visited: [],
   };
 }
@@ -240,6 +242,17 @@ export function updateMairieProgress(
   };
 }
 
+export function updateGenericQuarterProgress(
+  previous: QuarterProgressBase | undefined,
+  payloads: QuarterPayloadMap | undefined
+): QuarterProgressBase {
+  const sanitized = sanitizePayloadMap(payloads);
+  return {
+    done: true,
+    payloads: previous ? { ...previous.payloads, ...sanitized } : sanitized,
+  } satisfies QuarterProgressBase;
+}
+
 export function cloneProgress(progress: ExplorateurProgress): ExplorateurProgress {
   return {
     clarte: { ...progress.clarte, payloads: cloneValue(progress.clarte.payloads) },
@@ -276,6 +289,16 @@ export function cloneProgress(progress: ExplorateurProgress): ExplorateurProgres
         ? cloneValue(progress.mairie.reflection)
         : progress.mairie.reflection,
     },
+    extras: Object.entries(progress.extras).reduce(
+      (acc, [id, extra]) => {
+        acc[id as QuarterId] = {
+          done: extra.done,
+          payloads: cloneValue(extra.payloads),
+        } satisfies QuarterProgressBase;
+        return acc;
+      },
+      {} as Record<QuarterId, QuarterProgressBase>
+    ),
     visited: [...progress.visited],
   };
 }

--- a/frontend/src/pages/explorateurIA/types.ts
+++ b/frontend/src/pages/explorateurIA/types.ts
@@ -6,11 +6,38 @@ export const DEFAULT_QUARTER_IDS = [
   "mairie",
 ] as const;
 
-export type QuarterId = (typeof DEFAULT_QUARTER_IDS)[number];
+export type QuarterId = string;
+
+const QUARTER_ID_MAX_LENGTH = 48;
+const QUARTER_ID_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+function normalizeDiacritics(source: string): string {
+  return source.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+export function normalizeQuarterId(value: unknown): QuarterId | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = normalizeDiacritics(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/--+/g, "-")
+    .slice(0, QUARTER_ID_MAX_LENGTH);
+  if (!normalized || !QUARTER_ID_PATTERN.test(normalized)) {
+    return null;
+  }
+  return normalized as QuarterId;
+}
 
 export function isQuarterId(value: unknown): value is QuarterId {
-  return (
-    typeof value === "string" &&
-    (DEFAULT_QUARTER_IDS as readonly string[]).includes(value)
-  );
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return QUARTER_ID_PATTERN.test(trimmed);
 }

--- a/frontend/src/pages/explorateurIA/types.ts
+++ b/frontend/src/pages/explorateurIA/types.ts
@@ -1,13 +1,16 @@
-export type QuarterId = "clarte" | "creation" | "decision" | "ethique" | "mairie";
-
-export const QUARTER_ORDER: QuarterId[] = [
+export const DEFAULT_QUARTER_IDS = [
   "clarte",
   "creation",
   "decision",
   "ethique",
   "mairie",
-];
+] as const;
+
+export type QuarterId = (typeof DEFAULT_QUARTER_IDS)[number];
 
 export function isQuarterId(value: unknown): value is QuarterId {
-  return typeof value === "string" && (QUARTER_ORDER as string[]).includes(value);
+  return (
+    typeof value === "string" &&
+    (DEFAULT_QUARTER_IDS as readonly string[]).includes(value)
+  );
 }

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["tests/setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- centralize the Explorateur IA quarter metadata in a dedicated config module and derive progression, buildings and inventory dynamically from it
- update world generation, gating, exports and step editing to respect the configured order while keeping Clarity Map defaults consistent with prompt modules
- add the jest-dom vitest setup to retain matcher support now that dynamic config is in place

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d584995f5c8322af2cb177041d19de