### PR TITLE
feat: add randomized variations to Explorateur IA theme

### DIFF
--- a/frontend/src/pages/explorateurIA/audio/chiptuneTheme.ts
+++ b/frontend/src/pages/explorateurIA/audio/chiptuneTheme.ts
@@ -81,8 +81,32 @@ function createNoiseWave(context: AudioContext): PeriodicWave {
   return context.createPeriodicWave(real, imag, { disableNormalization: true });
 }
 
-function createMelodyPattern(): PatternNote[] {
-  const sequence: Array<[number, number, string, number?]> = [
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, value));
+
+const jitterValue = (value: number, amount: number) =>
+  value + (Math.random() * 2 - 1) * amount;
+
+const pickVariantIndex = (
+  variantCount: number,
+  previousIndex: number
+) => {
+  if (variantCount <= 1) {
+    return 0;
+  }
+  let index = Math.floor(Math.random() * variantCount);
+  if (index === previousIndex) {
+    index = (index + 1 + Math.floor(Math.random() * (variantCount - 1))) % variantCount;
+  }
+  return index;
+};
+
+type MelodySequenceEntry = [number, number, string, number?];
+type BassSequenceEntry = [number, number, string, number?, OscillatorType?];
+type NoiseSequenceEntry = [number, number, number?];
+
+const MELODY_VARIANTS: MelodySequenceEntry[][] = [
+  [
     [0, 0.5, "C5"],
     [0.5, 0.5, "E5"],
     [1, 0.5, "G5"],
@@ -96,19 +120,60 @@ function createMelodyPattern(): PatternNote[] {
     [5.5, 0.5, "G5"],
     [6, 1, "F5", 0.8],
     [7, 1, "E5", 0.7],
-  ];
+  ],
+  [
+    [0, 0.5, "C5"],
+    [0.5, 0.5, "D5", 0.9],
+    [1, 0.5, "E5", 0.95],
+    [1.5, 0.5, "G5"],
+    [2, 0.5, "A5"],
+    [2.5, 0.5, "G5", 0.85],
+    [3, 1, "E5", 0.9],
+    [4, 0.5, "D5"],
+    [4.5, 0.5, "F5"],
+    [5, 0.5, "A5"],
+    [5.5, 0.5, "G5"],
+    [6, 0.5, "F5", 0.85],
+    [6.5, 0.5, "D5", 0.9],
+    [7, 1, "G5", 0.75],
+  ],
+  [
+    [0, 0.5, "C5"],
+    [0.5, 0.5, "G5", 0.85],
+    [1, 0.5, "A5"],
+    [1.5, 0.5, "G5"],
+    [2, 0.5, "F5"],
+    [2.5, 0.5, "D5"],
+    [3, 0.5, "E5", 0.9],
+    [3.5, 0.5, "C5"],
+    [4, 0.5, "E5"],
+    [4.5, 0.5, "G5"],
+    [5, 0.5, "B5", 0.85],
+    [5.5, 0.5, "A5"],
+    [6, 1, "F5", 0.8],
+    [7, 1, "E5", 0.75],
+  ],
+  [
+    [0, 0.5, "E5"],
+    [0.5, 0.5, "G5"],
+    [1, 0.5, "C6", 0.9],
+    [1.5, 0.5, "B5"],
+    [2, 0.5, "A5"],
+    [2.5, 0.5, "F5"],
+    [3, 0.5, "G5", 0.85],
+    [3.5, 0.5, "E5"],
+    [4, 0.5, "C5"],
+    [4.5, 0.5, "D5"],
+    [5, 0.5, "F5"],
+    [5.5, 0.5, "E5"],
+    [6, 0.5, "D5", 0.85],
+    [6.5, 0.5, "F5", 0.9],
+    [7, 1, "G5", 0.8],
+  ],
+];
 
