### PR TITLE
Stream activity generation progress and reasoning

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -977,6 +977,53 @@ def _extract_reasoning_summary(response) -> str:
     return "\n".join(summary_chunks).strip()
 
 
+def _format_sse_event(event: str, data: Any | None) -> str:
+    """Construit un événement SSE sérialisé en JSON."""
+
+    try:
+        payload = "null" if data is None else json.dumps(data, ensure_ascii=False)
+    except TypeError:
+        logger.exception("Échec de la sérialisation SSE pour l'événement %s", event)
+        payload = json.dumps({"message": "Données non sérialisables"}, ensure_ascii=False)
+    return f"event: {event}\ndata: {payload}\n\n"
+
+
+def _extract_step_highlight(step: Mapping[str, Any]) -> str | None:
+    """Tente d'extraire un libellé pertinent d'une étape."""
+
+    if not isinstance(step, Mapping):
+        return None
+
+    def _pluck(mapping: Mapping[str, Any] | None) -> str | None:
+        if not isinstance(mapping, Mapping):
+            return None
+        for key in ("title", "label", "heading", "name"):
+            value = mapping.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+        return None
+
+    highlight = _pluck(step.get("config"))
+    if highlight:
+        return highlight
+
+    metadata = step.get("metadata")
+    if isinstance(metadata, Mapping):
+        highlight = _pluck(metadata)
+        if highlight:
+            return highlight
+
+    composite = step.get("composite")
+    if isinstance(composite, Mapping):
+        highlight = _pluck(composite)
+        if highlight:
+            return highlight
+
+    return None
+
+
 def _build_activity_generation_prompt(
     details: ActivityGenerationDetails, existing_ids: Sequence[str]
 ) -> str:
@@ -2473,14 +2520,12 @@ def admin_save_activities_config(
     return {"ok": True, "message": "Configuration sauvegardée avec succès"}
 
 
-@admin_router.post(
-    "/activities/generate", response_model=ActivityGenerationResponse
-)
+@admin_router.post("/activities/generate")
 def admin_generate_activity(
     payload: ActivityGenerationRequest,
     _: LocalUser = Depends(_require_admin_user),
-) -> ActivityGenerationResponse:
-    """Génère une activité StepSequence via l'API Responses."""
+) -> StreamingResponse:
+    """Génère une activité StepSequence via l'API Responses en flux continu."""
 
     client = _ensure_client()
     model = _validate_model(payload.model)
@@ -2506,14 +2551,10 @@ def admin_generate_activity(
         {"role": "developer", "content": developer_message},
         {"role": "user", "content": prompt},
     ]
-    reasoning_summary: str | None = None
     cached_steps: dict[str, StepDefinition] = {}
     tools = [
         *STEP_SEQUENCE_TOOL_DEFINITIONS,
-        {
-            "type": "web_search",
-            "filters": {"allowed_domains": ["youtube.com", "youtu.be"]},
-        },
+        {"type": "web_search"},
     ]
 
     def _remember_step(result: Any) -> None:
