### PR TITLE
feat: rendre éditable le brief de génération d'activité IA

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -362,9 +362,14 @@ export interface ActivitySelectorHeaderConfig {
   badge?: string;
 }
 
+export interface ActivityGenerationAdminConfig {
+  developerMessage: string;
+}
+
 export interface ActivityConfig {
   activities: any[];
   activitySelectorHeader?: ActivitySelectorHeaderConfig;
+  activityGeneration?: ActivityGenerationAdminConfig;
 }
 
 export interface ActivityConfigResponse extends ActivityConfig {
@@ -390,6 +395,7 @@ export interface GenerateActivityPayload {
   thinking: ThinkingChoice;
   details: ActivityGenerationDetailsPayload;
   existingActivityIds?: string[];
+  developerMessage?: string;
 }
 
 


### PR DESCRIPTION
## Summary
- move the AI activity design requirements from the user prompt to the developer message used during generation
- persist the developer instructions in activities_config and expose them through the admin API and UI for editing
- extend admin tests to cover the new configuration field and developer-message selection logic

## Testing
- pytest backend/tests/test_admin_activities_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ee0858d8832293d71debfca206da