### PR TITLE
Limit learner card simplification to mobile view

### DIFF
--- a/frontend/src/components/ActivityLayout.tsx
+++ b/frontend/src/components/ActivityLayout.tsx
@@ -89,7 +89,7 @@ function ActivityLayout({
     <div
       className={combineClasses(
         useDynamicViewportHeight ? "min-h-[100dvh]" : "min-h-screen",
-        withBasePadding ? "px-6 pb-16 pt-10" : "",
+        withBasePadding ? "px-4 pb-16 pt-10 sm:px-6" : "",
         "text-[color:var(--brand-black)]",
         withLandingGradient ? "landing-gradient" : "",
         outerClassName

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -1838,7 +1838,7 @@ function ActivitySelector(): JSX.Element {
           </p>
         </div>
       ) : null}
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid grid-cols-2 gap-4 sm:gap-6">
         {activitiesToDisplay.map((activity: ActivityDefinition, index: number) => {
           const isDisabled = activity.enabled === false;
           const isCompleted = completedMap[activity.id];
@@ -1876,7 +1876,7 @@ function ActivitySelector(): JSX.Element {
               onDragStart={() => handleDragStart(index)}
               onDragOver={(e) => handleDragOver(e, index)}
               onDragEnd={handleDragEnd}
-              className={`group relative flex h-full flex-col gap-6 rounded-3xl border p-8 shadow-sm backdrop-blur transition ${hoverClasses} ${statusClasses} ${editClasses} ${generatedClasses} ${dragClasses}`.trim()}
+              className={`group relative flex h-full flex-col gap-6 rounded-3xl border p-6 shadow-sm backdrop-blur transition ${hoverClasses} ${statusClasses} ${editClasses} ${generatedClasses} ${dragClasses} ${isEditMode ? "items-stretch text-left sm:p-8" : "items-center text-center"}`.trim()}
             >
               {isEditMode && (
                 <div className="absolute left-4 top-4 flex flex-col gap-1">
@@ -1943,11 +1943,13 @@ function ActivitySelector(): JSX.Element {
                 Désactivée
               </span>
             )}
-              <div className="space-y-3">
-                {isEditMode ? (
-                  <>
-                    <input
-                      type="text"
+            <div
+              className={`space-y-3${isEditMode ? "" : " hidden sm:block"}`}
+            >
+              {isEditMode ? (
+                <>
+                  <input
+                    type="text"
                     value={activity.card.title}
                     onChange={(e) => handleUpdateActivityText(activity.id, 'title', e.target.value)}
                     className="w-full border-b border-gray-200 bg-transparent text-2xl font-semibold text-[color:var(--brand-black)] focus:border-orange-400 focus:outline-none"
@@ -1956,7 +1958,7 @@ function ActivitySelector(): JSX.Element {
                     value={activity.card.description}
                     onChange={(e) => handleUpdateActivityText(activity.id, 'description', e.target.value)}
                     rows={3}
-                    className="w-full resize-none border border-gray-200 rounded-lg p-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 focus:border-orange-400 focus:outline-none"
+                    className="w-full resize-none rounded-lg border border-gray-200 p-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 focus:border-orange-400 focus:outline-none"
                   />
                 </>
               ) : (
@@ -1970,9 +1972,30 @@ function ActivitySelector(): JSX.Element {
                 </>
               )}
             </div>
-            <ul className="flex flex-col gap-2 text-sm text-[color:var(--brand-charcoal)]">
+            {!isEditMode ? (
+              <Link
+                to={activity.card.cta.to}
+                aria-label={`${activity.card.cta.label} – ${activity.card.title}`}
+                className="flex h-full w-full flex-1 flex-col items-center justify-center gap-3 text-center sm:hidden"
+              >
+                <h2 className="text-lg font-semibold text-[color:var(--brand-black)]">
+                  {activity.card.title}
+                </h2>
+                <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90">
+                  {activity.card.description}
+                </p>
+              </Link>
+            ) : null}
+            <ul
+              className={`flex-col gap-2 text-sm text-[color:var(--brand-charcoal)] ${
+                isEditMode ? "flex" : "hidden sm:flex"
+              }`}
+            >
               {activity.card.highlights.map((item, highlightIndex) => (
-                <li key={`${activity.id}-highlight-${highlightIndex}`} className="flex items-center gap-3">
+                <li
+                  key={`${activity.id}-highlight-${highlightIndex}`}
+                  className="flex items-center gap-3"
+                >
                   <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
                     +
                   </span>
@@ -1996,7 +2019,7 @@ function ActivitySelector(): JSX.Element {
                   )}
                 </li>
               ))}
-              {isEditMode && (
+              {isEditMode ? (
                 <li className="flex items-center gap-3">
                   <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-400">
                     +
@@ -2008,7 +2031,7 @@ function ActivitySelector(): JSX.Element {
                     Ajouter un point
                   </button>
                 </li>
-              )}
+              ) : null}
             </ul>
             {isEditMode && activity.componentKey === STEP_SEQUENCE_COMPONENT_KEY ? (
               <StepSequenceEditor
@@ -2032,9 +2055,15 @@ function ActivitySelector(): JSX.Element {
                 }
               />
             ) : null}
-            <div className="mt-auto">
+            <div
+              className={
+                isEditMode
+                  ? "mt-auto space-y-4"
+                  : "mt-auto hidden sm:block"
+              }
+            >
               {isEditMode ? (
-                <div className="space-y-4">
+                <>
                   <label className="flex items-center gap-2 text-xs text-gray-600">
                     <input
                       type="checkbox"
@@ -2051,9 +2080,9 @@ function ActivitySelector(): JSX.Element {
                     type="text"
                     value={activity.card.cta.label}
                     onChange={(e) => handleUpdateActivityText(activity.id, 'cta.label', e.target.value)}
-                    className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:border-orange-400 focus:outline-none"
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-orange-400 focus:outline-none"
                   />
-                </div>
+                </>
               ) : (
                 <Link
                   to={activity.card.cta.to}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -82,7 +82,7 @@ function LandingPage(): JSX.Element {
   }, [isLTISession, ltiLoading, navigate]);
 
   return (
-    <div className="landing-gradient min-h-screen px-6 pb-24 pt-10 text-[color:var(--brand-black)]">
+    <div className="landing-gradient min-h-screen px-4 pb-24 pt-10 text-[color:var(--brand-black)] sm:px-6">
       <div className="mx-auto flex max-w-6xl flex-col gap-16">
         <header className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
           <Link to="/" className="flex items-center gap-3">

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -25,7 +25,7 @@ export function AdminLayout(): JSX.Element {
   }, [expiresAt]);
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-10 px-6 py-10 text-[color:var(--brand-black)]">
+    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-10 px-4 py-10 text-[color:var(--brand-black)] sm:px-6">
       <header className="space-y-6 rounded-3xl border border-white/60 bg-white/95 p-8 shadow-lg backdrop-blur">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 text-sm text-[color:var(--brand-charcoal)]/90 sm:text-base">


### PR DESCRIPTION
## Summary
- keep the compact bubble link for learners only on small screens while leaving edit controls unaffected
- restore the detailed highlight list and CTA on larger breakpoints so desktop users keep the full card content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d702fdb194832290995e9376986acd