@@ -2525,117 +2566,209 @@ def admin_generate_activity(
             return
         cached_steps[str(step_id)] = deepcopy(result)  # type: ignore[arg-type]
 
-    max_iterations = 12
-    for _ in range(max_iterations):
-        try:
-            response = client.responses.create(
-                model=model,
-                input=conversation,
-                tools=tools,
-                parallel_tool_calls=False,
-                text={"verbosity": payload.verbosity},
-                reasoning={"effort": payload.thinking, "summary": "auto"},
-            )
-        except Exception as exc:  # pragma: no cover - defensive
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
+    def event_stream() -> Generator[str, None, None]:
+        reasoning_summary: str | None = None
+        last_summary_sent: str | None = None
 
-        reasoning_summary = _extract_reasoning_summary(response) or reasoning_summary
-        output_items = getattr(response, "output", None)
-        if not output_items:
-            continue
+        yield _format_sse_event(
+            "status", {"message": "Initialisation de la génération..."}
+        )
 
-        filtered_items: list[Any] = []
-        for item in output_items:
-            item_type = getattr(item, "type", None) or (
-                item.get("type") if isinstance(item, dict) else None
-            )
-            if item_type == "web_search_call":
-                logger.debug("Ignoring web_search_call output: %r", item)
-                continue
-            filtered_items.append(item)
-
-        conversation += filtered_items
-
-        for item in filtered_items:
-            item_type = getattr(item, "type", None) or (
-                item.get("type") if isinstance(item, dict) else None
-            )
-            if item_type != "function_call":
-                continue
-
-            name = getattr(item, "name", None) or (
-                item.get("name") if isinstance(item, dict) else None
-            )
-            if not name:
-                continue
-
-            call_id = getattr(item, "call_id", None) or (
-                item.get("call_id") if isinstance(item, dict) else None
-            )
-            raw_arguments = getattr(item, "arguments", None)
-            if raw_arguments is None and isinstance(item, dict):
-                raw_arguments = item.get("arguments")
-
-            arguments_obj, arguments_text = _coerce_tool_arguments(raw_arguments)
-
-            python_arguments = normalize_tool_arguments(arguments_obj)
-            if name == "build_step_sequence_activity":
-                merged_steps = _enrich_steps_argument(
-                    python_arguments.get("steps"), cached_steps
-                )
-                if merged_steps:
-                    python_arguments["steps"] = merged_steps
-                    arguments_obj["steps"] = deepcopy(merged_steps)
-                    try:
-                        arguments_text = json.dumps(arguments_obj)
-                    except TypeError:
-                        arguments_text = None
-
-            tool_callable = STEP_SEQUENCE_TOOLKIT.get(name)
-            if tool_callable is None:
-                raise HTTPException(
-                    status_code=500,
-                    detail=f"L'outil {name} n'est pas pris en charge par le backend.",
-                )
-            try:
-                result = tool_callable(**python_arguments)
-            except Exception as exc:  # pragma: no cover - defensive
-                raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-            if name.startswith("create_") and name != "create_step_sequence_activity":
-                _remember_step(result)
-
-            try:
-                serialized_output = json.dumps(result)
-            except TypeError as exc:  # pragma: no cover - defensive
-                raise HTTPException(
-                    status_code=500,
-                    detail="Résultat d'outil non sérialisable.",
-                ) from exc
-
-            conversation.append(
+        max_iterations = 12
+        for iteration in range(max_iterations):
+            yield _format_sse_event(
+                "status",
                 {
-                    "type": "function_call_output",
-                    "call_id": call_id,
-                    "output": serialized_output,
-                }
+                    "message": (
+                        "Appel au modèle (itération "
+                        f"{iteration + 1}/{max_iterations})..."
+                    )
+                },
+            )
+            try:
+                response = client.responses.create(
+                    model=model,
+                    input=conversation,
+                    tools=tools,
+                    parallel_tool_calls=False,
+                    text={"verbosity": payload.verbosity},
+                    reasoning={"effort": payload.thinking, "summary": "auto"},
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Erreur lors de l'appel au modèle de génération", exc_info=exc)
+                detail = str(exc) or "Erreur du service de génération."
+                yield _format_sse_event("error", {"message": detail})
+                return
+
+            yield _format_sse_event(
+                "status", {"message": "Analyse de la réponse du modèle..."}
             )
 
-            if name == "build_step_sequence_activity":
-                return ActivityGenerationResponse(
-                    tool_call=ActivityGenerationToolCall(
-                        name=name,
-                        call_id=call_id,
-                        arguments=arguments_obj,
-                        arguments_text=arguments_text,
-                        definition=deepcopy(STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION),
-                    ),
-                    reasoning_summary=reasoning_summary or None,
+            reasoning_summary = _extract_reasoning_summary(response) or reasoning_summary
+            if reasoning_summary and reasoning_summary != last_summary_sent:
+                last_summary_sent = reasoning_summary
+                yield _format_sse_event(
+                    "reasoning_summary", {"summary": reasoning_summary}
                 )
 
-    raise HTTPException(
-        status_code=500,
-        detail="Le modèle n'a pas renvoyé d'activité complète après plusieurs itérations.",
+            output_items = getattr(response, "output", None)
+            if not output_items:
+                continue
+
+            filtered_items: list[Any] = []
+            for item in output_items:
+                item_type = getattr(item, "type", None) or (
+                    item.get("type") if isinstance(item, dict) else None
+                )
+                if item_type == "web_search_call":
+                    logger.debug("Ignoring web_search_call output: %r", item)
+                    continue
+                filtered_items.append(item)
+
+            conversation.extend(filtered_items)
+
+            for item in filtered_items:
+                item_type = getattr(item, "type", None) or (
+                    item.get("type") if isinstance(item, dict) else None
+                )
+                if item_type != "function_call":
+                    continue
+
+                name = getattr(item, "name", None) or (
+                    item.get("name") if isinstance(item, dict) else None
+                )
+                if not name:
+                    continue
+
+                call_id = getattr(item, "call_id", None) or (
+                    item.get("call_id") if isinstance(item, dict) else None
+                )
+                raw_arguments = getattr(item, "arguments", None)
+                if raw_arguments is None and isinstance(item, dict):
+                    raw_arguments = item.get("arguments")
+
+                arguments_obj, arguments_text = _coerce_tool_arguments(raw_arguments)
+                python_arguments = normalize_tool_arguments(arguments_obj)
+
+                if name == "build_step_sequence_activity":
+                    merged_steps = _enrich_steps_argument(
+                        python_arguments.get("steps"), cached_steps
+                    )
+                    if merged_steps:
+                        python_arguments["steps"] = merged_steps
+                        arguments_obj["steps"] = deepcopy(merged_steps)
+                        try:
+                            arguments_text = json.dumps(arguments_obj)
+                        except TypeError:
+                            arguments_text = None
+
+                tool_callable = STEP_SEQUENCE_TOOLKIT.get(name)
+                if tool_callable is None:
+                    yield _format_sse_event(
+                        "error",
+                        {
+                            "message": (
+                                f"L'outil {name} n'est pas pris en charge par le backend."
+                            )
+                        },
+                    )
+                    return
+
+                try:
+                    result = tool_callable(**python_arguments)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.exception("Erreur lors de l'exécution de l'outil %s", name, exc_info=exc)
+                    detail = str(exc) or "Erreur lors de l'exécution d'un outil."
+                    yield _format_sse_event("error", {"message": detail})
+                    return
+
+                if name == "create_step_sequence_activity":
+                    activity_identifier = (
+                        python_arguments.get("activity_id")
+                        or arguments_obj.get("activityId")
+                        or arguments_obj.get("activity_id")
+                    )
+                    yield _format_sse_event(
+                        "status",
+                        {
+                            "message": "Structure de l'activité initialisée.",
+                            "activityId": activity_identifier,
+                        },
+                    )
+                if name.startswith("create_") and name != "create_step_sequence_activity":
+                    _remember_step(result)
+                    step_count = len(cached_steps)
+                    highlight = _extract_step_highlight(result)
+                    yield _format_sse_event(
+                        "step",
+                        {
+                            "id": result.get("id"),
+                            "component": result.get("component"),
+                            "count": step_count,
+                            "highlight": highlight,
+                        },
+                    )
+
+                try:
+                    serialized_output = json.dumps(result)
+                except TypeError as exc:  # pragma: no cover - defensive
+                    logger.exception("Résultat d'outil non sérialisable", exc_info=exc)
+                    yield _format_sse_event(
+                        "error",
+                        {"message": "Résultat d'outil non sérialisable."},
+                    )
+                    return
+
+                conversation.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": serialized_output,
+                    }
+                )
+
+                if name == "build_step_sequence_activity":
+                    yield _format_sse_event(
+                        "status", {"message": "Finalisation de l'activité..."}
+                    )
+
+                    response_payload = ActivityGenerationResponse(
+                        tool_call=ActivityGenerationToolCall(
+                            name=name,
+                            call_id=call_id,
+                            arguments=arguments_obj,
+                            arguments_text=arguments_text,
+                            definition=deepcopy(
+                                STEP_SEQUENCE_ACTIVITY_TOOL_DEFINITION
+                            ),
+                        ),
+                        reasoning_summary=reasoning_summary or None,
+                    )
+
+                    final_summary = response_payload.reasoning_summary
+                    if final_summary and final_summary != last_summary_sent:
+                        last_summary_sent = final_summary
+                        yield _format_sse_event(
+                            "reasoning_summary", {"summary": final_summary}
+                        )
+
+                    yield _format_sse_event(
+                        "complete",
+                        response_payload.model_dump(
+                            by_alias=True, exclude_none=True
+                        ),
+                    )
+                    return
+
+        yield _format_sse_event(
+            "error",
+            {
+                "message": "Le modèle n'a pas renvoyé d'activité complète après plusieurs itérations.",
+            },
+        )
+
+    return StreamingResponse(
+        event_stream(), media_type="text/event-stream", headers=_sse_headers()
     )
 
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -405,6 +405,20 @@ export interface ActivityGenerationResponse {
   reasoningSummary?: string | null;
 }
 
+export interface ActivityGenerationProgressEvent {
+  id?: string | null;
+  component?: string | null;
+  count: number;
+  highlight?: string | null;
+}
+
+export interface ActivityGenerationStreamOptions {
+  signal?: AbortSignal;
+  onStatus?: (message: string) => void;
+  onStep?: (event: ActivityGenerationProgressEvent) => void;
+  onReasoningSummary?: (summary: string) => void;
+}
+
 export const activities = {
   getConfig: async (): Promise<ActivityConfigResponse> =>
     fetchJson<ActivityConfigResponse>(`${API_BASE_URL}/activities-config`),
@@ -436,21 +450,194 @@ export const admin = {
       ),
     generate: async (
       payload: GenerateActivityPayload,
-      token?: string | null
-    ): Promise<ActivityGenerationResponse> =>
-      fetchJson<ActivityGenerationResponse>(
-        `${API_BASE_URL}/admin/activities/generate`,
-        withAdminCredentials(
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(payload),
+      token?: string | null,
+      options?: ActivityGenerationStreamOptions
+    ): Promise<ActivityGenerationResponse> => {
+      const requestInit = withAdminCredentials(
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
           },
-          token
-        )
-      ),
+          body: JSON.stringify(payload),
+        },
+        token
+      );
+
+      const response = await fetch(
+        `${API_BASE_URL}/admin/activities/generate`,
+        {
+          ...requestInit,
+          signal: options?.signal,
+        }
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Erreur serveur (${response.status}).`);
+      }
+
+      if (!response.body) {
+        throw new Error("Flux de réponse indisponible.");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let finalPayload: ActivityGenerationResponse | null = null;
+      let streamError: Error | null = null;
+
+      const emitStep = (data: unknown) => {
+        if (!options?.onStep || typeof data !== "object" || data === null) {
+          return;
+        }
+        const stepData = data as Record<string, unknown>;
+        const rawCount = stepData.count;
+        const parsedCount =
+          typeof rawCount === "number"
+            ? rawCount
+            : Number.parseInt(String(rawCount ?? ""), 10);
+        const count = Number.isFinite(parsedCount) ? parsedCount : 0;
+        const component =
+          typeof stepData.component === "string" && stepData.component.trim().length > 0
+            ? stepData.component
+            : null;
+        const highlight =
+          typeof stepData.highlight === "string" && stepData.highlight.trim().length > 0
+            ? stepData.highlight.trim()
+            : null;
+        const id =
+          typeof stepData.id === "string" && stepData.id.trim().length > 0
+            ? stepData.id.trim()
+            : null;
+        options.onStep({ id, component, count, highlight });
+      };
+
+      const dispatchEvent = (eventName: string, data: unknown) => {
+        switch (eventName) {
+          case "status": {
+            if (
+              options?.onStatus &&
+              typeof data === "object" &&
+              data !== null &&
+              typeof (data as Record<string, unknown>).message === "string"
+            ) {
+              const message = ((data as Record<string, unknown>).message as string).trim();
+              if (message) {
+                options.onStatus(message);
+              }
+            }
+            break;
+          }
+          case "step":
+            emitStep(data);
+            break;
+          case "reasoning_summary":
+            if (
+              options?.onReasoningSummary &&
+              typeof data === "object" &&
+              data !== null &&
+              typeof (data as Record<string, unknown>).summary === "string"
+            ) {
+              const summary = ((data as Record<string, unknown>).summary as string).trim();
+              if (summary) {
+                options.onReasoningSummary(summary);
+              }
+            }
+            break;
+          case "complete":
+            if (data && typeof data === "object") {
+              finalPayload = data as ActivityGenerationResponse;
+            }
+            break;
+          case "error": {
+            const message =
+              typeof data === "object" &&
+              data !== null &&
+              typeof (data as Record<string, unknown>).message === "string"
+                ? ((data as Record<string, unknown>).message as string)
+                : "La génération de l'activité a échoué.";
+            streamError = new Error(message);
+            break;
+          }
+          default:
+            break;
+        }
+      };
+
+      const processChunk = (chunk: string) => {
+        const trimmed = chunk.trim();
+        if (!trimmed) {
+          return;
+        }
+        let eventName = "message";
+        const dataLines: string[] = [];
+        for (const line of trimmed.split("\n")) {
+          if (line.startsWith("event:")) {
+            eventName = line.replace("event:", "", 1).trim();
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.replace("data:", "", 1).trim());
+          }
+        }
+
+        let parsed: unknown = null;
+        if (dataLines.length > 0) {
+          const dataStr = dataLines.join("");
+          if (dataStr && dataStr !== "null") {
+            try {
+              parsed = JSON.parse(dataStr);
+            } catch {
+              parsed = null;
+            }
+          }
+        }
+
+        dispatchEvent(eventName, parsed);
+      };
+
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            if (buffer.trim()) {
+              processChunk(buffer);
+            }
+            break;
+          }
+          buffer += decoder.decode(value, { stream: true });
+          let boundary = buffer.indexOf("\n\n");
+          while (boundary !== -1) {
+            const chunk = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            processChunk(chunk);
+            if (streamError) {
+              break;
+            }
+            boundary = buffer.indexOf("\n\n");
+          }
+          if (streamError) {
+            break;
+          }
+        }
+      } finally {
+        if (streamError) {
+          await reader.cancel().catch(() => {
+            /* noop */
+          });
+        }
+      }
+
+      if (streamError) {
+        throw streamError;
+      }
+
+      if (!finalPayload) {
+        throw new Error("La génération n'a pas retourné de résultat.");
+      }
+
+      return finalPayload;
+    },
   },
   auth: {
     login: async (payload: AdminLoginPayload): Promise<AdminAuthResponse> =>


### PR DESCRIPTION
## Summary
- stream the admin activity generation endpoint with SSE events for status, steps, and reasoning summaries while removing the web search domain filter
- adjust backend tests to parse the streamed output and verify the final tool call payload
- update the frontend API client and modal flow to consume streaming updates, surface progress, and show live reasoning summaries

## Testing
- pytest backend/tests/test_admin_activities_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d6d7c331d4832285827955ad8b8ae2