### PR TITLE
Make AI activity generation accessible without mandatory fields

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -376,10 +376,10 @@ export interface SaveActivityConfigResponse {
 }
 
 export interface ActivityGenerationDetailsPayload {
-  theme: string;
-  audience: string;
-  objectives: string;
-  deliverable: string;
+  theme?: string;
+  audience?: string;
+  objectives?: string;
+  deliverable?: string;
   constraints?: string;
 }
 

--- a/frontend/src/components/admin/AdminModal.tsx
+++ b/frontend/src/components/admin/AdminModal.tsx
@@ -30,18 +30,19 @@ export function AdminModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8">
-      <div
-        className={`w-full ${SIZE_CLASS[size]} rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl backdrop-blur`}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="admin-modal-title"
-      >
-        <div className="flex items-start justify-between gap-6">
-          <div>
-            <h2 id="admin-modal-title" className="text-xl font-semibold text-[color:var(--brand-black)]">
-              {title}
-            </h2>
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex min-h-full items-center justify-center bg-black/40 px-4 py-8">
+        <div
+          className={`w-full ${SIZE_CLASS[size]} max-h-[90vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl backdrop-blur`}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="admin-modal-title"
+        >
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <h2 id="admin-modal-title" className="text-xl font-semibold text-[color:var(--brand-black)]">
+                {title}
+              </h2>
             {description ? (
               <p className="mt-1 text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90">{description}</p>
             ) : null}
@@ -56,11 +57,12 @@ export function AdminModal({
           </button>
         </div>
         <div className="mt-6 space-y-4 text-[color:var(--brand-charcoal)]">{children}</div>
-        {footer ? (
-          <div className="mt-6 flex flex-col gap-3 border-t border-[color:var(--brand-charcoal)]/10 pt-4 text-right md:flex-row md:justify-end">
-            {footer}
-          </div>
-        ) : null}
+          {footer ? (
+            <div className="mt-6 flex flex-col gap-3 border-t border-[color:var(--brand-charcoal)]/10 pt-4 text-right md:flex-row md:justify-end">
+              {footer}
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow activity generation with optional context by relaxing backend validation and updating the prompt builder
- make the generation form optional on the selector page, improve error reporting, and keep admin-only flows functional when the token header is missing
- allow scrolling inside the admin modal on small screens to unblock access to hidden fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d664eeb540832282d5793fc9ae7bb2