### PR TITLE
Expose step sequence tools to AI generation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,12 @@ from .lti import (
 )
 from .lti import DeepLinkContext
 from .progress_store import ActivityRecord, ProgressStore, get_progress_store
+from .step_sequence_components import (
+    STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION,
+    STEP_SEQUENCE_TOOLKIT,
+    STEP_SEQUENCE_TOOL_DEFINITIONS,
+    normalize_tool_arguments,
+)
 
 SUPPORTED_MODELS = (
     "gpt-5",
@@ -328,53 +334,6 @@ OVERRIDES_JSON_SCHEMA: dict[str, Any] = {
                 {"type": "array", "items": STEP_JSON_SCHEMA},
                 {"type": "null"},
             ]
-        },
-    },
-}
-
-
-STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
-    "type": "function",
-    "name": "build_step_sequence_activity",
-    "description": "Assemble une configuration d'activité basée sur une suite d'étapes générées.",
-    "strict": True,
-    "parameters": {
-        "type": "object",
-        "additionalProperties": False,
-        "required": ["activityId", "steps", "metadata"],
-        "properties": {
-            "activityId": {"type": "string"},
-            "steps": {
-                "type": "array",
-                "minItems": 1,
-                "items": STEP_JSON_SCHEMA,
-            },
-            "metadata": _nullable_schema(
-                {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": [
-                        "componentKey",
-                        "path",
-                        "completionId",
-                        "enabled",
-                        "header",
-                        "layout",
-                        "card",
-                        "overrides",
-                    ],
-                    "properties": {
-                        "componentKey": {"type": ["string", "null"]},
-                        "path": {"type": ["string", "null"]},
-                        "completionId": {"type": ["string", "null"]},
-                        "enabled": {"type": ["boolean", "null"]},
-                        "header": _nullable_schema(HEADER_JSON_SCHEMA),
-                        "layout": _nullable_schema(LAYOUT_JSON_SCHEMA),
-                        "card": _nullable_schema(CARD_JSON_SCHEMA),
-                        "overrides": _nullable_schema(OVERRIDES_JSON_SCHEMA),
-                    },
-                }
-            ),
         },
     },
 }
