### PR TITLE
Add web search tool handling for StepSequence activity generation

### DIFF
--- a/backend/tests/test_admin_activities_config.py
+++ b/backend/tests/test_admin_activities_config.py
@@ -238,8 +238,15 @@ def test_admin_generate_activity_includes_tool_definition(monkeypatch) -> None:
             data = response.json()
             assert data["toolCall"]["definition"] == STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION
             assert len(captured_requests) == 3
+            expected_tools = [
+                *STEP_SEQUENCE_TOOL_DEFINITIONS,
+                {
+                    "type": "web_search",
+                    "filters": {"allowed_domains": ["youtube.com", "youtu.be"]},
+                },
+            ]
             for request in captured_requests:
-                assert request["tools"] == STEP_SEQUENCE_TOOL_DEFINITIONS
+                assert request["tools"] == expected_tools
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- add the YouTube-only web search definition alongside existing StepSequence tools
- filter out `web_search_call` outputs so only actionable messages are stored in the conversation history

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6d00cfb248322b7a54a9ff0842141