### PR TITLE
Handle snake_case step identifiers when enriching activity steps

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1062,6 +1062,13 @@ def _merge_step_definition(
     for key in ("id", "component", "config", "composite"):
         merged.setdefault(key, None)
 
+    step_id = merged.get("id")
+    if step_id is not None:
+        merged["id"] = str(step_id)
+
+    merged.pop("stepId", None)
+    merged.pop("step_id", None)
+
     return merged
 
 
@@ -1078,12 +1085,21 @@ def _enrich_steps_argument(
         if not isinstance(step, dict):
             continue
 
-        step_id = step.get("id") or step.get("stepId")
+        normalized_step = dict(step)
+
+        step_id = (
+            normalized_step.get("id")
+            or normalized_step.get("stepId")
+            or normalized_step.get("step_id")
+        )
+        if step_id is not None and normalized_step.get("id") in {None, ""}:
+            normalized_step["id"] = step_id
+
         cached = None
         if step_id is not None:
             cached = cached_steps.get(str(step_id))
 
-        enriched.append(_merge_step_definition(step, cached))
+        enriched.append(_merge_step_definition(normalized_step, cached))
 
     return enriched
 

--- a/backend/tests/test_admin_activities_config.py
+++ b/backend/tests/test_admin_activities_config.py
@@ -364,3 +364,102 @@ def test_admin_generate_activity_backfills_missing_config(monkeypatch) -> None:
             ]
     finally:
         app.dependency_overrides.clear()
+
+
+def test_admin_generate_activity_supports_snake_case_step_id(monkeypatch) -> None:
+    admin_user = LocalUser(username="admin", password_hash="bcrypt$dummy", roles=["admin"])
+    app.dependency_overrides[_require_admin_user] = lambda: admin_user
+
+    class DummyResponse:
+        def __init__(self, output) -> None:  # type: ignore[no-untyped-def]
+            self.output = output
+
+    class FakeResponsesClient:
+        def __init__(self) -> None:
+            self._responses = [
+                DummyResponse(
+                    [
+                        {
+                            "type": "function_call",
+                            "name": "create_step_sequence_activity",
+                            "call_id": "call_1",
+                            "arguments": {"activityId": "atelier-intro"},
+                        }
+                    ]
+                ),
+                DummyResponse(
+                    [
+                        {
+                            "type": "function_call",
+                            "name": "create_rich_content_step",
+                            "call_id": "call_2",
+                            "arguments": {
+                                "stepId": "intro",
+                                "title": "Introduction",
+                                "body": "Bienvenue",
+                            },
+                        }
+                    ]
+                ),
+                DummyResponse(
+                    [
+                        {
+                            "type": "function_call",
+                            "name": "build_step_sequence_activity",
+                            "call_id": "call_3",
+                            "arguments": {
+                                "activityId": "atelier-intro",
+                                "steps": [
+                                    {
+                                        "step_id": "intro",
+                                        "component": "rich-content",
+                                        "config": None,
+                                        "composite": None,
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                ),
+            ]
+            self._index = 0
+
+        def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            response = self._responses[self._index]
+            self._index += 1
+            return response
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.responses = FakeResponsesClient()
+
+    monkeypatch.setattr("backend.app.main._ensure_client", lambda: FakeClient())
+
+    try:
+        with TestClient(app) as client:
+            payload = {
+                "model": "gpt-5-mini",
+                "verbosity": "medium",
+                "thinking": "medium",
+                "details": {"theme": "Introduction"},
+            }
+            response = client.post("/api/admin/activities/generate", json=payload)
+            assert response.status_code == 200, response.text
+
+            data = response.json()
+            steps = data["toolCall"]["arguments"]["steps"]
+            assert steps == [
+                {
+                    "id": "intro",
+                    "component": "rich-content",
+                    "config": {
+                        "title": "Introduction",
+                        "body": "Bienvenue",
+                        "media": [],
+                        "sidebar": None,
+                    },
+                    "composite": None,
+                }
+            ]
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- normalise step identifiers returned by the model so cached definitions are reused even with snake_case keys
- strip stepId aliases from merged step definitions while preserving canonical ids
- cover the regression with a unit test ensuring snake_case step_id values are accepted

## Testing
- pytest backend/tests/test_admin_activities_config.py -k snake_case

------
https://chatgpt.com/codex/tasks/task_e_68d6ca490a808322ae615ba006c22b01