@@ -1049,38 +1008,40 @@ def _build_activity_generation_prompt(
     return "\n".join(sections)
 
 
-def _extract_first_tool_call(response: Any) -> tuple[str, str | None, Any] | None:
-    output_items = getattr(response, "output", None)
-    if output_items is None and isinstance(response, dict):
-        output_items = response.get("output")
-    if not output_items:
-        return None
+def _coerce_tool_arguments(raw_arguments: Any) -> tuple[dict[str, Any], str]:
+    arguments_obj: dict[str, Any] | None = None
+    arguments_text: str | None = None
 
-    for item in output_items:
-        item_type = getattr(item, "type", None) or (
-            item.get("type") if isinstance(item, dict) else None
-        )
-        if item_type != "function_call":
-            continue
+    if isinstance(raw_arguments, dict):
+        arguments_obj = raw_arguments
+        try:
+            arguments_text = json.dumps(raw_arguments)
+        except TypeError:  # pragma: no cover - fallback
+            arguments_text = None
+    elif isinstance(raw_arguments, (bytes, bytearray)):
+        arguments_text = raw_arguments.decode("utf-8", "ignore")
+    elif raw_arguments is not None:
+        arguments_text = str(raw_arguments)
 
-        name = getattr(item, "name", None) or (
-            item.get("name") if isinstance(item, dict) else None
-        )
-        if not name:
-            continue
+    if arguments_obj is None:
+        try:
+            parsed = json.loads(arguments_text or "null")
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise HTTPException(
+                status_code=500,
+                detail="Arguments d'outil invalides renvoyés par le modèle.",
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise HTTPException(
+                status_code=500,
+                detail="Les arguments d'outil ne sont pas un objet JSON.",
+            )
+        arguments_obj = parsed
 
-        call_id = getattr(item, "call_id", None) or (
-            item.get("call_id") if isinstance(item, dict) else None
-        )
-        arguments = getattr(item, "arguments", None)
-        if arguments is None and isinstance(item, dict):
-            arguments = item.get("arguments")
-        if arguments is None:
-            continue
+    if arguments_text is None:
+        arguments_text = json.dumps(arguments_obj)
 
-        return name, call_id, arguments
-
-    return None
+    return arguments_obj, arguments_text
 
 
 class SummaryRequest(BaseModel):
@@ -2453,81 +2414,107 @@ def admin_generate_activity(
         "structurées pour des professionnels en formation continue."
     )
     developer_message = (
-        "Réponds exclusivement via l'appel à la fonction build_step_sequence_activity. "
-        "Chaque étape doit utiliser un composant disponible et rester cohérente avec "
-        "les objectifs fournis. Assure-toi que la carte d'activité et le header sont "
-        "renseignés avec des textes concis, inclusifs et professionnels."
+        "Utilise exclusivement les fonctions fournies pour construire une activité StepSequence cohérente. "
+        "Commence par create_step_sequence_activity pour initialiser l'activité, enchaîne avec les create_* adaptées "
+        "pour définir chaque étape, puis finalise en appelant build_step_sequence_activity lorsque la configuration est complète. "
+        "Chaque étape doit rester alignée avec les objectifs fournis et renseigne la carte d'activité ainsi que le header "
+        "avec des formulations concises, inclusives et professionnelles."
     )
 
-    try:
-        response = client.responses.create(
-            model=model,
-            input=[
-                {"role": "system", "content": system_message},
-                {"role": "developer", "content": developer_message},
-                {"role": "user", "content": prompt},
-            ],
-            tools=[STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION],
-            tool_choice={"type": "function", "name": "build_step_sequence_activity"},
-            text={"verbosity": payload.verbosity},
-            reasoning={"effort": payload.thinking, "summary": "auto"},
-            parallel_tool_calls=False,
-        )
-    except Exception as exc:  # pragma: no cover - defensive
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    conversation: list[dict[str, Any]] = [
+        {"role": "system", "content": system_message},
+        {"role": "developer", "content": developer_message},
+        {"role": "user", "content": prompt},
+    ]
+    reasoning_summary: str | None = None
 
-    extracted = _extract_first_tool_call(response)
-    if not extracted:
-        raise HTTPException(
-            status_code=500,
-            detail="Le modèle n'a pas renvoyé d'appel d'outil valide.",
-        )
-
-    name, call_id, raw_arguments = extracted
-
-    arguments_obj: dict[str, Any] | None = None
-    arguments_text: str | None = None
-
-    if isinstance(raw_arguments, dict):
-        arguments_obj = raw_arguments
+    max_iterations = 12
+    for _ in range(max_iterations):
         try:
-            arguments_text = json.dumps(raw_arguments)
-        except TypeError:  # pragma: no cover - fallback
-            arguments_text = None
-    elif isinstance(raw_arguments, (bytes, bytearray)):
-        arguments_text = raw_arguments.decode("utf-8", "ignore")
-    else:
-        arguments_text = str(raw_arguments)
-
-    if arguments_obj is None:
-        try:
-            parsed = json.loads(arguments_text or "null")
-        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
-            raise HTTPException(
-                status_code=500,
-                detail="Arguments d'outil invalides renvoyés par le modèle.",
-            ) from exc
-        if not isinstance(parsed, dict):
-            raise HTTPException(
-                status_code=500,
-                detail="Les arguments d'outil ne sont pas un objet JSON.",
+            response = client.responses.create(
+                model=model,
+                input=conversation,
+                tools=STEP_SEQUENCE_TOOL_DEFINITIONS,
+                parallel_tool_calls=False,
+                text={"verbosity": payload.verbosity},
+                reasoning={"effort": payload.thinking, "summary": "auto"},
             )
-        arguments_obj = parsed
+        except Exception as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    if arguments_text is None:
-        arguments_text = json.dumps(arguments_obj)
+        reasoning_summary = _extract_reasoning_summary(response) or reasoning_summary
+        output_items = getattr(response, "output", None)
+        if not output_items:
+            continue
 
-    reasoning_summary = _extract_reasoning_summary(response) or None
+        conversation += list(output_items)
 
-    return ActivityGenerationResponse(
-        tool_call=ActivityGenerationToolCall(
-            name=name,
-            call_id=call_id,
-            arguments=arguments_obj,
-            arguments_text=arguments_text,
-            definition=deepcopy(STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION),
-        ),
-        reasoning_summary=reasoning_summary or None,
+        for item in output_items:
+            item_type = getattr(item, "type", None) or (
+                item.get("type") if isinstance(item, dict) else None
+            )
+            if item_type != "function_call":
+                continue
+
+            name = getattr(item, "name", None) or (
+                item.get("name") if isinstance(item, dict) else None
+            )
+            if not name:
+                continue
+
+            call_id = getattr(item, "call_id", None) or (
+                item.get("call_id") if isinstance(item, dict) else None
+            )
+            raw_arguments = getattr(item, "arguments", None)
+            if raw_arguments is None and isinstance(item, dict):
+                raw_arguments = item.get("arguments")
+
+            arguments_obj, arguments_text = _coerce_tool_arguments(raw_arguments)
+
+            tool_callable = STEP_SEQUENCE_TOOLKIT.get(name)
+            if tool_callable is None:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"L'outil {name} n'est pas pris en charge par le backend.",
+                )
+
+            python_arguments = normalize_tool_arguments(arguments_obj)
+            try:
+                result = tool_callable(**python_arguments)
+            except Exception as exc:  # pragma: no cover - defensive
+                raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+            try:
+                serialized_output = json.dumps(result)
+            except TypeError as exc:  # pragma: no cover - defensive
+                raise HTTPException(
+                    status_code=500,
+                    detail="Résultat d'outil non sérialisable.",
+                ) from exc
+
+            conversation.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": serialized_output,
+                }
+            )
+
+            if name == "build_step_sequence_activity":
+                return ActivityGenerationResponse(
+                    tool_call=ActivityGenerationToolCall(
+                        name=name,
+                        call_id=call_id,
+                        arguments=arguments_obj,
+                        arguments_text=arguments_text,
+                        definition=deepcopy(STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION),
+                    ),
+                    reasoning_summary=reasoning_summary or None,
+                )
+
+    raise HTTPException(
+        status_code=500,
+        detail="Le modèle n'a pas renvoyé d'activité complète après plusieurs itérations.",
     )
 
 

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -1063,7 +1063,10 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
         "strict": True,
         "parameters": _strict_object_schema(
             {
-                "stepId": _nullable_schema({"type": "string"}),
+                "stepId": {
+                    "type": "string",
+                    "description": "Identifiant unique de l'étape dans la séquence.",
+                },
                 "id": _nullable_schema({"type": "string"}),
                 "idHint": _nullable_schema({"type": "string"}),
                 "existingStepIds": _nullable_schema(
@@ -1080,8 +1083,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "submitLabel": _nullable_schema({"type": "string"}),
                 "allowEmpty": _nullable_schema({"type": "boolean"}),
                 "initialValues": _nullable_schema(_any_object_schema()),
-            },
-            required=("fields",),
+            }
         ),
     },
     {

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -26,6 +26,11 @@ from typing import Any
 StepDefinition = dict[str, Any]
 
 
+JSON_VALUE_SCHEMA: dict[str, Any] = {
+    "type": ["array", "boolean", "integer", "null", "number", "object", "string"],
+}
+
+
 def _nullable_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Return a JSON schema allowing ``null`` in addition to ``schema``."""
 
@@ -41,6 +46,16 @@ def _snake_case(name: str) -> str:
     first_pass = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     second_pass = re.sub("([a-z0-9])([A-Z])", r"\1_\2", first_pass)
     return second_pass.lower()
+
+
+def _any_object_schema() -> dict[str, Any]:
+    """Return a permissive object schema compatible with strict mode."""
+
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "patternProperties": {".*": deepcopy(JSON_VALUE_SCHEMA)},
+    }
 
 
 def create_step_sequence_activity(
@@ -816,8 +831,8 @@ STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
                     "properties": {
                         "id": {"type": "string"},
                         "component": {"type": ["string", "null"]},
-                        "config": _nullable_schema({"type": "object"}),
-                        "composite": _nullable_schema({"type": "object"}),
+                        "config": _nullable_schema(_any_object_schema()),
+                        "composite": _nullable_schema(_any_object_schema()),
                     },
                 },
             },
@@ -840,10 +855,10 @@ STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
                         "path": {"type": ["string", "null"]},
                         "completionId": {"type": ["string", "null"]},
                         "enabled": {"type": ["boolean", "null"]},
-                        "header": _nullable_schema({"type": "object"}),
-                        "layout": _nullable_schema({"type": "object"}),
-                        "card": _nullable_schema({"type": "object"}),
-                        "overrides": _nullable_schema({"type": "object"}),
+                        "header": _nullable_schema(_any_object_schema()),
+                        "layout": _nullable_schema(_any_object_schema()),
+                        "card": _nullable_schema(_any_object_schema()),
+                        "overrides": _nullable_schema(_any_object_schema()),
                     },
                 }
             ),
@@ -876,12 +891,12 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                         "properties": {
                             "id": {"type": "string"},
                             "component": {"type": ["string", "null"]},
-                            "config": _nullable_schema({"type": "object"}),
-                            "composite": _nullable_schema({"type": "object"}),
+                            "config": _nullable_schema(_any_object_schema()),
+                            "composite": _nullable_schema(_any_object_schema()),
                         },
                     },
                 },
-                "metadata": _nullable_schema({"type": "object"}),
+                "metadata": _nullable_schema(_any_object_schema()),
             },
         },
     },
@@ -960,11 +975,11 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "fields": {
                     "type": "array",
                     "minItems": 1,
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "submitLabel": {"type": "string"},
                 "allowEmpty": {"type": "boolean"},
-                "initialValues": _nullable_schema({"type": "object"}),
+                "initialValues": _nullable_schema(_any_object_schema()),
             },
         },
     },
@@ -982,12 +997,12 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "sources": {
                     "type": "array",
                     "minItems": 1,
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "poster": {"type": "string"},
                 "captions": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "autoAdvanceOnEnd": {"type": "boolean"},
                 "expectedDuration": {"type": ["number", "integer"]},
@@ -1008,10 +1023,10 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "title": {"type": "string"},
                 "helpText": {"type": "string"},
                 "missionId": {"type": "string"},
-                "roles": _nullable_schema({"type": "object"}),
+                "roles": _nullable_schema(_any_object_schema()),
                 "stages": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
             },
         },
@@ -1033,7 +1048,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "columns": {"type": "integer"},
                 "cards": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
             },
         },
@@ -1070,11 +1085,11 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "stepId": {"type": "string"},
                 "contextStepId": {"type": "string"},
                 "contextField": {"type": "string"},
-                "copy": _nullable_schema({"type": "object"}),
-                "request": _nullable_schema({"type": "object"}),
-                "variants": {"type": "object"},
-                "defaultConfigA": _nullable_schema({"type": "object"}),
-                "defaultConfigB": _nullable_schema({"type": "object"}),
+                "copy": _nullable_schema(_any_object_schema()),
+                "request": _nullable_schema(_any_object_schema()),
+                "variants": _any_object_schema(),
+                "defaultConfigA": _nullable_schema(_any_object_schema()),
+                "defaultConfigB": _nullable_schema(_any_object_schema()),
             },
         },
     },
@@ -1090,7 +1105,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "properties": {
                 "stepId": {"type": "string"},
                 "obstacleCount": {"type": "integer"},
-                "initialTarget": _nullable_schema({"type": "object"}),
+                "initialTarget": _nullable_schema(_any_object_schema()),
                 "promptStepId": {"type": "string"},
                 "allowInstructionInput": {"type": "boolean"},
                 "instructionLabel": {"type": "string"},
@@ -1130,18 +1145,18 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "required": ["stepId"],
             "properties": {
                 "stepId": {"type": "string"},
-                "terrain": _nullable_schema({"type": "object"}),
+                "terrain": _nullable_schema(_any_object_schema()),
                 "steps": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "quarterDesignerSteps": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "quarters": {
                     "type": "array",
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
             },
         },
@@ -1160,7 +1175,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "modules": {
                     "type": "array",
                     "minItems": 1,
-                    "items": {"type": "object"},
+                    "items": _any_object_schema(),
                 },
                 "autoAdvance": {"type": "boolean"},
                 "continueLabel": {"type": "string"},

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -327,8 +327,7 @@ GUIDED_FIELD_SCHEMA: dict[str, Any] = _strict_object_schema(
         }),
         "minSelections": _nullable_schema({"type": "number"}),
         "maxSelections": _nullable_schema({"type": "number"}),
-    },
-    required=("id", "label", "type"),
+    }
 )
 
 
@@ -377,6 +376,18 @@ def create_form_step(
             continue
 
         normalized_field = deepcopy(field)
+        normalized_field.setdefault("minBullets", None)
+        normalized_field.setdefault("maxBullets", None)
+        normalized_field.setdefault("maxWordsPerBullet", None)
+        normalized_field.setdefault("mustContainAny", None)
+        normalized_field.setdefault("meals", None)
+        normalized_field.setdefault("minWords", None)
+        normalized_field.setdefault("maxWords", None)
+        normalized_field.setdefault("forbidWords", None)
+        normalized_field.setdefault("tone", None)
+        normalized_field.setdefault("minSelections", None)
+        normalized_field.setdefault("maxSelections", None)
+
         options = normalized_field.get("options")
         if isinstance(options, Sequence):
             normalized_options: list[dict[str, Any]] = []
@@ -387,6 +398,8 @@ def create_form_step(
                 normalized_option.setdefault("description", None)
                 normalized_options.append(normalized_option)
             normalized_field["options"] = normalized_options
+        else:
+            normalized_field["options"] = None
 
         normalized_fields.append(normalized_field)
 

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -843,11 +843,8 @@ STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
     "name": "build_step_sequence_activity",
     "description": "Assemble une configuration d'activité basée sur une suite d'étapes générées.",
     "strict": True,
-    "parameters": {
-        "type": "object",
-        "additionalProperties": False,
-        "required": ["activityId", "steps", "metadata"],
-        "properties": {
+    "parameters": _strict_object_schema(
+        {
             "activityId": {"type": "string"},
             "steps": {
                 "type": "array",
@@ -862,20 +859,8 @@ STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
                 ),
             },
             "metadata": _nullable_schema(
-                {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": [
-                        "componentKey",
-                        "path",
-                        "completionId",
-                        "enabled",
-                        "header",
-                        "layout",
-                        "card",
-                        "overrides",
-                    ],
-                    "properties": {
+                _strict_object_schema(
+                    {
                         "componentKey": {"type": ["string", "null"]},
                         "path": {"type": ["string", "null"]},
                         "completionId": {"type": ["string", "null"]},
@@ -884,11 +869,11 @@ STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
                         "layout": _nullable_schema(_any_object_schema()),
                         "card": _nullable_schema(_any_object_schema()),
                         "overrides": _nullable_schema(_any_object_schema()),
-                    },
-                }
+                    }
+                )
             ),
-        },
-    },
+        }
+    ),
 }
 
 
@@ -898,11 +883,8 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
         "name": "create_step_sequence_activity",
         "description": "Initialise un objet activité StepSequence prêt à être complété.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["activityId", "steps", "metadata"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "activityId": {
                     "type": "string",
                     "description": "Identifiant unique de l'activité dans le catalogue.",
@@ -920,36 +902,35 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                     ),
                 },
                 "metadata": _nullable_schema(_any_object_schema()),
-            },
-        },
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_rich_content_step",
         "description": "Crée une étape riche en contenu (texte, médias, barre latérale).",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "title"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {
                     "type": "string",
                     "description": "Identifiant unique de l'étape dans la séquence.",
                 },
                 "title": {"type": "string"},
-                "body": {"type": "string"},
-                "media": {
-                    "type": "array",
-                    "items": _strict_object_schema(
-                        {
-                            "id": _nullable_schema({"type": "string"}),
-                            "url": {"type": "string"},
-                            "alt": _nullable_schema({"type": "string"}),
-                            "caption": _nullable_schema({"type": "string"}),
-                        }
-                    ),
-                },
+                "body": _nullable_schema({"type": "string"}),
+                "media": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _strict_object_schema(
+                            {
+                                "id": _nullable_schema({"type": "string"}),
+                                "url": {"type": "string"},
+                                "alt": _nullable_schema({"type": "string"}),
+                                "caption": _nullable_schema({"type": "string"}),
+                            }
+                        ),
+                    }
+                ),
                 "sidebar": _nullable_schema(
                     _strict_object_schema(
                         {
@@ -972,229 +953,211 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                         }
                     )
                 ),
-            },
-        },
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_form_step",
         "description": "Crée une étape formulaire interactive avec validations GuidedFields.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "fields"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "fields": {
                     "type": "array",
                     "minItems": 1,
                     "items": _any_object_schema(),
                 },
-                "submitLabel": {"type": "string"},
-                "allowEmpty": {"type": "boolean"},
+                "submitLabel": _nullable_schema({"type": "string"}),
+                "allowEmpty": _nullable_schema({"type": "boolean"}),
                 "initialValues": _nullable_schema(_any_object_schema()),
-            },
-        },
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_video_step",
         "description": "Définit une étape vidéo avec sources, sous-titres et options de lecture.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "sources"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "sources": {
                     "type": "array",
                     "minItems": 1,
                     "items": _any_object_schema(),
                 },
-                "poster": {"type": "string"},
-                "captions": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-                "autoAdvanceOnEnd": {"type": "boolean"},
-                "expectedDuration": {"type": ["number", "integer"]},
-            },
-        },
+                "poster": _nullable_schema({"type": "string"}),
+                "captions": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+                "autoAdvanceOnEnd": _nullable_schema({"type": "boolean"}),
+                "expectedDuration": _nullable_schema({"type": "number"}),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_simulation_chat_step",
         "description": "Configure une simulation de chat guidée par étapes.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "title", "helpText"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "title": {"type": "string"},
                 "helpText": {"type": "string"},
-                "missionId": {"type": "string"},
+                "missionId": _nullable_schema({"type": "string"}),
                 "roles": _nullable_schema(_any_object_schema()),
-                "stages": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-            },
-        },
+                "stages": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_info_cards_step",
         "description": "Construit une étape d'informations synthétiques sous forme de cartes.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "title"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
-                "eyebrow": {"type": "string"},
-                "title": {"type": "string"},
-                "description": {"type": "string"},
-                "columns": {"type": "integer"},
-                "cards": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-            },
-        },
+                "eyebrow": _nullable_schema({"type": "string"}),
+                "title": _nullable_schema({"type": "string"}),
+                "description": _nullable_schema({"type": "string"}),
+                "columns": _nullable_schema({"type": "integer"}),
+                "cards": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_prompt_evaluation_step",
         "description": "Évalue un prompt en configurant modèle, verbosité et effort de pensée.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "defaultText", "developerMessage", "model"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "defaultText": {"type": "string"},
                 "developerMessage": {"type": "string"},
                 "model": {"type": "string"},
                 "verbosity": {"type": "string"},
                 "thinking": {"type": "string"},
-            },
-        },
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_ai_comparison_step",
         "description": "Compare deux configurations IA à partir d'un même contexte utilisateur.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "contextStepId", "contextField", "variants"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
-                "contextStepId": {"type": "string"},
-                "contextField": {"type": "string"},
+                "contextStepId": _nullable_schema({"type": "string"}),
+                "contextField": _nullable_schema({"type": "string"}),
                 "copy": _nullable_schema(_any_object_schema()),
                 "request": _nullable_schema(_any_object_schema()),
-                "variants": _any_object_schema(),
+                "variants": _nullable_schema(_any_object_schema()),
                 "defaultConfigA": _nullable_schema(_any_object_schema()),
                 "defaultConfigB": _nullable_schema(_any_object_schema()),
-            },
-        },
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_clarity_map_step",
         "description": "Configure une carte Clarté d'abord (grille, obstacles, objectif).",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
-                "obstacleCount": {"type": "integer"},
+                "obstacleCount": _nullable_schema({"type": "integer"}),
                 "initialTarget": _nullable_schema(_any_object_schema()),
-                "promptStepId": {"type": "string"},
-                "allowInstructionInput": {"type": "boolean"},
-                "instructionLabel": {"type": "string"},
-                "instructionPlaceholder": {"type": "string"},
-            },
-        },
+                "promptStepId": _nullable_schema({"type": "string"}),
+                "allowInstructionInput": _nullable_schema({"type": "boolean"}),
+                "instructionLabel": _nullable_schema({"type": "string"}),
+                "instructionPlaceholder": _nullable_schema({"type": "string"}),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_clarity_prompt_step",
         "description": "Crée la consigne d'entrée pour une activité Clarté d'abord.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "promptLabel"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
-                "promptLabel": {"type": "string"},
-                "promptPlaceholder": {"type": "string"},
-                "model": {"type": "string"},
-                "verbosity": {"type": "string"},
-                "thinking": {"type": "string"},
-                "developerPrompt": {"type": "string"},
-                "settingsMode": {"type": "string"},
-            },
-        },
+                "promptLabel": _nullable_schema({"type": "string"}),
+                "promptPlaceholder": _nullable_schema({"type": "string"}),
+                "model": _nullable_schema({"type": "string"}),
+                "verbosity": _nullable_schema({"type": "string"}),
+                "thinking": _nullable_schema({"type": "string"}),
+                "developerPrompt": _nullable_schema({"type": "string"}),
+                "settingsMode": _nullable_schema({"type": "string"}),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_explorateur_world_step",
         "description": "Initialise une étape Explorateur IA (monde, quartiers, étapes).",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "terrain": _nullable_schema(_any_object_schema()),
-                "steps": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-                "quarterDesignerSteps": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-                "quarters": {
-                    "type": "array",
-                    "items": _any_object_schema(),
-                },
-            },
-        },
+                "steps": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+                "quarterDesignerSteps": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+                "quarters": _nullable_schema(
+                    {
+                        "type": "array",
+                        "items": _any_object_schema(),
+                    }
+                ),
+            }
+        ),
     },
     {
         "type": "function",
         "name": "create_composite_step",
         "description": "Assemble une étape composite regroupant plusieurs modules.",
         "strict": True,
-        "parameters": {
-            "type": "object",
-            "additionalProperties": False,
-            "required": ["stepId", "modules"],
-            "properties": {
+        "parameters": _strict_object_schema(
+            {
                 "stepId": {"type": "string"},
                 "modules": {
                     "type": "array",
                     "minItems": 1,
                     "items": _any_object_schema(),
                 },
-                "autoAdvance": {"type": "boolean"},
-                "continueLabel": {"type": "string"},
-            },
-        },
+                "autoAdvance": _nullable_schema({"type": "boolean"}),
+                "continueLabel": _nullable_schema({"type": "string"}),
+            }
+        ),
     },
     STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION,
 ]

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -876,7 +876,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
         "parameters": {
             "type": "object",
             "additionalProperties": False,
-            "required": ["activityId"],
+            "required": ["activityId", "steps", "metadata"],
             "properties": {
                 "activityId": {
                     "type": "string",
@@ -884,6 +884,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 },
                 "steps": {
                     "type": "array",
+                    "minItems": 0,
                     "items": {
                         "type": "object",
                         "additionalProperties": False,

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -1,0 +1,1189 @@
+"""Helper utilities for building StepSequence activities and steps.
+
+The step sequence designer relies on a catalogue of React components that can
+be orchestrated by the Responses API.  To offer the same experience during the
+server-side generation flow we expose small factory functions – one per
+component – that return fully hydrated step definitions.  Each factory
+explicitly documents the intent, required payload and default behaviour of the
+component so that downstream call sites (including function-calling workflows)
+can serialise the result without having to guess optional keys.
+
+The module also exposes thin ``add_*`` helpers that simply append a newly
+created step to an existing list.  They are convenient when unit testing and
+when composing steps in imperative scripts, whereas orchestration layers that
+follow a tool-calling loop will typically call the ``create_*`` factories
+directly and manage the sequencing themselves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, MutableSequence, Sequence
+from copy import deepcopy
+import re
+from typing import Any
+
+
+StepDefinition = dict[str, Any]
+
+
+def _nullable_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a JSON schema allowing ``null`` in addition to ``schema``."""
+
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+def _snake_case(name: str) -> str:
+    """Convert ``camelCase``/``PascalCase`` identifiers to ``snake_case``."""
+
+    if "_" in name:
+        return name
+
+    first_pass = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    second_pass = re.sub("([a-z0-9])([A-Z])", r"\1_\2", first_pass)
+    return second_pass.lower()
+
+
+def create_step_sequence_activity(
+    *,
+    activity_id: str,
+    steps: Sequence[StepDefinition] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return a canonical payload describing a new StepSequence activity.
+
+    The IA driven generation flow always starts by creating an empty activity
+    shell.  This structure mirrors the objects produced on the frontend and is
+    therefore directly compatible with the registry stored in
+    ``frontend/src/modules/step-sequence``.  ``steps`` defaults to an empty
+    sequence and ``metadata`` allows pre-populating the activity card, header or
+    layout overrides when they are already known by the caller.
+
+    Parameters
+    ----------
+    activity_id:
+        Identifier used by the activity catalogue.
+    steps:
+        Optional collection of pre-built step definitions.  When omitted the
+        sequence starts empty so that the orchestration layer can decide which
+        component factories to call next.
+    metadata:
+        Optional mapping that may contain ``componentKey``, ``path``,
+        ``completionId``, ``enabled``, ``header``, ``layout`` and ``card``
+        entries.  Missing keys are explicitly set to ``None`` to ease
+        serialisation.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary ready to be serialised and returned to the frontend.
+    """
+
+    normalized_metadata: dict[str, Any] = {
+        "componentKey": "step-sequence",
+        "path": None,
+        "completionId": None,
+        "enabled": None,
+        "header": None,
+        "layout": None,
+        "card": None,
+        "overrides": None,
+    }
+    if isinstance(metadata, Mapping):
+        normalized_metadata.update(
+            {
+                "componentKey": metadata.get("componentKey", "step-sequence"),
+                "path": metadata.get("path"),
+                "completionId": metadata.get("completionId"),
+                "enabled": metadata.get("enabled"),
+                "header": deepcopy(metadata.get("header")),
+                "layout": deepcopy(metadata.get("layout")),
+                "card": deepcopy(metadata.get("card")),
+                "overrides": deepcopy(metadata.get("overrides")),
+            }
+        )
+
+    return {
+        "id": str(activity_id),
+        "componentKey": normalized_metadata["componentKey"],
+        "path": normalized_metadata["path"],
+        "completionId": normalized_metadata["completionId"],
+        "enabled": normalized_metadata["enabled"],
+        "header": normalized_metadata["header"],
+        "layout": normalized_metadata["layout"],
+        "card": normalized_metadata["card"],
+        "stepSequence": list(steps) if steps else [],
+        "overrides": normalized_metadata["overrides"],
+    }
+
+
+def _append_step(
+    step_sequence: MutableSequence[StepDefinition], step: StepDefinition
+) -> StepDefinition:
+    step_sequence.append(step)
+    return step
+
+
+def create_rich_content_step(
+    *,
+    step_id: str,
+    title: str,
+    body: str | None = None,
+    media: Sequence[Mapping[str, Any]] | None = None,
+    sidebar: Mapping[str, Any] | None = None,
+) -> StepDefinition:
+    """Crée une étape « rich-content » structurée autour d'un contenu narratif.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant unique de l'étape au sein de la séquence.
+    title:
+        Titre principal affiché en en-tête du bloc.
+    body:
+        Texte HTML ou Markdown enrichi constituant le coeur de l'explication.
+    media:
+        Collection optionnelle de médias (images, vidéos) affichés en galerie.
+        Chaque entrée est normalisée pour garantir la présence d'un identifiant
+        stable, d'une URL et des métadonnées associées.
+    sidebar:
+        Configuration d'une colonne latérale. Elle peut représenter soit une
+        liste d'astuces (`type="tips"`), soit une checklist (`type="checklist"`).
+
+    Returns
+    -------
+    StepDefinition
+        Dictionnaire prêt à être intégré dans la séquence StepSequence.
+    """
+
+    normalized_media: list[dict[str, Any]] = []
+    if media:
+        for index, item in enumerate(media, start=1):
+            if not isinstance(item, Mapping):
+                continue
+            url = item.get("url")
+            if not url:
+                continue
+            normalized_media.append(
+                {
+                    "id": str(item.get("id") or f"{step_id}-media-{index}"),
+                    "url": str(url),
+                    "alt": item.get("alt"),
+                    "caption": item.get("caption"),
+                }
+            )
+
+    normalized_sidebar: dict[str, Any] | None = None
+    if isinstance(sidebar, Mapping):
+        sidebar_type = sidebar.get("type")
+        if sidebar_type == "tips":
+            tips = sidebar.get("tips")
+            normalized_sidebar = {
+                "type": "tips",
+                "title": sidebar.get("title"),
+                "tips": [str(item) for item in tips] if isinstance(tips, Sequence) else [],
+            }
+        elif sidebar_type == "checklist":
+            items: list[dict[str, Any]] = []
+            raw_items = sidebar.get("items")
+            if isinstance(raw_items, Sequence):
+                for index, raw_item in enumerate(raw_items, start=1):
+                    if not isinstance(raw_item, Mapping):
+                        continue
+                    label = raw_item.get("label")
+                    if label is None:
+                        continue
+                    items.append(
+                        {
+                            "id": raw_item.get("id")
+                            or f"{step_id}-item-{index}",
+                            "label": str(label),
+                            "checked": bool(raw_item.get("checked", False)),
+                        }
+                    )
+            normalized_sidebar = {
+                "type": "checklist",
+                "title": sidebar.get("title"),
+                "items": items,
+            }
+
+    config = {
+        "title": str(title),
+        "body": body or "",
+        "media": normalized_media,
+        "sidebar": normalized_sidebar,
+    }
+    return {
+        "id": str(step_id),
+        "component": "rich-content",
+        "config": config,
+        "composite": None,
+    }
+ 
+
+def add_rich_content_step(
+    step_sequence: MutableSequence[StepDefinition],
+    **kwargs: Any,
+) -> StepDefinition:
+    """Append a rich content step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_rich_content_step(**kwargs))
+
+
+def create_form_step(
+    *,
+    step_id: str,
+    fields: Sequence[Mapping[str, Any]],
+    submit_label: str | None = None,
+    allow_empty: bool | None = None,
+    initial_values: Mapping[str, Any] | None = None,
+) -> StepDefinition:
+    """Crée une étape « form » interactive basée sur des GuidedFields.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant unique de l'étape.
+    fields:
+        Liste ordonnée de dictionnaires décrivant les champs (id, label,
+        validations…). Chaque entrée est copiée profondément pour éviter les
+        effets de bord.
+    submit_label:
+        Intitulé du bouton de validation. Laisse la valeur par défaut du
+        composant lorsqu'il est omis.
+    allow_empty:
+        Autorise ou non l'envoi du formulaire sans réponse.
+    initial_values:
+        Valeurs pré-remplies associées aux ids de champs.
+
+    Returns
+    -------
+    StepDefinition
+        Définition d'étape prête à être ajoutée à la séquence.
+    """
+
+    normalized_fields = [deepcopy(field) for field in fields if isinstance(field, Mapping)]
+
+    config = {
+        "fields": normalized_fields,
+        "submitLabel": submit_label,
+        "allowEmpty": allow_empty,
+        "initialValues": deepcopy(initial_values) if isinstance(initial_values, Mapping) else None,
+    }
+    return {
+        "id": str(step_id),
+        "component": "form",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_form_step(step_sequence: MutableSequence[StepDefinition], **kwargs: Any) -> StepDefinition:
+    """Append a form step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_form_step(**kwargs))
+
+
+def create_video_step(
+    *,
+    step_id: str,
+    sources: Sequence[Mapping[str, Any]],
+    poster: str | None = None,
+    captions: Sequence[Mapping[str, Any]] | None = None,
+    auto_advance_on_end: bool | None = None,
+    expected_duration: int | float | None = None,
+) -> StepDefinition:
+    """Crée une étape « video » configurée pour la lecture multimédia.
+
+    Chaque source et piste de sous-titres est copiée pour préserver
+    l'immuabilité de la configuration retournée. Les options supplémentaires
+    permettent d'afficher une image d'aperçu, de déclencher l'avancement
+    automatique en fin de lecture ou d'indiquer une durée estimée.
+    """
+
+    normalized_sources = [deepcopy(source) for source in sources if isinstance(source, Mapping)]
+    normalized_captions = (
+        [deepcopy(caption) for caption in captions if isinstance(caption, Mapping)]
+        if captions
+        else []
+    )
+
+    config = {
+        "sources": normalized_sources,
+        "poster": poster,
+        "captions": normalized_captions,
+        "autoAdvanceOnEnd": auto_advance_on_end,
+        "expectedDuration": expected_duration,
+    }
+    return {
+        "id": str(step_id),
+        "component": "video",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_video_step(step_sequence: MutableSequence[StepDefinition], **kwargs: Any) -> StepDefinition:
+    """Append a video step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_video_step(**kwargs))
+
+
+def create_simulation_chat_step(
+    *,
+    step_id: str,
+    title: str,
+    help_text: str,
+    mission_id: str | None = None,
+    roles: Mapping[str, Any] | None = None,
+    stages: Sequence[Mapping[str, Any]] | None = None,
+) -> StepDefinition:
+    """Crée une étape « simulation-chat » dédiée aux jeux de rôle guidés.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant de l'étape.
+    title:
+        Titre pédagogique présenté aux apprenants.
+    help_text:
+        Texte d'accompagnement expliquant la mission.
+    mission_id:
+        Référence optionnelle vers un scénario de simulation pré-enregistré.
+    roles:
+        Dictionnaire avec les intitulés des rôles `ai` et `user`.
+    stages:
+        Liste ordonnée d'étapes internes, chacune contenant un prompt et une
+        configuration de champs pour la réponse de l'utilisateur.
+
+    Returns
+    -------
+    StepDefinition
+        Définition d'étape compatible avec le renderer frontend.
+    """
+
+    normalized_roles = {
+        "ai": roles.get("ai") if isinstance(roles, Mapping) else None,
+        "user": roles.get("user") if isinstance(roles, Mapping) else None,
+    }
+
+    normalized_stages: list[dict[str, Any]] = []
+    if stages:
+        for index, stage in enumerate(stages, start=1):
+            if not isinstance(stage, Mapping):
+                continue
+            normalized_stages.append(
+                {
+                    "id": stage.get("id") or f"{step_id}-stage-{index}",
+                    "prompt": stage.get("prompt", ""),
+                    "fields": deepcopy(stage.get("fields")) if stage.get("fields") is not None else [],
+                    "allowEmpty": stage.get("allowEmpty"),
+                    "submitLabel": stage.get("submitLabel"),
+                }
+            )
+
+    config = {
+        "title": str(title),
+        "help": str(help_text),
+        "missionId": mission_id,
+        "roles": normalized_roles,
+        "stages": normalized_stages,
+    }
+    return {
+        "id": str(step_id),
+        "component": "simulation-chat",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_simulation_chat_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append a simulation chat step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_simulation_chat_step(**kwargs))
+
+
+def create_info_cards_step(
+    *,
+    step_id: str,
+    eyebrow: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    columns: int | None = None,
+    cards: Sequence[Mapping[str, Any]] | None = None,
+) -> StepDefinition:
+    """Crée une étape « info-cards » pour présenter des points clés synthétiques.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant unique de l'étape.
+    eyebrow:
+        Sur-titre ou rubrique optionnelle.
+    title:
+        Titre principal de la section.
+    description:
+        Texte introductif accompagnant les cartes.
+    columns:
+        Nombre de colonnes à afficher (mise en page responsive).
+    cards:
+        Collection de cartes comprenant titre, description, tonalité visuelle et
+        éventuellement une liste d'éléments ou un appel à l'action.
+
+    Returns
+    -------
+    StepDefinition
+        Configuration complète de l'étape.
+    """
+
+    normalized_cards: list[dict[str, Any]] = []
+    if cards:
+        for card in cards:
+            if not isinstance(card, Mapping):
+                continue
+            normalized_cards.append(
+                {
+                    "title": card.get("title", ""),
+                    "description": card.get("description", ""),
+                    "tone": card.get("tone"),
+                    "items": deepcopy(card.get("items")) if card.get("items") is not None else None,
+                }
+            )
+
+    config = {
+        "eyebrow": eyebrow,
+        "title": title,
+        "description": description,
+        "columns": columns,
+        "cards": normalized_cards,
+    }
+    return {
+        "id": str(step_id),
+        "component": "info-cards",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_info_cards_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append an info cards step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_info_cards_step(**kwargs))
+
+
+def create_prompt_evaluation_step(
+    *,
+    step_id: str,
+    default_text: str,
+    developer_message: str,
+    model: str,
+    verbosity: str,
+    thinking: str,
+) -> StepDefinition:
+    """Crée une étape « prompt-evaluation » pour tester des variantes de prompts.
+
+    Les paramètres `model`, `verbosity` et `thinking` déterminent le profil de
+    l'assistant utilisé lors de l'évaluation. La consigne développeur est
+    stockée telle quelle afin que le frontend puisse alimenter le champ système
+    du modèle.
+    """
+
+    config = {
+        "defaultText": default_text,
+        "developerMessage": developer_message,
+        "model": model,
+        "verbosity": verbosity,
+        "thinking": thinking,
+    }
+    return {
+        "id": str(step_id),
+        "component": "prompt-evaluation",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_prompt_evaluation_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append a prompt evaluation step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_prompt_evaluation_step(**kwargs))
+
+
+def create_ai_comparison_step(
+    *,
+    step_id: str,
+    context_step_id: str | None = None,
+    context_field: str | None = None,
+    copy: Mapping[str, Any] | None = None,
+    request: Mapping[str, Any] | None = None,
+    variants: Mapping[str, Any] | None = None,
+    default_config_a: Mapping[str, Any] | None = None,
+    default_config_b: Mapping[str, Any] | None = None,
+) -> StepDefinition:
+    """Crée une étape « ai-comparison » comparant deux configurations d'assistants.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant de l'étape de comparaison.
+    context_step_id:
+        Étape source dont on réutilise éventuellement la production.
+    context_field:
+        Nom du champ contenant les données à réinjecter.
+    copy:
+        Textes d'interface (titres, descriptions, labels) affichés autour du
+        comparatif.
+    request:
+        Paramètres techniques de l'appel IA (endpoint, payload additionnel).
+    variants:
+        Définition éditoriale de chaque variante (A/B) proposée à l'utilisateur.
+    default_config_a / default_config_b:
+        Paramètres par défaut des deux assistants (modèle, température…).
+
+    Returns
+    -------
+    StepDefinition
+        Étape prête à être rendue par le module de comparaison.
+    """
+
+    config = {
+        "contextStepId": context_step_id,
+        "contextField": context_field,
+        "copy": deepcopy(copy) if isinstance(copy, Mapping) else None,
+        "request": deepcopy(request) if isinstance(request, Mapping) else None,
+        "variants": deepcopy(variants) if isinstance(variants, Mapping) else None,
+        "defaultConfigA": deepcopy(default_config_a) if isinstance(default_config_a, Mapping) else None,
+        "defaultConfigB": deepcopy(default_config_b) if isinstance(default_config_b, Mapping) else None,
+    }
+    return {
+        "id": str(step_id),
+        "component": "ai-comparison",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_ai_comparison_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append an AI comparison step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_ai_comparison_step(**kwargs))
+
+
+def create_clarity_map_step(
+    *,
+    step_id: str,
+    obstacle_count: int | None = None,
+    initial_target: Mapping[str, Any] | None = None,
+    prompt_step_id: str | None = None,
+    allow_instruction_input: bool | None = None,
+    instruction_label: str | None = None,
+    instruction_placeholder: str | None = None,
+) -> StepDefinition:
+    """Crée une étape « clarity-map » pour la navigation sur la grille Clarity.
+
+    Les paramètres permettent de calibrer la difficulté (nombre d'obstacles), de
+    définir la cible initiale ainsi que les libellés guidant la rédaction de
+    nouvelles instructions par l'utilisateur.
+    """
+
+    config = {
+        "obstacleCount": obstacle_count,
+        "initialTarget": deepcopy(initial_target) if isinstance(initial_target, Mapping) else None,
+        "promptStepId": prompt_step_id,
+        "allowInstructionInput": allow_instruction_input,
+        "instructionLabel": instruction_label,
+        "instructionPlaceholder": instruction_placeholder,
+    }
+    return {
+        "id": str(step_id),
+        "component": "clarity-map",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_clarity_map_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append a clarity map step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_clarity_map_step(**kwargs))
+
+
+def create_clarity_prompt_step(
+    *,
+    step_id: str,
+    prompt_label: str | None = None,
+    prompt_placeholder: str | None = None,
+    model: str | None = None,
+    verbosity: str | None = None,
+    thinking: str | None = None,
+    developer_prompt: str | None = None,
+    settings_mode: str | None = None,
+) -> StepDefinition:
+    """Crée une étape « clarity-prompt » qui configure l'assistant Clarity.
+
+    Les différents champs contrôlent l'apparence du formulaire et les options
+    IA (modèle, verbosité, effort de raisonnement). `settings_mode` ajuste le
+    niveau d'édition autorisé côté interface (lecture seule, éditable…).
+    """
+
+    config = {
+        "promptLabel": prompt_label,
+        "promptPlaceholder": prompt_placeholder,
+        "model": model,
+        "verbosity": verbosity,
+        "thinking": thinking,
+        "developerPrompt": developer_prompt,
+        "settingsMode": settings_mode,
+    }
+    return {
+        "id": str(step_id),
+        "component": "clarity-prompt",
+        "config": config,
+        "composite": None,
+    }
+
+
+def add_clarity_prompt_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append a clarity prompt step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_clarity_prompt_step(**kwargs))
+
+
+def create_explorateur_world_step(
+    *,
+    step_id: str,
+    config: Mapping[str, Any] | None = None,
+) -> StepDefinition:
+    """Crée une étape « explorateur-world » représentant un monde Explorateur IA.
+
+    Lorsque `config` n'est pas fourni, la fonction renvoie une structure
+    entièrement initialisée avec des listes vides pour que le modèle puisse
+    enrichir progressivement les terrains, quartiers et étapes.
+    """
+
+    default_config: dict[str, Any] = {
+        "terrain": None,
+        "steps": [],
+        "quarterDesignerSteps": None,
+        "quarters": [],
+    }
+    normalized_config = default_config
+    if isinstance(config, Mapping):
+        normalized_config = {
+            "terrain": deepcopy(config.get("terrain")),
+            "steps": deepcopy(config.get("steps")) if config.get("steps") is not None else [],
+            "quarterDesignerSteps": deepcopy(config.get("quarterDesignerSteps")),
+            "quarters": deepcopy(config.get("quarters")) if config.get("quarters") is not None else [],
+        }
+
+    return {
+        "id": str(step_id),
+        "component": "explorateur-world",
+        "config": normalized_config,
+        "composite": None,
+    }
+
+
+def add_explorateur_world_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append an Explorateur world step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_explorateur_world_step(**kwargs))
+
+
+def create_composite_step(
+    *,
+    step_id: str,
+    modules: Sequence[Mapping[str, Any]],
+    auto_advance: bool | None = None,
+    continue_label: str | None = None,
+) -> StepDefinition:
+    """Crée une étape « composite » orchestrant plusieurs modules imbriqués.
+
+    Parameters
+    ----------
+    step_id:
+        Identifiant de l'étape conteneur.
+    modules:
+        Liste ordonnée des modules enfants. Chaque entrée reçoit un identifiant
+        stable généré par défaut, le composant à instancier, l'emplacement (`slot`)
+        et la configuration spécifique.
+    auto_advance:
+        Active le passage automatique à l'étape suivante lorsque tous les
+        modules signalent leur complétion.
+    continue_label:
+        Libellé du bouton de poursuite affiché sous l'agrégateur.
+
+    Returns
+    -------
+    StepDefinition
+        Définition complète comprenant la clé ``composite`` attendue par le
+        renderer.
+    """
+
+    normalized_modules: list[dict[str, Any]] = []
+    for index, module in enumerate(modules, start=1):
+        if not isinstance(module, Mapping):
+            continue
+        normalized_modules.append(
+            {
+                "id": module.get("id") or f"{step_id}-module-{index}",
+                "component": module.get("component", ""),
+                "slot": module.get("slot", "main"),
+                "config": deepcopy(module.get("config")) if module.get("config") is not None else None,
+            }
+        )
+
+    return {
+        "id": str(step_id),
+        "component": "composite",
+        "config": None,
+        "composite": {
+            "modules": normalized_modules,
+            "autoAdvance": auto_advance,
+            "continueLabel": continue_label,
+        },
+    }
+
+
+def add_composite_step(
+    step_sequence: MutableSequence[StepDefinition], **kwargs: Any
+) -> StepDefinition:
+    """Append a composite step to ``step_sequence`` and return it."""
+
+    return _append_step(step_sequence, create_composite_step(**kwargs))
+
+
+def build_step_sequence_activity(
+    *,
+    activity_id: str | None = None,
+    steps: Sequence[Mapping[str, Any]],
+    metadata: Mapping[str, Any] | None = None,
+    activityId: str | None = None,
+) -> dict[str, Any]:
+    """Alias used by the IA tooling to finaliser une activité complète."""
+
+    resolved_activity_id = activity_id or activityId
+    if not resolved_activity_id:
+        raise ValueError("Un identifiant d'activité est requis.")
+
+    return create_step_sequence_activity(
+        activity_id=resolved_activity_id,
+        steps=steps,
+        metadata=metadata,
+    )
+
+
+def normalize_tool_arguments(arguments: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalise les clés d'arguments d'outil en ``snake_case``."""
+
+    normalized: dict[str, Any] = {}
+    for key, value in arguments.items():
+        normalized[_snake_case(str(key))] = value
+    return normalized
+
+
+STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION: dict[str, Any] = {
+    "type": "function",
+    "name": "build_step_sequence_activity",
+    "description": "Assemble une configuration d'activité basée sur une suite d'étapes générées.",
+    "strict": True,
+    "parameters": {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["activityId", "steps", "metadata"],
+        "properties": {
+            "activityId": {"type": "string"},
+            "steps": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["id", "component", "config", "composite"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "component": {"type": ["string", "null"]},
+                        "config": _nullable_schema({"type": "object"}),
+                        "composite": _nullable_schema({"type": "object"}),
+                    },
+                },
+            },
+            "metadata": _nullable_schema(
+                {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": [
+                        "componentKey",
+                        "path",
+                        "completionId",
+                        "enabled",
+                        "header",
+                        "layout",
+                        "card",
+                        "overrides",
+                    ],
+                    "properties": {
+                        "componentKey": {"type": ["string", "null"]},
+                        "path": {"type": ["string", "null"]},
+                        "completionId": {"type": ["string", "null"]},
+                        "enabled": {"type": ["boolean", "null"]},
+                        "header": _nullable_schema({"type": "object"}),
+                        "layout": _nullable_schema({"type": "object"}),
+                        "card": _nullable_schema({"type": "object"}),
+                        "overrides": _nullable_schema({"type": "object"}),
+                    },
+                }
+            ),
+        },
+    },
+}
+
+
+STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "name": "create_step_sequence_activity",
+        "description": "Initialise un objet activité StepSequence prêt à être complété.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["activityId"],
+            "properties": {
+                "activityId": {
+                    "type": "string",
+                    "description": "Identifiant unique de l'activité dans le catalogue.",
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["id", "component", "config", "composite"],
+                        "properties": {
+                            "id": {"type": "string"},
+                            "component": {"type": ["string", "null"]},
+                            "config": _nullable_schema({"type": "object"}),
+                            "composite": _nullable_schema({"type": "object"}),
+                        },
+                    },
+                },
+                "metadata": _nullable_schema({"type": "object"}),
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_rich_content_step",
+        "description": "Crée une étape riche en contenu (texte, médias, barre latérale).",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "title"],
+            "properties": {
+                "stepId": {
+                    "type": "string",
+                    "description": "Identifiant unique de l'étape dans la séquence.",
+                },
+                "title": {"type": "string"},
+                "body": {"type": "string"},
+                "media": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["url"],
+                        "properties": {
+                            "id": {"type": "string"},
+                            "url": {"type": "string"},
+                            "alt": {"type": "string"},
+                            "caption": {"type": "string"},
+                        },
+                    },
+                },
+                "sidebar": _nullable_schema(
+                    {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["type"],
+                        "properties": {
+                            "type": {"type": "string", "enum": ["tips", "checklist"]},
+                            "title": {"type": "string"},
+                            "tips": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": False,
+                                    "required": ["label"],
+                                    "properties": {
+                                        "id": {"type": "string"},
+                                        "label": {"type": "string"},
+                                        "checked": {"type": "boolean"},
+                                    },
+                                },
+                            },
+                        },
+                    }
+                ),
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_form_step",
+        "description": "Crée une étape formulaire interactive avec validations GuidedFields.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "fields"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "fields": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "object"},
+                },
+                "submitLabel": {"type": "string"},
+                "allowEmpty": {"type": "boolean"},
+                "initialValues": _nullable_schema({"type": "object"}),
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_video_step",
+        "description": "Définit une étape vidéo avec sources, sous-titres et options de lecture.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "sources"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "sources": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "object"},
+                },
+                "poster": {"type": "string"},
+                "captions": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+                "autoAdvanceOnEnd": {"type": "boolean"},
+                "expectedDuration": {"type": ["number", "integer"]},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_simulation_chat_step",
+        "description": "Configure une simulation de chat guidée par étapes.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "title", "helpText"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "title": {"type": "string"},
+                "helpText": {"type": "string"},
+                "missionId": {"type": "string"},
+                "roles": _nullable_schema({"type": "object"}),
+                "stages": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_info_cards_step",
+        "description": "Construit une étape d'informations synthétiques sous forme de cartes.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "title"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "eyebrow": {"type": "string"},
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "columns": {"type": "integer"},
+                "cards": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_prompt_evaluation_step",
+        "description": "Évalue un prompt en configurant modèle, verbosité et effort de pensée.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "defaultText", "developerMessage", "model"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "defaultText": {"type": "string"},
+                "developerMessage": {"type": "string"},
+                "model": {"type": "string"},
+                "verbosity": {"type": "string"},
+                "thinking": {"type": "string"},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_ai_comparison_step",
+        "description": "Compare deux configurations IA à partir d'un même contexte utilisateur.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "contextStepId", "contextField", "variants"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "contextStepId": {"type": "string"},
+                "contextField": {"type": "string"},
+                "copy": _nullable_schema({"type": "object"}),
+                "request": _nullable_schema({"type": "object"}),
+                "variants": {"type": "object"},
+                "defaultConfigA": _nullable_schema({"type": "object"}),
+                "defaultConfigB": _nullable_schema({"type": "object"}),
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_clarity_map_step",
+        "description": "Configure une carte Clarté d'abord (grille, obstacles, objectif).",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "obstacleCount": {"type": "integer"},
+                "initialTarget": _nullable_schema({"type": "object"}),
+                "promptStepId": {"type": "string"},
+                "allowInstructionInput": {"type": "boolean"},
+                "instructionLabel": {"type": "string"},
+                "instructionPlaceholder": {"type": "string"},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_clarity_prompt_step",
+        "description": "Crée la consigne d'entrée pour une activité Clarté d'abord.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "promptLabel"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "promptLabel": {"type": "string"},
+                "promptPlaceholder": {"type": "string"},
+                "model": {"type": "string"},
+                "verbosity": {"type": "string"},
+                "thinking": {"type": "string"},
+                "developerPrompt": {"type": "string"},
+                "settingsMode": {"type": "string"},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_explorateur_world_step",
+        "description": "Initialise une étape Explorateur IA (monde, quartiers, étapes).",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "terrain": _nullable_schema({"type": "object"}),
+                "steps": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+                "quarterDesignerSteps": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+                "quarters": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "name": "create_composite_step",
+        "description": "Assemble une étape composite regroupant plusieurs modules.",
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["stepId", "modules"],
+            "properties": {
+                "stepId": {"type": "string"},
+                "modules": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "object"},
+                },
+                "autoAdvance": {"type": "boolean"},
+                "continueLabel": {"type": "string"},
+            },
+        },
+    },
+    STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION,
+]
+
+
+STEP_SEQUENCE_TOOLKIT: dict[str, Callable[..., Any]] = {
+    "create_step_sequence_activity": create_step_sequence_activity,
+    "create_rich_content_step": create_rich_content_step,
+    "create_form_step": create_form_step,
+    "create_video_step": create_video_step,
+    "create_simulation_chat_step": create_simulation_chat_step,
+    "create_info_cards_step": create_info_cards_step,
+    "create_prompt_evaluation_step": create_prompt_evaluation_step,
+    "create_ai_comparison_step": create_ai_comparison_step,
+    "create_clarity_map_step": create_clarity_map_step,
+    "create_clarity_prompt_step": create_clarity_prompt_step,
+    "create_explorateur_world_step": create_explorateur_world_step,
+    "create_composite_step": create_composite_step,
+    "build_step_sequence_activity": build_step_sequence_activity,
+}
+

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -106,6 +106,16 @@ VIDEO_CAPTION_SCHEMA = _strict_object_schema(
 )
 
 