-  return sequence.map(([time, duration, note, velocity = 1]) => ({
-    time,
-    duration,
-    velocity,
-    frequency: noteToFrequency(note),
-    waveform: "square",
-  }));
-}
-
-function createBassPattern(): PatternNote[] {
-  const sequence: Array<[number, number, string, number?]> = [
+const BASS_VARIANTS: BassSequenceEntry[][] = [
+  [
     [0, 1, "C3", 0.8],
     [1, 1, "C2", 0.6],
     [2, 1, "F2", 0.8],
@@ -117,19 +182,40 @@ function createBassPattern(): PatternNote[] {
     [5, 1, "C2", 0.6],
     [6, 1, "F2", 0.8],
     [7, 1, "G2", 0.7],
-  ];
+  ],
+  [
+    [0, 0.5, "C2", 0.7, "square"],
+    [0.5, 0.5, "G2", 0.7, "square"],
+    [1, 0.5, "C3", 0.85, "square"],
+    [1.5, 0.5, "E3", 0.75, "triangle"],
+    [2, 0.5, "F2", 0.8, "square"],
+    [2.5, 0.5, "C3", 0.75, "triangle"],
+    [3, 1, "G2", 0.8, "square"],
+    [4, 0.5, "C2", 0.7, "square"],
+    [4.5, 0.5, "G2", 0.7, "square"],
+    [5, 0.5, "C3", 0.85, "square"],
+    [5.5, 0.5, "E3", 0.75, "triangle"],
+    [6, 0.5, "F2", 0.8, "square"],
+    [6.5, 0.5, "C3", 0.75, "triangle"],
+    [7, 1, "G2", 0.8, "square"],
+  ],
+  [
+    [0, 1, "C2", 0.75, "triangle"],
+    [1, 0.5, "E2", 0.7, "triangle"],
+    [1.5, 0.5, "G2", 0.7, "square"],
+    [2, 1, "F2", 0.85, "square"],
+    [3, 0.5, "E2", 0.7, "triangle"],
+    [3.5, 0.5, "G2", 0.8, "square"],
+    [4, 1, "C2", 0.8, "triangle"],
+    [5, 0.5, "E2", 0.7, "triangle"],
+    [5.5, 0.5, "G2", 0.7, "square"],
+    [6, 1, "F2", 0.85, "square"],
+    [7, 1, "G2", 0.8, "square"],
+  ],
+];
 
-  return sequence.map(([time, duration, note, velocity = 1]) => ({
-    time,
-    duration,
-    velocity,
-    frequency: noteToFrequency(note),
-    waveform: "square",
-  }));
-}
-
-function createNoisePattern(noiseWave: PeriodicWave): PatternNote[] {
-  const sequence: Array<[number, number, number?]> = [
+const NOISE_VARIANTS: NoiseSequenceEntry[][] = [
+  [
     [0, 0.25, 0.7],
     [0.5, 0.25, 0.5],
     [1, 0.25, 0.6],
@@ -146,17 +232,46 @@ function createNoisePattern(noiseWave: PeriodicWave): PatternNote[] {
     [6.5, 0.25, 0.5],
     [7, 0.25, 0.8],
     [7.5, 0.25, 0.5],
-  ];
-
-  return sequence.map(([time, duration, velocity = 0.6]) => ({
-    time,
-    duration,
-    velocity,
-    frequency: 220,
-    waveform: "custom",
-    periodicWave: noiseWave,
-  }));
-}
+  ],
+  [
+    [0, 0.2, 0.65],
+    [0.5, 0.3, 0.55],
+    [1, 0.2, 0.6],
+    [1.5, 0.3, 0.5],
+    [2, 0.2, 0.7],
+    [2.5, 0.2, 0.55],
+    [3, 0.3, 0.75],
+    [3.5, 0.2, 0.55],
+    [4, 0.2, 0.7],
+    [4.5, 0.2, 0.55],
+    [5, 0.3, 0.6],
+    [5.5, 0.2, 0.55],
+    [6, 0.2, 0.72],
+    [6.5, 0.2, 0.55],
+    [7, 0.3, 0.85],
+    [7.5, 0.2, 0.55],
+  ],
+  [
+    [0, 0.15, 0.6],
+    [0.25, 0.15, 0.5],
+    [0.5, 0.15, 0.65],
+    [0.75, 0.15, 0.5],
+    [1, 0.15, 0.6],
+    [1.5, 0.15, 0.55],
+    [2, 0.25, 0.7],
+    [2.5, 0.15, 0.55],
+    [3, 0.25, 0.8],
+    [3.75, 0.15, 0.55],
+    [4, 0.15, 0.65],
+    [4.5, 0.15, 0.55],
+    [5, 0.2, 0.6],
+    [5.5, 0.15, 0.55],
+    [6, 0.2, 0.7],
+    [6.5, 0.15, 0.55],
+    [7, 0.25, 0.85],
+    [7.5, 0.15, 0.55],
+  ],
+];
 
 export function createChiptuneTheme(): ChiptuneTheme {
   if (typeof window === "undefined") {
@@ -188,9 +303,67 @@ export function createChiptuneTheme(): ChiptuneTheme {
 
   const noiseWave = createNoiseWave(context);
 
-  const melodyPattern = createMelodyPattern();
-  const bassPattern = createBassPattern();
-  const noisePattern = createNoisePattern(noiseWave);
+  let lastMelodyVariantIndex = -1;
+  let lastBassVariantIndex = -1;
+  let lastNoiseVariantIndex = -1;
+
+  const createMelodyPattern = (): PatternNote[] => {
+    const variantIndex = pickVariantIndex(
+      MELODY_VARIANTS.length,
+      lastMelodyVariantIndex
+    );
+    lastMelodyVariantIndex = variantIndex;
+    const sequence = MELODY_VARIANTS[variantIndex];
+    const velocityJitter = 0.08;
+    return sequence.map(([time, duration, note, baseVelocity = 1]) => ({
+      time,
+      duration,
+      velocity: clamp(jitterValue(baseVelocity, velocityJitter), 0.1, 1),
+      frequency: noteToFrequency(note),
+      waveform: "square",
+    }));
+  };
+
+  const createBassPattern = (): PatternNote[] => {
+    const variantIndex = pickVariantIndex(
+      BASS_VARIANTS.length,
+      lastBassVariantIndex
+    );
+    lastBassVariantIndex = variantIndex;
+    const sequence = BASS_VARIANTS[variantIndex];
+    const velocityJitter = 0.07;
+    return sequence.map(
+      ([time, duration, note, baseVelocity = 0.8, waveform = "square"]) => ({
+        time,
+        duration,
+        velocity: clamp(jitterValue(baseVelocity, velocityJitter), 0.08, 0.95),
+        frequency: noteToFrequency(note),
+        waveform,
+      })
+    );
+  };
+
+  const createNoisePattern = (): PatternNote[] => {
+    const variantIndex = pickVariantIndex(
+      NOISE_VARIANTS.length,
+      lastNoiseVariantIndex
+    );
+    lastNoiseVariantIndex = variantIndex;
+    const sequence = NOISE_VARIANTS[variantIndex];
+    const velocityJitter = 0.1;
+    return sequence.map(([time, baseDuration, baseVelocity = 0.6]) => ({
+      time,
+      duration: clamp(
+        jitterValue(baseDuration, baseDuration * 0.15),
+        baseDuration * 0.7,
+        baseDuration * 1.3
+      ),
+      velocity: clamp(jitterValue(baseVelocity, velocityJitter), 0.05, 0.9),
+      frequency: 220,
+      waveform: "custom",
+      periodicWave: noiseWave,
+    }));
+  };
 
   let isPlaying = false;
   let disposed = false;
@@ -270,9 +443,9 @@ export function createChiptuneTheme(): ChiptuneTheme {
   };
 
   const scheduleLoop = (loopStart: number) => {
-    scheduleNote(melodyPattern, melodyGain, loopStart);
-    scheduleNote(bassPattern, bassGain, loopStart);
-    scheduleNote(noisePattern, noiseGain, loopStart);
+    scheduleNote(createMelodyPattern(), melodyGain, loopStart);
+    scheduleNote(createBassPattern(), bassGain, loopStart);
+    scheduleNote(createNoisePattern(), noiseGain, loopStart);
   };
 
   const scheduler = () => {


### PR DESCRIPTION
## Summary
- add multiple melody, bass and noise variants for the Explorateur IA soundtrack
- introduce lightweight jitter on velocities and durations to keep loops lively without breaking seamless playback
- ensure each loop picks a different variant to reduce repetition while retaining the original mood

## Testing
- npm run test *(fails: existing vitest suites error because isCompositeStepDefinition is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68d594a987c88322a9921b43bd7e9993