### PR TITLE
Add step sequence tools and coverage

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -14,13 +14,13 @@ import { useAdminAuth } from "../providers/AdminAuthProvider";
 import ClarityPath from "../pages/ClarityPath";
 import ClarteDabord from "../pages/ClarteDabord";
 import PromptDojo from "../pages/PromptDojo";
+import { StepSequenceActivity } from "../modules/step-sequence/StepSequenceActivity";
+import { createDefaultExplorateurWorldConfig } from "../modules/step-sequence/modules/explorateur-world";
 import {
-  StepSequenceActivity,
-  createDefaultExplorateurWorldConfig,
   isCompositeStepDefinition,
   resolveStepComponentKey,
   type StepDefinition,
-} from "../modules/step-sequence";
+} from "../modules/step-sequence/types";
 import type { ModelConfig } from "../config";
 const WORKSHOP_DEFAULT_TEXT = `L'automatisation est particulièrement utile pour structurer des notes de cours, créer des rappels et générer des résumés ciblés. Les étudiantes et étudiants qui savent dialoguer avec l'IA peuvent obtenir des analyses précises, du survol rapide jusqu'à des synthèses détaillées. Comprendre comment ajuster les paramètres du modèle aide à mieux contrôler la production, à gagner du temps et à repérer les limites de l'outil.`;
 

