### PR TITLE
Expose tool definitions for generated activities

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1145,6 +1145,7 @@ class ActivityGenerationToolCall(BaseModel):
     arguments: dict[str, Any]
     call_id: str | None = Field(default=None, alias="callId")
     arguments_text: str | None = Field(default=None, alias="argumentsText")
+    definition: dict[str, Any] | None = None
 
 
 class ActivityGenerationResponse(BaseModel):
@@ -2519,6 +2520,7 @@ def admin_generate_activity(
             call_id=call_id,
             arguments=arguments_obj,
             arguments_text=arguments_text,
+            definition=deepcopy(STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION),
         ),
         reasoning_summary=reasoning_summary or None,
     )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL, API_AUTH_KEY } from "./config";
 import type { ModelChoice, VerbosityChoice, ThinkingChoice } from "./config";
+import type { StepSequenceToolDefinition } from "./modules/step-sequence";
 
 export type FieldType =
   | "bulleted_list"
@@ -396,6 +397,7 @@ export interface ActivityGenerationToolCall {
   callId?: string | null;
   arguments: Record<string, unknown>;
   argumentsText?: string | null;
+  definition?: StepSequenceToolDefinition;
 }
 
 export interface ActivityGenerationResponse {


### PR DESCRIPTION
## Summary
- include the StepSequence tool schema in the /admin/activities/generate response so callers can inspect the function definition
- type the tool definition on the frontend to accommodate the enriched payload
- add a regression test that stubs the Responses client and verifies the function definition is forwarded to the API and echoed in the response

## Testing
- pytest backend/tests/test_admin_activities_config.py::test_admin_generate_activity_includes_tool_definition

------
https://chatgpt.com/codex/tasks/task_e_68d6a16844d0832299380c1b2dc54229