### PR TITLE
Fix logger initialization typo

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -84,7 +84,7 @@ def _resolve_summary_heartbeat_interval() -> float:
 
 SUMMARY_HEARTBEAT_INTERVAL = _resolve_summary_heartbeat_interval()
 
-logger = logging.getLogger(__nam__)
+logger = logging.getLogger(__name__)
 
 def _resolve_activities_config_path() -> Path:
     raw_path = os.getenv("ACTIVITIES_CONFIG_PATH")


### PR DESCRIPTION
## Summary
- correct the logger initialization in `backend/app/main.py` to use `__name__`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6d3c0fbbc83228469f442ebf32b4a