### PR TITLE
Add admin page to manage AI activity prompts

### DIFF
--- a/backend/tests/test_admin_activities_config.py
+++ b/backend/tests/test_admin_activities_config.py
@@ -54,6 +54,10 @@ def test_admin_save_activities_with_step_sequence(tmp_path, monkeypatch) -> None
             returned = get_response.json()
             assert returned["activities"][0]["stepSequence"] == payload["activities"][0]["stepSequence"]
             assert (
+                returned["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
+            assert (
                 returned["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
             )
@@ -64,6 +68,10 @@ def test_admin_save_activities_with_step_sequence(tmp_path, monkeypatch) -> None
             assert (
                 public_payload["activities"][0]["stepSequence"]
                 == payload["activities"][0]["stepSequence"]
+            )
+            assert (
+                public_payload["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
             )
             assert (
                 public_payload["activityGeneration"]["developerMessage"]
@@ -77,6 +85,10 @@ def test_admin_save_activities_with_step_sequence(tmp_path, monkeypatch) -> None
     assert (
         persisted["activities"][0]["stepSequence"]
         == payload["activities"][0]["stepSequence"]
+    )
+    assert (
+        persisted["activityGeneration"]["systemMessage"]
+        == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
     )
     assert (
         persisted["activityGeneration"]["developerMessage"]
@@ -134,6 +146,10 @@ def test_admin_can_remove_all_activities(tmp_path, monkeypatch) -> None:
             assert admin_payload["activities"] == []
             assert admin_payload.get("usesDefaultFallback") is False
             assert (
+                admin_payload["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
+            assert (
                 admin_payload["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
             )
@@ -144,6 +160,10 @@ def test_admin_can_remove_all_activities(tmp_path, monkeypatch) -> None:
             assert public_payload["activities"] == []
             assert public_payload.get("usesDefaultFallback") is False
             assert (
+                public_payload["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
+            assert (
                 public_payload["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
             )
@@ -153,6 +173,10 @@ def test_admin_can_remove_all_activities(tmp_path, monkeypatch) -> None:
     assert config_path.exists(), "Une configuration vide doit être persistée"
     persisted = json.loads(config_path.read_text(encoding="utf-8"))
     assert persisted["activities"] == []
+    assert (
+        persisted["activityGeneration"]["systemMessage"]
+        == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+    )
     assert (
         persisted["activityGeneration"]["developerMessage"]
         == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
@@ -301,6 +325,11 @@ def test_admin_generate_activity_includes_tool_definition(tmp_path, monkeypatch)
                 assert request["tools"] == expected_tools
 
             first_request = captured_requests[0]
+            assert first_request["input"][0]["role"] == "system"
+            assert (
+                first_request["input"][0]["content"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert first_request["input"][1]["role"] == "developer"
             assert (
                 first_request["input"][1]["content"]
@@ -311,6 +340,10 @@ def test_admin_generate_activity_includes_tool_definition(tmp_path, monkeypatch)
             persisted = json.loads(config_path.read_text(encoding="utf-8"))
             saved_activity = persisted["activities"][0]
             assert saved_activity == activity
+            assert (
+                persisted["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert (
                 persisted["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
@@ -451,6 +484,11 @@ def test_admin_generate_activity_backfills_missing_config(tmp_path, monkeypatch)
                 assert request["tools"] == expected_tools
 
             first_request = captured_requests[0]
+            assert first_request["input"][0]["role"] == "system"
+            assert (
+                first_request["input"][0]["content"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert first_request["input"][1]["role"] == "developer"
             assert (
                 first_request["input"][1]["content"]
@@ -461,6 +499,10 @@ def test_admin_generate_activity_backfills_missing_config(tmp_path, monkeypatch)
             persisted = json.loads(config_path.read_text(encoding="utf-8"))
             saved_activity = persisted["activities"][0]
             assert saved_activity == activity
+            assert (
+                persisted["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert (
                 persisted["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
@@ -590,6 +632,11 @@ def test_admin_generate_activity_supports_snake_case_step_id(tmp_path, monkeypat
                 assert request["tools"] == expected_tools
 
             first_request = captured_requests[0]
+            assert first_request["input"][0]["role"] == "system"
+            assert (
+                first_request["input"][0]["content"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert first_request["input"][1]["role"] == "developer"
             assert (
                 first_request["input"][1]["content"]
@@ -600,6 +647,10 @@ def test_admin_generate_activity_supports_snake_case_step_id(tmp_path, monkeypat
             persisted = json.loads(config_path.read_text(encoding="utf-8"))
             saved_activity = persisted["activities"][0]
             assert saved_activity == activity
+            assert (
+                persisted["activityGeneration"]["systemMessage"]
+                == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+            )
             assert (
                 persisted["activityGeneration"]["developerMessage"]
                 == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
@@ -719,12 +770,132 @@ def test_admin_generate_activity_uses_saved_developer_message(tmp_path, monkeypa
             assert status_response.status_code == 200
 
         first_request = captured_requests[0]
+        assert first_request["input"][0]["role"] == "system"
+        assert (
+            first_request["input"][0]["content"]
+            == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+        )
         assert first_request["input"][1]["role"] == "developer"
         assert first_request["input"][1]["content"] == custom_message
 
         persisted = json.loads(config_path.read_text(encoding="utf-8"))
         assert (
+            persisted["activityGeneration"]["systemMessage"]
+            == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+        )
+        assert (
             persisted["activityGeneration"]["developerMessage"] == custom_message
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_admin_generate_activity_uses_saved_system_message(tmp_path, monkeypatch) -> None:
+    admin_user = LocalUser(username="admin", password_hash="bcrypt$dummy", roles=["admin"])
+    app.dependency_overrides[_require_admin_user] = lambda: admin_user
+
+    config_path = tmp_path / "activities_config.json"
+    monkeypatch.setattr("backend.app.main.ACTIVITIES_CONFIG_PATH", config_path)
+
+    custom_system_message = (
+        "Tu es un concepteur chevronné qui privilégie les scénarios immersifs et collaboratifs."
+    )
+
+    try:
+        with TestClient(app) as client:
+            save_response = client.post(
+                "/api/admin/activities",
+                json={
+                    "activities": [],
+                    "activityGeneration": {"systemMessage": custom_system_message},
+                },
+            )
+            assert save_response.status_code == 200, save_response.text
+
+        captured_requests: list[dict[str, object]] = []
+
+        class DummyResponse:
+            def __init__(self, output) -> None:  # type: ignore[no-untyped-def]
+                self.output = output
+
+        class FakeResponsesClient:
+            def __init__(self) -> None:
+                self._responses = [
+                    DummyResponse(
+                        [
+                            {
+                                "type": "function_call",
+                                "name": "create_step_sequence_activity",
+                                "call_id": "call_1",
+                                "arguments": {"activityId": "atelier-intro"},
+                            }
+                        ]
+                    ),
+                    DummyResponse(
+                        [
+                            {
+                                "type": "function_call",
+                                "name": "build_step_sequence_activity",
+                                "call_id": "call_2",
+                                "arguments": {
+                                    "activityId": "atelier-intro",
+                                    "steps": [],
+                                },
+                            }
+                        ]
+                    ),
+                ]
+                self._index = 0
+
+            def create(self, **kwargs):  # type: ignore[no-untyped-def]
+                captured_requests.append(kwargs)
+                response = self._responses[self._index]
+                self._index += 1
+                return response
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.responses = FakeResponsesClient()
+
+        monkeypatch.setattr("backend.app.main._ensure_client", lambda: FakeClient())
+        monkeypatch.setattr(
+            "backend.app.main._launch_activity_generation_job",
+            lambda job_id, payload: _run_activity_generation_job(job_id, payload),
+        )
+        main._ACTIVITY_GENERATION_JOBS.clear()
+
+        with TestClient(app) as client:
+            payload = {
+                "model": "gpt-5-mini",
+                "verbosity": "medium",
+                "thinking": "medium",
+                "details": {"theme": "Introduction"},
+            }
+            response = client.post("/api/admin/activities/generate", json=payload)
+            assert response.status_code == 200, response.text
+
+            job_id = response.json().get("jobId")
+            assert isinstance(job_id, str) and job_id
+
+            status_response = client.get(f"/api/admin/activities/generate/{job_id}")
+            assert status_response.status_code == 200
+
+        first_request = captured_requests[0]
+        assert first_request["input"][0]["role"] == "system"
+        assert first_request["input"][0]["content"] == custom_system_message
+        assert first_request["input"][1]["role"] == "developer"
+        assert (
+            first_request["input"][1]["content"]
+            == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
+        )
+
+        persisted = json.loads(config_path.read_text(encoding="utf-8"))
+        assert (
+            persisted["activityGeneration"]["systemMessage"] == custom_system_message
+        )
+        assert (
+            persisted["activityGeneration"]["developerMessage"]
+            == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
         )
     finally:
         app.dependency_overrides.clear()
@@ -823,12 +994,138 @@ def test_admin_generate_activity_allows_request_developer_message_override(
             assert status_response.status_code == 200
 
         first_request = captured_requests[0]
+        assert first_request["input"][0]["role"] == "system"
+        assert (
+            first_request["input"][0]["content"]
+            == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+        )
         assert first_request["input"][1]["role"] == "developer"
         assert first_request["input"][1]["content"] == override_message
 
         persisted = json.loads(config_path.read_text(encoding="utf-8"))
         assert (
+            persisted["activityGeneration"]["systemMessage"]
+            == main.DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE
+        )
+        assert (
             persisted["activityGeneration"]["developerMessage"] == saved_message
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_admin_generate_activity_allows_request_system_message_override(
+    tmp_path, monkeypatch
+) -> None:
+    admin_user = LocalUser(username="admin", password_hash="bcrypt$dummy", roles=["admin"])
+    app.dependency_overrides[_require_admin_user] = lambda: admin_user
+
+    config_path = tmp_path / "activities_config.json"
+    monkeypatch.setattr("backend.app.main.ACTIVITIES_CONFIG_PATH", config_path)
+
+    saved_system_message = (
+        "Tu es un concepteur rigoureux qui garantit une progression structurée."
+    )
+    override_system_message = (
+        "Tu es un facilitateur inspirant qui favorise l'intelligence collective."
+    )
+
+    try:
+        with TestClient(app) as client:
+            save_response = client.post(
+                "/api/admin/activities",
+                json={
+                    "activities": [],
+                    "activityGeneration": {"systemMessage": saved_system_message},
+                },
+            )
+            assert save_response.status_code == 200, save_response.text
+
+        captured_requests: list[dict[str, object]] = []
+
+        class DummyResponse:
+            def __init__(self, output) -> None:  # type: ignore[no-untyped-def]
+                self.output = output
+
+        class FakeResponsesClient:
+            def __init__(self) -> None:
+                self._responses = [
+                    DummyResponse(
+                        [
+                            {
+                                "type": "function_call",
+                                "name": "create_step_sequence_activity",
+                                "call_id": "call_1",
+                                "arguments": {"activityId": "atelier-intro"},
+                            }
+                        ]
+                    ),
+                    DummyResponse(
+                        [
+                            {
+                                "type": "function_call",
+                                "name": "build_step_sequence_activity",
+                                "call_id": "call_2",
+                                "arguments": {
+                                    "activityId": "atelier-intro",
+                                    "steps": [],
+                                },
+                            }
+                        ]
+                    ),
+                ]
+                self._index = 0
+
+            def create(self, **kwargs):  # type: ignore[no-untyped-def]
+                captured_requests.append(kwargs)
+                response = self._responses[self._index]
+                self._index += 1
+                return response
+
+        class FakeClient:
+            def __init__(self) -> None:
+                self.responses = FakeResponsesClient()
+
+        monkeypatch.setattr("backend.app.main._ensure_client", lambda: FakeClient())
+        monkeypatch.setattr(
+            "backend.app.main._launch_activity_generation_job",
+            lambda job_id, payload: _run_activity_generation_job(job_id, payload),
+        )
+        main._ACTIVITY_GENERATION_JOBS.clear()
+
+        with TestClient(app) as client:
+            payload = {
+                "model": "gpt-5-mini",
+                "verbosity": "medium",
+                "thinking": "medium",
+                "systemMessage": override_system_message,
+                "details": {"theme": "Introduction"},
+            }
+            response = client.post("/api/admin/activities/generate", json=payload)
+            assert response.status_code == 200, response.text
+
+            job_id = response.json().get("jobId")
+            assert isinstance(job_id, str) and job_id
+
+            status_response = client.get(f"/api/admin/activities/generate/{job_id}")
+            assert status_response.status_code == 200
+
+        first_request = captured_requests[0]
+        assert first_request["input"][0]["role"] == "system"
+        assert first_request["input"][0]["content"] == override_system_message
+        assert first_request["input"][1]["role"] == "developer"
+        assert (
+            first_request["input"][1]["content"]
+            == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
+        )
+
+        persisted = json.loads(config_path.read_text(encoding="utf-8"))
+        assert (
+            persisted["activityGeneration"]["systemMessage"] == saved_system_message
+        )
+        assert (
+            persisted["activityGeneration"]["developerMessage"]
+            == main.DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE
         )
     finally:
         app.dependency_overrides.clear()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { LoginPage } from "./pages/LoginPage";
 import { AdminLtiUsersPage } from "./pages/admin/AdminLtiUsersPage";
 import { AdminPlatformsPage } from "./pages/admin/AdminPlatformsPage";
 import { AdminActivityTrackingPage } from "./pages/admin/AdminActivityTrackingPage";
+import { AdminActivityGenerationPage } from "./pages/admin/AdminActivityGenerationPage";
 import { activities as activitiesClient } from "./api";
 
 function App(): JSX.Element {
@@ -99,10 +100,17 @@ function App(): JSX.Element {
       <Route element={<AdminGuard />}>
         <Route path="/admin" element={<AdminLayout />}>
           <Route index element={<Navigate to="platforms" replace />} />
+          <Route
+            path="activity-generation"
+            element={<AdminActivityGenerationPage />}
+          />
           <Route path="platforms" element={<AdminPlatformsPage />} />
           <Route path="lti-users" element={<AdminLtiUsersPage />} />
           <Route path="local-users" element={<AdminLocalUsersPage />} />
-          <Route path="activity-tracking" element={<AdminActivityTrackingPage />} />
+          <Route
+            path="activity-tracking"
+            element={<AdminActivityTrackingPage />}
+          />
         </Route>
       </Route>
       {resolvedActivities

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -365,7 +365,8 @@ export interface ActivitySelectorHeaderConfig {
 }
 
 export interface ActivityGenerationAdminConfig {
-  developerMessage: string;
+  systemMessage?: string;
+  developerMessage?: string;
 }
 
 export interface ActivityConfig {
@@ -397,6 +398,7 @@ export interface GenerateActivityPayload {
   thinking: ThinkingChoice;
   details: ActivityGenerationDetailsPayload;
   existingActivityIds?: string[];
+  systemMessage?: string;
   developerMessage?: string;
 }
 

--- a/frontend/src/config/activityGeneration.ts
+++ b/frontend/src/config/activityGeneration.ts
@@ -1,0 +1,20 @@
+export const DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE =
+  [
+    "Tu es un concepteur pédagogique francophone spécialisé en intelligence",
+    "artificielle générative. Tu proposes des activités engageantes et",
+    "structurées pour des professionnels en formation continue."
+  ].join(" ");
+
+export const DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE = [
+  "Utilise exclusivement les fonctions fournies pour construire une activité StepSequence cohérente.",
+  "Commence par create_step_sequence_activity pour initialiser l'activité, enchaîne avec les create_* adaptées pour définir chaque étape, puis finalise en appelant build_step_sequence_activity lorsque la configuration est complète.",
+  "Chaque étape doit rester alignée avec les objectifs fournis et renseigne la carte d'activité ainsi que le header avec des formulations concises, inclusives et professionnelles.",
+  "",
+  "Exigences de conception :",
+  "- Génère 3 à 5 étapes maximum en privilégiant la progression pédagogique (accroche, exploration guidée, consolidation).",
+  "- Utilise uniquement les composants disponibles : rich-content, form, video, simulation-chat, info-cards, prompt-evaluation, ai-comparison, clarity-map, clarity-prompt, explorateur-world ou composite.",
+  "- Propose des identifiants d'étape courts en minuscules séparés par des tirets.",
+  "- Les formulaires doivent comporter des consignes explicites et des contraintes adaptées (nombre de mots, choix, etc.).",
+  "- Complète la carte d'activité (titre, description, highlights, CTA) et le header avec des textes synthétiques.",
+  "- Si aucun chemin spécifique n'est requis, oriente le CTA vers /activites/{activityId}."
+].join("\n");

--- a/frontend/src/pages/admin/AdminActivityGenerationPage.tsx
+++ b/frontend/src/pages/admin/AdminActivityGenerationPage.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  admin,
+  type ActivityConfig,
+  type ActivityConfigResponse,
+  type ActivityGenerationAdminConfig,
+} from "../../api";
+import {
+  DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE,
+  DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE,
+} from "../../config/activityGeneration";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+interface FormState {
+  systemMessage: string;
+  developerMessage: string;
+}
+
+function sanitizeMessage(input: string): string {
+  return input.replace(/\r\n/g, "\n");
+}
+
+function resolveInitialForm(
+  config: ActivityGenerationAdminConfig | null | undefined
+): FormState {
+  const systemMessage =
+    typeof config?.systemMessage === "string" && config.systemMessage.trim().length > 0
+      ? config.systemMessage
+      : DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE;
+  const developerMessage =
+    typeof config?.developerMessage === "string" &&
+    config.developerMessage.trim().length > 0
+      ? config.developerMessage
+      : DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE;
+  return {
+    systemMessage,
+    developerMessage,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const trimmed = error.message?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error.trim();
+  }
+  return "Une erreur inattendue est survenue. Veuillez réessayer.";
+}
+
+export function AdminActivityGenerationPage(): JSX.Element {
+  const { token } = useAdminAuth();
+  const configRef = useRef<ActivityConfigResponse | null>(null);
+  const [formState, setFormState] = useState<FormState>(() =>
+    resolveInitialForm(null)
+  );
+  const [initialState, setInitialState] = useState<FormState>(() =>
+    resolveInitialForm(null)
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const hasChanges = useMemo(() => {
+    return (
+      formState.systemMessage !== initialState.systemMessage ||
+      formState.developerMessage !== initialState.developerMessage
+    );
+  }, [formState, initialState]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadConfig = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await admin.activities.get(token);
+        if (cancelled) {
+          return;
+        }
+        configRef.current = response;
+        const nextForm = resolveInitialForm(response.activityGeneration);
+        setFormState(nextForm);
+        setInitialState(nextForm);
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            getErrorMessage(loadError) ||
+              "Impossible de charger la configuration actuelle."
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadConfig();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (!success) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setSuccess(null);
+    }, 5000);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [success]);
+
+  const handleChange = useCallback(
+    (field: keyof FormState, value: string) => {
+      setFormState((previous) => ({
+        ...previous,
+        [field]: value,
+      }));
+    },
+    []
+  );
+
+  const handleResetForm = useCallback(() => {
+    setFormState(initialState);
+    setError(null);
+    setSuccess(null);
+  }, [initialState]);
+
+  const handleRestoreDefaults = useCallback(() => {
+    const defaults = resolveInitialForm({});
+    setFormState(defaults);
+    setError(null);
+    setSuccess(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) {
+      return;
+    }
+    const baseConfig = configRef.current;
+    if (!baseConfig) {
+      setError(
+        "La configuration initiale est introuvable. Rechargez la page puis réessayez."
+      );
+      return;
+    }
+
+    const trimmedSystem = sanitizeMessage(formState.systemMessage).trim();
+    const trimmedDeveloper = sanitizeMessage(
+      formState.developerMessage
+    ).trim();
+
+    if (trimmedSystem.length < 3 || trimmedDeveloper.length < 3) {
+      setError(
+        "Les messages système et développeur doivent contenir au moins trois caractères."
+      );
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    const payload: ActivityConfig = {
+      activities: Array.isArray(baseConfig.activities)
+        ? baseConfig.activities
+        : [],
+      activitySelectorHeader: baseConfig.activitySelectorHeader,
+      activityGeneration: {
+        systemMessage: trimmedSystem,
+        developerMessage: trimmedDeveloper,
+      },
+    };
+
+    try {
+      await admin.activities.save(payload, token);
+      const updatedForm: FormState = {
+        systemMessage: trimmedSystem,
+        developerMessage: trimmedDeveloper,
+      };
+      configRef.current = {
+        ...baseConfig,
+        activityGeneration: {
+          systemMessage: trimmedSystem,
+          developerMessage: trimmedDeveloper,
+        },
+      };
+      setFormState(updatedForm);
+      setInitialState(updatedForm);
+      setSuccess("Configuration sauvegardée avec succès.");
+    } catch (saveError) {
+      setError(
+        getErrorMessage(saveError) ||
+          "Impossible d'enregistrer les modifications."
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }, [formState, isSaving, token]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <header className="space-y-2">
+          <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">
+            Conception d'activités assistée par IA
+          </h2>
+          <p className="text-sm text-[color:var(--brand-charcoal)]/80">
+            Chargement de la configuration...
+          </p>
+        </header>
+        <div className="rounded-3xl border border-white/60 bg-white/70 p-6 text-sm text-[color:var(--brand-charcoal)]/70 shadow-sm backdrop-blur">
+          Initialisation en cours...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/60">
+            Génération d'activités
+          </p>
+          <h2 className="text-2xl font-semibold text-[color:var(--brand-black)]">
+            Conception d'activités assistée par IA
+          </h2>
+        </div>
+        <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/80">
+          Ajustez les messages envoyés au modèle pour orienter la conception automatique des activités.
+          Le message système fixe le rôle général de l'assistant tandis que le message développeur précise la méthodologie et les contraintes pédagogiques.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-3xl border border-red-200 bg-red-50/90 p-4 text-sm text-red-800 shadow-sm">
+          {error}
+        </div>
+      ) : null}
+
+      {success ? (
+        <div className="rounded-3xl border border-green-200 bg-green-50/90 p-4 text-sm text-green-800 shadow-sm">
+          {success}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="space-y-3 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-sm backdrop-blur">
+          <header className="space-y-2">
+            <h3 className="text-base font-semibold text-[color:var(--brand-black)]">
+              Message système
+            </h3>
+            <p className="text-sm text-[color:var(--brand-charcoal)]/70">
+              Définit le positionnement général de l'assistant IA (ton, expertise, public cible).
+            </p>
+          </header>
+          <textarea
+            value={formState.systemMessage}
+            onChange={(event) => handleChange("systemMessage", event.target.value)}
+            rows={10}
+            maxLength={4000}
+            className="min-h-[14rem] w-full resize-y rounded-2xl border border-[color:var(--brand-sand)]/70 bg-white/90 p-4 text-sm leading-relaxed text-[color:var(--brand-charcoal)] shadow-inner focus:border-[color:var(--brand-red)]/60 focus:outline-none focus:ring-0"
+          />
+          <p className="text-xs text-[color:var(--brand-charcoal)]/60">
+            {formState.systemMessage.length} caractères / 4000
+          </p>
+        </section>
+
+        <section className="space-y-3 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-sm backdrop-blur">
+          <header className="space-y-2">
+            <h3 className="text-base font-semibold text-[color:var(--brand-black)]">
+              Message développeur
+            </h3>
+            <p className="text-sm text-[color:var(--brand-charcoal)]/70">
+              Détaille les étapes attendues, les outils autorisés et les exigences de restitution pour chaque activité générée.
+            </p>
+          </header>
+          <textarea
+            value={formState.developerMessage}
+            onChange={(event) => handleChange("developerMessage", event.target.value)}
+            rows={12}
+            maxLength={6000}
+            className="min-h-[18rem] w-full resize-y rounded-2xl border border-[color:var(--brand-sand)]/70 bg-white/90 p-4 text-sm leading-relaxed text-[color:var(--brand-charcoal)] shadow-inner focus:border-[color:var(--brand-red)]/60 focus:outline-none focus:ring-0"
+          />
+          <p className="text-xs text-[color:var(--brand-charcoal)]/60">
+            {formState.developerMessage.length} caractères / 6000
+          </p>
+        </section>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/30 px-4 py-2 text-sm font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
+          onClick={handleResetForm}
+          disabled={isSaving || !hasChanges}
+        >
+          Annuler les modifications
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-sand)]/60 bg-[color:var(--brand-sand)]/30 px-4 py-2 text-sm font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-sand)]/80 hover:bg-[color:var(--brand-sand)]/50"
+          onClick={handleRestoreDefaults}
+          disabled={isSaving}
+        >
+          Restaurer les valeurs par défaut
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-300"
+          onClick={() => {
+            void handleSave();
+          }}
+          disabled={isSaving || !hasChanges}
+        >
+          {isSaving ? "Enregistrement..." : "Enregistrer les modifications"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -5,6 +5,7 @@ import logoPrincipal from "../../assets/logo_principal.svg";
 import { useAdminAuth } from "../../providers/AdminAuthProvider";
 
 const NAV_LINKS = [
+  { to: "/admin/activity-generation", label: "Conception d'activités IA" },
   { to: "/admin/platforms", label: "Plateformes LTI" },
   { to: "/admin/lti-users", label: "Utilisateurs LTI" },
   { to: "/admin/local-users", label: "Comptes internes" },


### PR DESCRIPTION
## Summary
- add configurable system prompt support to activity generation on the backend and persist it alongside developer prompts
- create an admin interface dedicated to AI activity conception and remove the legacy message editor from the activity selector
- update frontend types, routing, and configuration defaults to keep generated activities using the saved prompts

## Testing
- pytest backend/tests/test_admin_activities_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d700bd58248322888b5556583dfec2