### PR TITLE
Add gpt-5 option to AI activity generation

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -14,6 +14,11 @@ export const MODEL_OPTIONS = [
     value: "gpt-5-mini",
     label: "Profil expert",
     helper: "Explore davantage de nuances et de justification, parfait pour une analyse approfondie."
+  },
+  {
+    value: "gpt-5",
+    label: "Profil intégral",
+    helper: "Mobilise toute la profondeur analytique du modèle pour des scénarios exigeants et complexes."
   }
 ];
 


### PR DESCRIPTION
## Summary
- add the gpt-5 model to the shared model options used by the admin activity generator
- provide helper copy describing the new full-depth profile

## Testing
- npm test *(fails: vitest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d692ecffb0832281d3901e44635afb