--- a/frontend/src/modules/step-sequence/README.md
+++ b/frontend/src/modules/step-sequence/README.md
@@ -97,3 +97,23 @@ type StepSequenceActivityConfig = {
 ```
 
 Les étapes peuvent provenir directement des props ou de la clé `steps` de ces métadonnées. Lorsque la dernière étape appelle `onAdvance`, le callback `onComplete` fourni à l’activité est déclenché avec les `payloads` agrégés par identifiant d’étape.
+
+## Tools pour la génération assistée
+
+Le fichier `tools.ts` expose une série de tools au format `Responses` pour générer dynamiquement des étapes et des activités complètes. Chaque entrée de `STEP_SEQUENCE_TOOLS` regroupe un schéma JSON (clé `definition`) et un handler TypeScript (`handler`).
+
+```ts
+import { STEP_SEQUENCE_TOOLS } from "@/modules/step-sequence";
+
+const richContentStep = STEP_SEQUENCE_TOOLS.create_rich_content_step.handler({
+  title: "Introduction",
+  body: "Définissons la mission et les objectifs.",
+});
+
+const activityPayload = STEP_SEQUENCE_TOOLS.build_step_sequence_activity.handler({
+  activityId: "atelier",
+  steps: [richContentStep],
+});
+```
+
+L’utilitaire `generateStepId` est également disponible pour dériver des identifiants compatibles avec les conventions existantes (`workshop-…`, `step-…`, etc.).

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -50,6 +50,7 @@ export {
 };
 
 export * from "./modules";
+export * from "./tools";
 
 export { isCompositeStepDefinition, resolveStepComponentKey } from "./types";
 export type { CompositeStepConfig, CompositeStepModuleDefinition } from "./types";

--- a/frontend/src/modules/step-sequence/modules/workshop/WorkshopComparisonStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/workshop/WorkshopComparisonStep.tsx
@@ -16,7 +16,7 @@ import {
   type VariantRequestParameters,
 } from "../runComparisonRequests";
 
-interface WorkshopComparisonStepConfig {
+export interface WorkshopComparisonStepConfig {
   contextStepId: string;
   defaultConfigA?: ModelConfig;
   defaultConfigB?: ModelConfig;

--- a/frontend/src/modules/step-sequence/modules/workshop/WorkshopContextStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/workshop/WorkshopContextStep.tsx
@@ -3,7 +3,7 @@ import { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
 import InfoCard from "../../../../components/InfoCard";
 import type { StepComponentProps } from "../../types";
 
-interface WorkshopContextStepConfig {
+export interface WorkshopContextStepConfig {
   defaultText?: string;
 }
 

--- a/frontend/src/modules/step-sequence/modules/workshop/WorkshopSynthesisStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/workshop/WorkshopSynthesisStep.tsx
@@ -13,7 +13,7 @@ import { useStepSequence } from "../..";
 import type { WorkshopComparisonStepState } from "./WorkshopComparisonStep";
 import type { WorkshopContextStepState } from "./WorkshopContextStep";
 
-interface WorkshopSynthesisStepConfig {
+export interface WorkshopSynthesisStepConfig {
   contextStepId: string;
   comparisonStepId: string;
 }

--- a/frontend/src/modules/step-sequence/modules/workshop/index.ts
+++ b/frontend/src/modules/step-sequence/modules/workshop/index.ts
@@ -8,7 +8,13 @@ registerStepComponent("workshop-context", WorkshopContextStep);
 registerStepComponent("workshop-comparison", WorkshopComparisonStep);
 registerStepComponent("workshop-synthesis", WorkshopSynthesisStep);
 
-export type { WorkshopContextStepState } from "./WorkshopContextStep";
-export type { WorkshopComparisonStepState } from "./WorkshopComparisonStep";
-export type { WorkshopSynthesisStepState } from "./WorkshopSynthesisStep";
+export type { WorkshopContextStepConfig, WorkshopContextStepState } from "./WorkshopContextStep";
+export type {
+  WorkshopComparisonStepConfig,
+  WorkshopComparisonStepState,
+} from "./WorkshopComparisonStep";
+export type {
+  WorkshopSynthesisStepConfig,
+  WorkshopSynthesisStepState,
+} from "./WorkshopSynthesisStep";
 

--- a/frontend/src/modules/step-sequence/tools.ts
+++ b/frontend/src/modules/step-sequence/tools.ts
@@ -1,0 +1,911 @@
+import type {
+  ActivityCardDefinition,
+  ActivityConfigEntry,
+  ActivityConfigOverrides,
+  ActivityHeaderConfig,
+  ActivityLayoutOptions,
+} from "../../config/activities";
+import type { ModelConfig } from "../../config";
+import type {
+  CompositeStepConfig,
+  CompositeStepModuleDefinition,
+  StepDefinition,
+} from "./types";
+import type {
+  RichContentMediaItem,
+  RichContentSidebar,
+  RichContentStepConfig,
+} from "./modules";
+import type { FormStepConfig } from "./modules";
+import type { VideoCaption, VideoSource, VideoStepConfig } from "./modules";
+import type {
+  WorkshopComparisonStepConfig,
+  WorkshopContextStepConfig,
+  WorkshopSynthesisStepConfig,
+} from "./modules";
+
+export type JsonSchema = Record<string, unknown>;
+
+export interface StepSequenceToolDefinition {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+  strict: true;
+}
+
+export interface StepSequenceFunctionTool<
+  TArgs,
+  TResult = StepDefinition
+> {
+  definition: StepSequenceToolDefinition;
+  handler: (args: TArgs) => TResult | Promise<TResult>;
+}
+
+type StepIdSource = Iterable<string> | undefined;
+
+function sanitizeId(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}+/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+export function generateStepId(
+  preferred: string,
+  existingIds?: StepIdSource
+): string {
+  const taken = new Set<string>();
+  if (existingIds) {
+    for (const value of existingIds) {
+      if (typeof value === "string" && value.trim()) {
+        taken.add(value.trim());
+      }
+    }
+  }
+
+  const baseCandidate = sanitizeId(preferred) || "step";
+  if (!taken.has(baseCandidate)) {
+    return baseCandidate;
+  }
+
+  let attempt = 2;
+  while (taken.has(`${baseCandidate}-${attempt}`)) {
+    attempt += 1;
+  }
+
+  return `${baseCandidate}-${attempt}`;
+}
+
+interface ToolBaseInput {
+  id?: string;
+  idHint?: string;
+  existingStepIds?: string[];
+}
+
+function resolveId(input: ToolBaseInput, fallback: string): string {
+  if (input.id && input.id.trim()) {
+    return input.id.trim();
+  }
+  const hint = input.idHint && input.idHint.trim() ? input.idHint : fallback;
+  return generateStepId(hint, input.existingStepIds);
+}
+
+interface CreateRichContentStepInput extends ToolBaseInput {
+  title: string;
+  body?: string;
+  media?: Array<
+    Pick<RichContentMediaItem, "url" | "alt" | "caption"> & { id?: string }
+  >;
+  sidebar?: RichContentSidebar;
+}
+
+const createRichContentStep: StepSequenceFunctionTool<
+  CreateRichContentStepInput
+> = {
+  definition: {
+    type: "function",
+    name: "create_rich_content_step",
+    description:
+      "Crée une étape riche en contenu (texte et médias) destinée aux présentations ou briefings.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["title"],
+      properties: {
+        id: {
+          type: "string",
+          description: "Identifiant explicite de l'étape (sinon généré).",
+        },
+        idHint: {
+          type: "string",
+          description: "Texte utilisé pour dériver l'identifiant si `id` est absent.",
+        },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+          description: "Liste d'identifiants déjà utilisés pour éviter les collisions.",
+        },
+        title: {
+          type: "string",
+          description: "Titre principal affiché pour l'étape.",
+        },
+        body: {
+          type: "string",
+          description: "Corps de texte au format Markdown simplifié.",
+        },
+        media: {
+          type: "array",
+          description: "Illustrations ou ressources à afficher sous forme de grille.",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["url"],
+            properties: {
+              id: { type: "string" },
+              url: { type: "string" },
+              alt: { type: "string" },
+              caption: { type: "string" },
+            },
+          },
+        },
+        sidebar: {
+          description: "Bloc d'accompagnement affiché dans la colonne latérale.",
+          oneOf: [
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["type", "tips"],
+              properties: {
+                type: { const: "tips" },
+                title: { type: "string" },
+                tips: {
+                  type: "array",
+                  items: { type: "string" },
+                },
+              },
+            },
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["type", "items"],
+              properties: {
+                type: { const: "checklist" },
+                title: { type: "string" },
+                items: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["label"],
+                    properties: {
+                      id: { type: "string" },
+                      label: { type: "string" },
+                      checked: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, input.title);
+
+    const media: RichContentMediaItem[] = (input.media ?? [])
+      .filter((item): item is NonNullable<typeof item> => Boolean(item?.url))
+      .map((item, index) => ({
+        id: item.id && item.id.trim() ? item.id.trim() : `${id}-media-${index + 1}`,
+        url: item.url,
+        alt: item.alt,
+        caption: item.caption,
+      }));
+
+    let sidebar: RichContentSidebar | undefined;
+    if (input.sidebar && typeof input.sidebar === "object") {
+      if (input.sidebar.type === "tips") {
+        sidebar = {
+          type: "tips",
+          title: input.sidebar.title,
+          tips: [...input.sidebar.tips],
+        };
+      } else if (input.sidebar.type === "checklist") {
+        sidebar = {
+          type: "checklist",
+          title: input.sidebar.title,
+          items: (input.sidebar.items ?? []).map((item, index) => ({
+            id:
+              item.id && item.id.trim()
+                ? item.id.trim()
+                : `${id}-item-${index + 1}`,
+            label: item.label,
+            checked: item.checked ?? false,
+          })),
+        };
+      }
+    }
+
+    const config: RichContentStepConfig = {
+      title: input.title,
+      body: input.body ?? "",
+      media,
+      sidebar,
+    };
+
+    return {
+      id,
+      component: "rich-content",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CreateFormStepInput extends ToolBaseInput {
+  fields: FormStepConfig["fields"];
+  submitLabel?: string;
+  allowEmpty?: boolean;
+  initialValues?: FormStepConfig["initialValues"];
+}
+
+const fieldOptionSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["value", "label"],
+  properties: {
+    value: { type: "string" },
+    label: { type: "string" },
+    description: { type: "string" },
+  },
+};
+
+const createFormStep: StepSequenceFunctionTool<CreateFormStepInput> = {
+  definition: {
+    type: "function",
+    name: "create_form_step",
+    description:
+      "Construit une étape de formulaire exploitant la bibliothèque interne `GuidedFields`.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["fields"],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        fields: {
+          type: "array",
+          minItems: 1,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["id", "label", "type"],
+            properties: {
+              id: { type: "string" },
+              label: { type: "string" },
+              type: {
+                type: "string",
+                enum: [
+                  "bulleted_list",
+                  "table_menu_day",
+                  "table_menu_full",
+                  "textarea_with_counter",
+                  "two_bullets",
+                  "reference_line",
+                  "single_choice",
+                  "multiple_choice",
+                ],
+              },
+              minBullets: { type: "number" },
+              maxBullets: { type: "number" },
+              maxWordsPerBullet: { type: "number" },
+              mustContainAny: {
+                type: "array",
+                items: { type: "string" },
+              },
+              meals: {
+                type: "array",
+                items: { type: "string" },
+              },
+              minWords: { type: "number" },
+              maxWords: { type: "number" },
+              forbidWords: {
+                type: "array",
+                items: { type: "string" },
+              },
+              tone: { type: "string" },
+              options: {
+                type: "array",
+                items: fieldOptionSchema,
+              },
+              minSelections: { type: "number" },
+              maxSelections: { type: "number" },
+            },
+          },
+        },
+        submitLabel: { type: "string" },
+        allowEmpty: { type: "boolean" },
+        initialValues: {
+          type: "object",
+          additionalProperties: {
+            anyOf: [
+              { type: "string" },
+              { type: "null" },
+              {
+                type: "array",
+                items: { type: "string" },
+              },
+              {
+                type: "object",
+                additionalProperties: {
+                  anyOf: [
+                    { type: "string" },
+                    {
+                      type: "object",
+                      additionalProperties: false,
+                      required: ["plat", "boisson", "dessert"],
+                      properties: {
+                        plat: { type: "string" },
+                        boisson: { type: "string" },
+                        dessert: { type: "string" },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "form-step");
+
+    const config: FormStepConfig = {
+      fields: input.fields,
+      submitLabel: input.submitLabel,
+      allowEmpty: input.allowEmpty,
+      initialValues: input.initialValues,
+    };
+
+    return {
+      id,
+      component: "form",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CreateVideoStepInput extends ToolBaseInput {
+  sources: VideoSource[];
+  poster?: string;
+  captions?: VideoCaption[];
+  autoAdvanceOnEnd?: boolean;
+  expectedDuration?: number;
+}
+
+const captionSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["src"],
+  properties: {
+    src: { type: "string" },
+    srclang: { type: "string" },
+    label: { type: "string" },
+    default: { type: "boolean" },
+  },
+};
+
+const videoSourceSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["type", "url"],
+  properties: {
+    type: { type: "string", enum: ["mp4", "hls", "youtube"] },
+    url: { type: "string" },
+  },
+};
+
+const createVideoStep: StepSequenceFunctionTool<CreateVideoStepInput> = {
+  definition: {
+    type: "function",
+    name: "create_video_step",
+    description: "Configure une étape vidéo avec sources multiples et sous-titres.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["sources"],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        sources: {
+          type: "array",
+          minItems: 1,
+          items: videoSourceSchema,
+        },
+        poster: { type: "string" },
+        captions: {
+          type: "array",
+          items: captionSchema,
+        },
+        autoAdvanceOnEnd: { type: "boolean" },
+        expectedDuration: { type: "number" },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "video-step");
+
+    const config: VideoStepConfig = {
+      sources: input.sources,
+      poster: input.poster,
+      captions: input.captions,
+      autoAdvanceOnEnd: input.autoAdvanceOnEnd,
+      expectedDuration: input.expectedDuration,
+    };
+
+    return {
+      id,
+      component: "video",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CreateWorkshopContextStepInput extends ToolBaseInput {
+  defaultText?: string;
+}
+
+const createWorkshopContextStep: StepSequenceFunctionTool<
+  CreateWorkshopContextStepInput
+> = {
+  definition: {
+    type: "function",
+    name: "create_workshop_context_step",
+    description:
+      "Prépare l'étape d'ouverture de l'atelier comparatif (collecte du texte source).",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: [],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        defaultText: {
+          type: "string",
+          description: "Texte prérempli suggéré aux utilisateurs.",
+        },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "workshop-context");
+    const config: WorkshopContextStepConfig = {
+      defaultText: input.defaultText,
+    };
+
+    return {
+      id,
+      component: "workshop-context",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CreateWorkshopComparisonStepInput extends ToolBaseInput {
+  contextStepId: string;
+  defaultConfigA?: ModelConfig;
+  defaultConfigB?: ModelConfig;
+}
+
+const modelConfigSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["model", "verbosity", "thinking"],
+  properties: {
+    model: { type: "string" },
+    verbosity: { type: "string" },
+    thinking: { type: "string" },
+  },
+};
+
+const createWorkshopComparisonStep: StepSequenceFunctionTool<
+  CreateWorkshopComparisonStepInput
+> = {
+  definition: {
+    type: "function",
+    name: "create_workshop_comparison_step",
+    description:
+      "Génère l'étape de comparaison de modèles de l'atelier (paramétrage des variantes).",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["contextStepId"],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        contextStepId: {
+          type: "string",
+          description: "Identifiant de l'étape de contexte qui fournit le texte source.",
+        },
+        defaultConfigA: modelConfigSchema,
+        defaultConfigB: modelConfigSchema,
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "workshop-comparison");
+    const config: WorkshopComparisonStepConfig = {
+      contextStepId: input.contextStepId,
+      defaultConfigA: input.defaultConfigA,
+      defaultConfigB: input.defaultConfigB,
+    };
+
+    return {
+      id,
+      component: "workshop-comparison",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CreateWorkshopSynthesisStepInput extends ToolBaseInput {
+  contextStepId: string;
+  comparisonStepId: string;
+}
+
+const createWorkshopSynthesisStep: StepSequenceFunctionTool<
+  CreateWorkshopSynthesisStepInput
+> = {
+  definition: {
+    type: "function",
+    name: "create_workshop_synthesis_step",
+    description:
+      "Assemble l'étape finale de l'atelier en s'appuyant sur les réponses générées.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["contextStepId", "comparisonStepId"],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        contextStepId: {
+          type: "string" },
+        comparisonStepId: { type: "string" },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "workshop-synthesis");
+    const config: WorkshopSynthesisStepConfig = {
+      contextStepId: input.contextStepId,
+      comparisonStepId: input.comparisonStepId,
+    };
+
+    return {
+      id,
+      component: "workshop-synthesis",
+      config,
+    } satisfies StepDefinition;
+  },
+};
+
+interface CompositeModuleInput
+  extends Partial<Omit<CompositeStepModuleDefinition, "id" | "component">> {
+  id?: string;
+  component: string;
+}
+
+interface CreateCompositeStepInput extends ToolBaseInput {
+  modules: CompositeModuleInput[];
+  autoAdvance?: boolean;
+  continueLabel?: string;
+}
+
+const compositeModuleSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["component"],
+  properties: {
+    id: { type: "string" },
+    component: { type: "string" },
+    slot: { type: "string" },
+    config: {},
+  },
+};
+
+const createCompositeStep: StepSequenceFunctionTool<
+  CreateCompositeStepInput
+> = {
+  definition: {
+    type: "function",
+    name: "create_composite_step",
+    description:
+      "Construit une étape composite agrégeant plusieurs modules réutilisables.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["modules"],
+      properties: {
+        id: { type: "string" },
+        idHint: { type: "string" },
+        existingStepIds: {
+          type: "array",
+          items: { type: "string" },
+        },
+        modules: {
+          type: "array",
+          minItems: 1,
+          items: compositeModuleSchema,
+        },
+        autoAdvance: { type: "boolean" },
+        continueLabel: { type: "string" },
+      },
+    },
+  },
+  handler: (input) => {
+    const id = resolveId(input, "composite-step");
+    const modules: CompositeStepConfig["modules"] = input.modules.map(
+      (module, index) => ({
+        id:
+          module.id && module.id.trim()
+            ? module.id.trim()
+            : `${id}-module-${index + 1}`,
+        component: module.component,
+        slot: module.slot,
+        config: module.config,
+      })
+    );
+
+    const composite: CompositeStepConfig = {
+      modules,
+      autoAdvance: input.autoAdvance,
+      continueLabel: input.continueLabel,
+    };
+
+    return {
+      id,
+      composite,
+    } satisfies StepDefinition;
+  },
+};
+
+interface BuildActivityMetadata
+  extends Partial<Omit<ActivityConfigEntry, "id" | "stepSequence">> {
+  header?: ActivityHeaderConfig;
+  layout?: ActivityLayoutOptions;
+  card?: ActivityCardDefinition;
+  overrides?: ActivityConfigOverrides | null;
+}
+
+interface BuildStepSequenceActivityInput {
+  activityId: string;
+  steps: StepDefinition[];
+  metadata?: BuildActivityMetadata;
+}
+
+const headerSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["eyebrow", "title"],
+  properties: {
+    eyebrow: { type: "string" },
+    title: { type: "string" },
+    subtitle: { type: "string" },
+    badge: { type: "string" },
+    titleAlign: { type: "string", enum: ["left", "center"] },
+  },
+};
+
+const layoutSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [],
+  properties: {
+    activityId: { type: "string" },
+    outerClassName: { type: "string" },
+    innerClassName: { type: "string" },
+    headerClassName: { type: "string" },
+    contentClassName: { type: "string" },
+    contentAs: { type: "string" },
+    withLandingGradient: { type: "boolean" },
+    useDynamicViewportHeight: { type: "boolean" },
+    withBasePadding: { type: "boolean" },
+    withBaseContentSpacing: { type: "boolean" },
+    withBaseInnerGap: { type: "boolean" },
+    actions: {},
+    headerChildren: {},
+    beforeHeader: {},
+  },
+};
+
+const cardSchema: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["title", "description", "highlights", "cta"],
+  properties: {
+    title: { type: "string" },
+    description: { type: "string" },
+    highlights: {
+      type: "array",
+      items: { type: "string" },
+    },
+    cta: {
+      type: "object",
+      additionalProperties: false,
+      required: ["label", "to"],
+      properties: {
+        label: { type: "string" },
+        to: { type: "string" },
+      },
+    },
+  },
+};
+
+const buildStepSequenceActivity: StepSequenceFunctionTool<
+  BuildStepSequenceActivityInput,
+  ActivityConfigEntry
+> = {
+  definition: {
+    type: "function",
+    name: "build_step_sequence_activity",
+    description:
+      "Assemble une configuration d'activité basée sur une suite d'étapes générées.",
+    strict: true,
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["activityId", "steps"],
+      properties: {
+        activityId: { type: "string" },
+        steps: {
+          type: "array",
+          minItems: 1,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["id"],
+            properties: {
+              id: { type: "string" },
+              component: { type: "string" },
+              config: {},
+              composite: {
+                type: "object",
+                additionalProperties: false,
+                required: ["modules"],
+                properties: {
+                  modules: {
+                    type: "array",
+                    items: compositeModuleSchema,
+                  },
+                  autoAdvance: { type: "boolean" },
+                  continueLabel: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        metadata: {
+          type: "object",
+          additionalProperties: false,
+          required: [],
+          properties: {
+            componentKey: { type: "string" },
+            path: { type: "string" },
+            completionId: { type: "string" },
+            enabled: { type: "boolean" },
+            header: headerSchema,
+            layout: layoutSchema,
+            card: cardSchema,
+            overrides: {
+              type: "object",
+              additionalProperties: false,
+              required: [],
+              properties: {
+                header: headerSchema,
+                layout: layoutSchema,
+                card: cardSchema,
+                completionId: { type: "string" },
+                stepSequence: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["id"],
+                    properties: {
+                      id: { type: "string" },
+                      component: { type: "string" },
+                      config: {},
+                      composite: {
+                        type: "object",
+                        additionalProperties: false,
+                        required: ["modules"],
+                        properties: {
+                          modules: {
+                            type: "array",
+                            items: compositeModuleSchema,
+                          },
+                          autoAdvance: { type: "boolean" },
+                          continueLabel: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  handler: async (input) => {
+    const { resolveActivityDefinition, serializeActivityDefinition } =
+      await import("../../config/activities");
+    const { activityId, steps, metadata } = input;
+    const entry: ActivityConfigEntry = {
+      id: activityId,
+      componentKey: metadata?.componentKey ?? "step-sequence",
+      path: metadata?.path,
+      completionId: metadata?.completionId,
+      enabled: metadata?.enabled,
+      header: metadata?.header,
+      layout: metadata?.layout,
+      card: metadata?.card,
+      stepSequence: steps,
+      overrides: metadata?.overrides ?? null,
+    };
+
+    const resolvedDefinition = resolveActivityDefinition(entry);
+    const definitionWithSteps = {
+      ...resolvedDefinition,
+      stepSequence: steps,
+    };
+    const serialized = serializeActivityDefinition(definitionWithSteps);
+    return serialized;
+  },
+};
+
+export const STEP_SEQUENCE_TOOLS = {
+  create_rich_content_step: createRichContentStep,
+  create_form_step: createFormStep,
+  create_video_step: createVideoStep,
+  create_workshop_context_step: createWorkshopContextStep,
+  create_workshop_comparison_step: createWorkshopComparisonStep,
+  create_workshop_synthesis_step: createWorkshopSynthesisStep,
+  create_composite_step: createCompositeStep,
+  build_step_sequence_activity: buildStepSequenceActivity,
+} as const;
+
+export type StepSequenceToolName = keyof typeof STEP_SEQUENCE_TOOLS;

--- a/frontend/tests/step-sequence/tools.test.ts
+++ b/frontend/tests/step-sequence/tools.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STEP_SEQUENCE_TOOLS,
+  generateStepId,
+  type StepDefinition,
+} from "../../src/modules/step-sequence";
+import type { ActivityConfigEntry } from "../../src/config/activities";
+
+function expectStepDefinition(step: StepDefinition): void {
+  expect(typeof step.id).toBe("string");
+  expect(step.id.length).toBeGreaterThan(0);
+}
+
+describe("STEP_SEQUENCE_TOOLS", () => {
+  it("expose des schémas stricts", () => {
+    Object.values(STEP_SEQUENCE_TOOLS).forEach((tool) => {
+      expect(tool.definition.strict).toBe(true);
+      const params = tool.definition.parameters as {
+        additionalProperties?: unknown;
+        required?: unknown;
+      };
+      expect(params.additionalProperties).toBe(false);
+      expect(Array.isArray(params.required)).toBe(true);
+    });
+  });
+
+  it("crée une étape rich-content valide", () => {
+    const tool = STEP_SEQUENCE_TOOLS.create_rich_content_step;
+    const step = tool.handler({
+      title: "Introduction",
+      body: "Bienvenue",
+      media: [
+        {
+          url: "https://example.com/cover.png",
+          alt: "Illustration",
+        },
+      ],
+      sidebar: {
+        type: "tips",
+        tips: ["Astuce"],
+      },
+    });
+
+    expectStepDefinition(step);
+    expect(step.component).toBe("rich-content");
+    expect(step.config).toMatchObject({
+      title: "Introduction",
+      body: "Bienvenue",
+    });
+    expect((step.config as { media?: unknown[] }).media).toHaveLength(1);
+  });
+
+  it("crée une étape formulaire conforme", () => {
+    const rich = STEP_SEQUENCE_TOOLS.create_rich_content_step.handler({
+      title: "Contexte",
+    });
+    const tool = STEP_SEQUENCE_TOOLS.create_form_step;
+    const step = tool.handler({
+      idHint: "questionnaire",
+      existingStepIds: [rich.id],
+      fields: [
+        {
+          id: "objectif",
+          label: "Objectif",
+          type: "textarea_with_counter",
+          minWords: 10,
+          maxWords: 200,
+        },
+      ],
+      submitLabel: "Envoyer",
+      allowEmpty: false,
+    });
+
+    expectStepDefinition(step);
+    expect(step.id).toContain("questionnaire");
+    expect(step.component).toBe("form");
+    expect(step.config).toMatchObject({
+      submitLabel: "Envoyer",
+      allowEmpty: false,
+    });
+  });
+
+  it("crée une étape vidéo enrichie", () => {
+    const tool = STEP_SEQUENCE_TOOLS.create_video_step;
+    const step = tool.handler({
+      idHint: "video-de-demo",
+      sources: [
+        { type: "mp4", url: "https://example.com/demo.mp4" },
+        { type: "hls", url: "https://example.com/demo.m3u8" },
+      ],
+      captions: [
+        { src: "https://example.com/demo.vtt", srclang: "fr" },
+      ],
+      autoAdvanceOnEnd: true,
+      expectedDuration: 120,
+    });
+
+    expectStepDefinition(step);
+    expect(step.component).toBe("video");
+    expect(step.config).toMatchObject({
+      autoAdvanceOnEnd: true,
+      expectedDuration: 120,
+    });
+  });
+
+  it("crée les étapes de l'atelier", () => {
+    const contextStep = STEP_SEQUENCE_TOOLS.create_workshop_context_step.handler({
+      defaultText: "Texte exemple",
+    });
+    const comparisonStep =
+      STEP_SEQUENCE_TOOLS.create_workshop_comparison_step.handler({
+        contextStepId: contextStep.id,
+      });
+    const synthesisStep =
+      STEP_SEQUENCE_TOOLS.create_workshop_synthesis_step.handler({
+        contextStepId: contextStep.id,
+        comparisonStepId: comparisonStep.id,
+      });
+
+    [contextStep, comparisonStep, synthesisStep].forEach((step) => {
+      expectStepDefinition(step);
+      expect(typeof step.component).toBe("string");
+    });
+  });
+
+  it("crée une étape composite", () => {
+    const tool = STEP_SEQUENCE_TOOLS.create_composite_step;
+    const step = tool.handler({
+      idHint: "recapitulatif",
+      modules: [
+        { component: "rich-content" },
+        { component: "form", slot: "sidebar" },
+      ],
+      autoAdvance: true,
+      continueLabel: "Continuer",
+    });
+
+    expectStepDefinition(step);
+    expect("composite" in step).toBe(true);
+    if ("composite" in step) {
+      expect(step.composite?.modules).toHaveLength(2);
+      expect(step.composite?.autoAdvance).toBe(true);
+      expect(step.composite?.continueLabel).toBe("Continuer");
+    }
+  });
+
+  it("assemble une activité StepSequence complète", async () => {
+    const richStep = STEP_SEQUENCE_TOOLS.create_rich_content_step.handler({
+      title: "Étape 1",
+      body: "Déroulé",
+    });
+    const formStep = STEP_SEQUENCE_TOOLS.create_form_step.handler({
+      idHint: "collecte",
+      existingStepIds: [richStep.id],
+      fields: [
+        {
+          id: "retour",
+          label: "Retour",
+          type: "textarea_with_counter",
+          minWords: 5,
+          maxWords: 100,
+        },
+      ],
+    });
+
+    const entry = await STEP_SEQUENCE_TOOLS.build_step_sequence_activity.handler({
+      activityId: "atelier",
+      steps: [richStep, formStep],
+      metadata: {
+        header: { eyebrow: "Test", title: "Atelier test" },
+      },
+    });
+
+    expect((entry as ActivityConfigEntry).id).toBe("atelier");
+    expect(entry.componentKey).toBe("step-sequence");
+    expect(entry.path).toBe("/atelier");
+    expect(entry.overrides).toBeDefined();
+    expect(entry.overrides?.header).toMatchObject({
+      eyebrow: "Test",
+      title: "Atelier test",
+    });
+    expect(entry.overrides?.stepSequence).toMatchObject([
+      { id: richStep.id, component: "rich-content" },
+      { id: formStep.id, component: "form" },
+    ]);
+  });
+
+  it("génère des identifiants compatibles", () => {
+    const first = generateStepId("Synthèse", ["atelier-intro"]);
+    const second = generateStepId("Synthèse", ["atelier-intro", first]);
+
+    expect(first).toBe("synthese");
+    expect(second).toBe("synthese-2");
+  });
+});


### PR DESCRIPTION
## Summary
- add a tools module exposing function-callable builders for step sequence steps and activities
- export workshop configs/types and document the tools entry point
- cover every tool handler with vitest

## Testing
- npm run test --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d5e21024508322b1fa0580a01f7f65