### PR TITLE
Fix missing future annotations import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import json
 import os


### PR DESCRIPTION
## Summary
- add ``from __future__ import annotations`` to postpone evaluation of type hints in ``backend/app/main.py``

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5e9bcf77c832297c6900ae63e604c