### PR TITLE
Add correction handling to StepSequence choice fields

### DIFF
--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -88,9 +88,13 @@ def test_create_form_step_includes_all_fields() -> None:
         "options",
         "minSelections",
         "maxSelections",
+        "correctAnswer",
+        "correctAnswers",
     }
     assert field["options"][0]["description"] is None
     assert field["minBullets"] is None
+    assert field["correctAnswer"] == "a"
+    assert field["correctAnswers"] is None
 
 
 def test_create_form_step_accepts_id_alias() -> None:
@@ -104,6 +108,8 @@ def test_create_form_step_accepts_id_alias() -> None:
     assert field["type"] == "single_choice"
     assert field["options"] is None
     assert field["minSelections"] is None
+    assert field["correctAnswer"] is None
+    assert field["correctAnswers"] is None
 
 
 def test_create_video_step_preserves_sources_and_captions() -> None:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -62,6 +62,7 @@ export interface ChoiceFieldOption {
 export interface SingleChoiceFieldSpec extends BaseFieldSpec {
   type: "single_choice";
   options: ChoiceFieldOption[];
+  correctAnswer?: string;
 }
 
 export interface MultipleChoiceFieldSpec extends BaseFieldSpec {
@@ -69,6 +70,7 @@ export interface MultipleChoiceFieldSpec extends BaseFieldSpec {
   options: ChoiceFieldOption[];
   minSelections?: number;
   maxSelections?: number;
+  correctAnswers?: string[];
 }
 
 export type FieldSpec =


### PR DESCRIPTION
## Summary
- allow designers to mark correct answers for single and multiple choice FormStep fields and surface correction feedback to learners
- extend API types and runtime validation to track correct choices on guided fields
- update the StepSequence generation schema/tests so AI-created forms can set correct answers

## Testing
- npm test -- --run tests/step-sequence/FormStep.test.tsx
- pytest backend/tests/test_step_sequence_components.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ece12514832288c80116359c2eef