+COMPOSITE_MODULE_SCHEMA = _strict_object_schema(
+    {
+        "id": _nullable_schema({"type": "string"}),
+        "component": {"type": "string"},
+        "slot": {"type": "string"},
+        "config": _nullable_schema(_any_object_schema()),
+    }
+)
+
+
 def create_step_sequence_activity(
     *,
     activity_id: str,
@@ -948,6 +958,9 @@ def create_composite_step(
             }
         )
 
+    if not normalized_modules:
+        raise ValueError("Au moins un module est requis pour create_composite_step.")
+
     return {
         "id": str(step_id),
         "component": "composite",
@@ -1322,7 +1335,7 @@ STEP_SEQUENCE_TOOL_DEFINITIONS: list[dict[str, Any]] = [
                 "modules": {
                     "type": "array",
                     "minItems": 1,
-                    "items": _any_object_schema(),
+                    "items": COMPOSITE_MODULE_SCHEMA,
                 },
                 "autoAdvance": _nullable_schema({"type": "boolean"}),
                 "continueLabel": _nullable_schema({"type": "string"}),

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from backend.app.step_sequence_components import (
+    add_ai_comparison_step,
+    add_clarity_map_step,
+    add_clarity_prompt_step,
+    add_composite_step,
+    add_explorateur_world_step,
+    add_form_step,
+    add_info_cards_step,
+    add_prompt_evaluation_step,
+    add_rich_content_step,
+    add_simulation_chat_step,
+    add_video_step,
+    create_ai_comparison_step,
+    create_clarity_map_step,
+    create_clarity_prompt_step,
+    create_composite_step,
+    create_explorateur_world_step,
+    create_form_step,
+    create_info_cards_step,
+    create_prompt_evaluation_step,
+    create_rich_content_step,
+    create_simulation_chat_step,
+    create_step_sequence_activity,
+    create_video_step,
+    STEP_SEQUENCE_TOOLKIT,
+    STEP_SEQUENCE_TOOL_DEFINITIONS,
+    build_step_sequence_activity,
+    normalize_tool_arguments,
+)
+
+
+def test_create_rich_content_step_exposes_expected_config() -> None:
+    step = create_rich_content_step(
+        step_id="intro",
+        title="Introduction",
+        body="Bienvenue",
+        media=[{"url": "https://cdn.example/image.png"}],
+        sidebar={"type": "tips", "tips": ["Astuce"]},
+    )
+
+    assert step["component"] == "rich-content"
+    config = step["config"]
+    assert set(config) == {"title", "body", "media", "sidebar"}
+    assert config["media"][0]["url"] == "https://cdn.example/image.png"
+
+
+def test_create_form_step_includes_all_fields() -> None:
+    step = create_form_step(
+        step_id="formulaire",
+        fields=[{"id": "field", "label": "Label", "type": "textarea"}],
+        submit_label="Envoyer",
+        allow_empty=True,
+        initial_values={"field": ""},
+    )
+
+    assert step["component"] == "form"
+    config = step["config"]
+    assert set(config) == {"fields", "submitLabel", "allowEmpty", "initialValues"}
+
+
+def test_create_video_step_preserves_sources_and_captions() -> None:
+    step = create_video_step(
+        step_id="video",
+        sources=[{"type": "mp4", "url": "https://cdn.example/video.mp4"}],
+        captions=[{"src": "https://cdn.example/video.vtt"}],
+        auto_advance_on_end=True,
+        expected_duration=120,
+    )
+
+    config = step["config"]
+    assert config["sources"][0]["type"] == "mp4"
+    assert config["captions"][0]["src"] == "https://cdn.example/video.vtt"
+    assert config["autoAdvanceOnEnd"] is True
+    assert config["expectedDuration"] == 120
+
+
+def test_create_simulation_chat_step_sets_roles_and_stages() -> None:
+    step = create_simulation_chat_step(
+        step_id="simulation",
+        title="Simulation",
+        help_text="Réponds",
+        mission_id="mission-1",
+        roles={"ai": "Coach", "user": "Participant"},
+        stages=[{"prompt": "Question", "fields": []}],
+    )
+
+    config = step["config"]
+    assert config["roles"] == {"ai": "Coach", "user": "Participant"}
+    assert len(config["stages"]) == 1
+    assert config["stages"][0]["prompt"] == "Question"
+
+
+def test_create_info_cards_step_includes_columns_and_cards() -> None:
+    step = create_info_cards_step(
+        step_id="infos",
+        eyebrow="À retenir",
+        title="Synthèse",
+        description="Points clés",
+        columns=2,
+        cards=[{"title": "A", "description": "Desc", "tone": "sand"}],
+    )
+
+    config = step["config"]
+    assert config["columns"] == 2
+    assert config["cards"][0]["title"] == "A"
+
+
+def test_create_prompt_evaluation_step_sets_all_options() -> None:
+    step = create_prompt_evaluation_step(
+        step_id="evaluation",
+        default_text="Prompt",
+        developer_message="Dev",
+        model="gpt-5-mini",
+        verbosity="medium",
+        thinking="minimal",
+    )
+
+    config = step["config"]
+    assert config == {
+        "defaultText": "Prompt",
+        "developerMessage": "Dev",
+        "model": "gpt-5-mini",
+        "verbosity": "medium",
+        "thinking": "minimal",
+    }
+
+
+def test_create_ai_comparison_step_handles_optional_sections() -> None:
+    step = create_ai_comparison_step(
+        step_id="comparaison",
+        context_step_id="context",
+        context_field="field",
+        copy={"title": "Comparer"},
+        request={"endpoint": "/api"},
+        variants={"A": {"title": "Profil A"}},
+        default_config_a={"model": "gpt-5-mini"},
+        default_config_b={"model": "gpt-5"},
+    )
+
+    config = step["config"]
+    assert config["contextStepId"] == "context"
+    assert config["variants"]["A"]["title"] == "Profil A"
+
+
+def test_create_clarity_map_step_records_all_options() -> None:
+    step = create_clarity_map_step(
+        step_id="clarte-map",
+        obstacle_count=4,
+        initial_target={"x": 1, "y": 2},
+        prompt_step_id="clarte-prompt",
+        allow_instruction_input=True,
+        instruction_label="Instruction",
+        instruction_placeholder="Décris l'action",
+    )
+
+    config = step["config"]
+    assert config["obstacleCount"] == 4
+    assert config["initialTarget"] == {"x": 1, "y": 2}
+
+
+def test_create_clarity_prompt_step_sets_preferences() -> None:
+    step = create_clarity_prompt_step(
+        step_id="clarte-prompt",
+        prompt_label="Consigne",
+        prompt_placeholder="Décrire",
+        model="gpt-5-mini",
+        verbosity="medium",
+        thinking="medium",
+        developer_prompt="Aide",
+        settings_mode="editable",
+    )
+
+    config = step["config"]
+    assert config["settingsMode"] == "editable"
+    assert config["model"] == "gpt-5-mini"
+
+
+def test_create_explorateur_world_step_defaults_structure() -> None:
+    step = create_explorateur_world_step(step_id="explorateur")
+
+    config = step["config"]
+    assert set(config) == {"terrain", "steps", "quarterDesignerSteps", "quarters"}
+    assert config["steps"] == []
+
+
+def test_create_composite_step_wraps_modules() -> None:
+    step = create_composite_step(
+        step_id="composite",
+        modules=[{"component": "rich-content", "config": {"title": "Bloc"}}],
+        auto_advance=True,
+        continue_label="Continuer",
+    )
+
+    assert step["component"] == "composite"
+    assert step["config"] is None
+    composite = step["composite"]
+    assert composite["autoAdvance"] is True
+    assert composite["modules"][0]["component"] == "rich-content"
+
+
+def test_add_helpers_append_created_steps() -> None:
+    sequence: list[dict[str, object]] = []
+    add_rich_content_step(
+        sequence,
+        step_id="intro",
+        title="Introduction",
+    )
+    add_video_step(
+        sequence,
+        step_id="video",
+        sources=[{"type": "mp4", "url": "https://example.com/video.mp4"}],
+    )
+
+    assert [step["id"] for step in sequence] == ["intro", "video"]
+
+
+def test_create_step_sequence_activity_sets_defaults() -> None:
+    activity = create_step_sequence_activity(activity_id="atelier")
+
+    assert activity["componentKey"] == "step-sequence"
+    assert activity["stepSequence"] == []
+
+
+def test_create_step_sequence_activity_keeps_metadata_and_steps() -> None:
+    steps = [create_rich_content_step(step_id="intro", title="Intro")]
+    activity = create_step_sequence_activity(
+        activity_id="atelier",
+        steps=steps,
+        metadata={
+            "componentKey": "step-sequence",
+            "path": "/atelier",
+            "completionId": "atelier-1",
+            "enabled": True,
+            "header": {"title": "Atelier"},
+            "layout": {"outerClassName": "min-h-screen"},
+            "card": {"title": "Atelier"},
+            "overrides": {"stepSequence": steps},
+        },
+    )
+
+    assert activity["path"] == "/atelier"
+    assert activity["stepSequence"] == steps
+
+
+def test_add_wrappers_return_created_step() -> None:
+    sequence: list[dict[str, object]] = []
+    created = add_clarity_map_step(sequence, step_id="carte")
+
+    assert created["id"] == "carte"
+    assert sequence[-1] is created
+
+
+def test_build_step_sequence_activity_aliases_create() -> None:
+    steps = [create_rich_content_step(step_id="intro", title="Introduction")]
+    activity = build_step_sequence_activity(
+        activity_id="atelier",
+        steps=steps,
+        metadata={"enabled": True},
+    )
+
+    assert activity["id"] == "atelier"
+    assert activity["stepSequence"] == steps
+    assert activity["enabled"] is True
+
+
+def test_normalize_tool_arguments_handles_camel_case() -> None:
+    normalized = normalize_tool_arguments({"stepId": "intro", "defaultText": "Bonjour"})
+
+    assert normalized == {"step_id": "intro", "default_text": "Bonjour"}
+
+
+def test_tool_definitions_cover_toolkit() -> None:
+    defined_names = {definition["name"] for definition in STEP_SEQUENCE_TOOL_DEFINITIONS}
+
+    assert set(STEP_SEQUENCE_TOOLKIT) <= defined_names
+

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -49,7 +49,19 @@ def test_create_rich_content_step_exposes_expected_config() -> None:
 def test_create_form_step_includes_all_fields() -> None:
     step = create_form_step(
         step_id="formulaire",
-        fields=[{"id": "field", "label": "Label", "type": "textarea"}],
+        fields=[
+            {
+                "id": "field",
+                "label": "Label",
+                "type": "single_choice",
+                "options": [
+                    {
+                        "value": "a",
+                        "label": "Option A",
+                    }
+                ],
+            }
+        ],
         submit_label="Envoyer",
         allow_empty=True,
         initial_values={"field": ""},
@@ -58,6 +70,7 @@ def test_create_form_step_includes_all_fields() -> None:
     assert step["component"] == "form"
     config = step["config"]
     assert set(config) == {"fields", "submitLabel", "allowEmpty", "initialValues"}
+    assert config["fields"][0]["options"][0]["description"] is None
 
 
 def test_create_form_step_accepts_id_alias() -> None:

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import pytest
 
 from backend.app.step_sequence_components import (
     add_ai_comparison_step,
@@ -117,8 +118,16 @@ def test_create_video_step_preserves_sources_and_captions() -> None:
     config = step["config"]
     assert config["sources"][0]["type"] == "mp4"
     assert config["captions"][0]["src"] == "https://cdn.example/video.vtt"
+    assert config["captions"][0]["srclang"] is None
+    assert config["captions"][0]["label"] is None
+    assert config["captions"][0]["default"] is False
     assert config["autoAdvanceOnEnd"] is True
     assert config["expectedDuration"] == 120
+
+
+def test_create_video_step_rejects_missing_sources() -> None:
+    with pytest.raises(ValueError):
+        create_video_step(step_id="video", sources=[{"type": "mp4"}])
 
 
 def test_create_simulation_chat_step_sets_roles_and_stages() -> None:

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -316,6 +316,19 @@ def test_normalize_tool_arguments_handles_camel_case() -> None:
     assert normalized == {"step_id": "intro", "default_text": "Bonjour"}
 
 
+def test_create_form_step_tool_requires_step_id() -> None:
+    definition = next(
+        definition
+        for definition in STEP_SEQUENCE_TOOL_DEFINITIONS
+        if definition["name"] == "create_form_step"
+    )
+
+    parameters = definition["parameters"]
+
+    assert "stepId" in parameters["required"]
+    assert parameters["properties"]["stepId"]["type"] == "string"
+
+
 def test_tool_definitions_cover_toolkit() -> None:
     defined_names = {definition["name"] for definition in STEP_SEQUENCE_TOOL_DEFINITIONS}
 

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -70,7 +70,26 @@ def test_create_form_step_includes_all_fields() -> None:
     assert step["component"] == "form"
     config = step["config"]
     assert set(config) == {"fields", "submitLabel", "allowEmpty", "initialValues"}
-    assert config["fields"][0]["options"][0]["description"] is None
+    field = config["fields"][0]
+    assert set(field) == {
+        "id",
+        "label",
+        "type",
+        "minBullets",
+        "maxBullets",
+        "maxWordsPerBullet",
+        "mustContainAny",
+        "meals",
+        "minWords",
+        "maxWords",
+        "forbidWords",
+        "tone",
+        "options",
+        "minSelections",
+        "maxSelections",
+    }
+    assert field["options"][0]["description"] is None
+    assert field["minBullets"] is None
 
 
 def test_create_form_step_accepts_id_alias() -> None:
@@ -80,7 +99,10 @@ def test_create_form_step_accepts_id_alias() -> None:
     )
 
     assert step["id"] == "alias"
-    assert step["config"]["fields"][0]["type"] == "single_choice"
+    field = step["config"]["fields"][0]
+    assert field["type"] == "single_choice"
+    assert field["options"] is None
+    assert field["minSelections"] is None
 
 
 def test_create_video_step_preserves_sources_and_captions() -> None:

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -60,6 +60,16 @@ def test_create_form_step_includes_all_fields() -> None:
     assert set(config) == {"fields", "submitLabel", "allowEmpty", "initialValues"}
 
 
+def test_create_form_step_accepts_id_alias() -> None:
+    step = create_form_step(
+        id="alias",
+        fields=[{"id": "field", "label": "Label", "type": "single_choice"}],
+    )
+
+    assert step["id"] == "alias"
+    assert step["config"]["fields"][0]["type"] == "single_choice"
+
+
 def test_create_video_step_preserves_sources_and_captions() -> None:
     step = create_video_step(
         step_id="video",


### PR DESCRIPTION
## Summary
- expose build_step_sequence_activity, per-component factories, and their JSON-schema tool definitions for IA orchestration
- rework the admin activity generation loop to execute step-sequence tools iteratively before returning the final build call
- extend backend unit tests to cover the new toolkit helpers and the updated multi-call generation workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6a9ea316c83228029cf5a3cbdf738