### PR TITLE
feat: persist editable landing page content

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -92,6 +92,133 @@ DEFAULT_ACTIVITY_GENERATION_DEVELOPER_MESSAGE = "\n".join(
     ]
 )
 
+DEFAULT_LANDING_PAGE_CONFIG: dict[str, Any] = {
+    "brandTagline": "Formation IA",
+    "navActivitiesLabel": "Studio d'activités",
+    "navIntegrationsLabel": "Intégrations",
+    "navLoginLabel": "Se connecter",
+    "heroEyebrow": "Créateur d'activités",
+    "heroTitle": "Concevez des activités pédagogiques autoportantes alimentées par l'IA.",
+    "heroDescription": (
+        "Formation IA devient votre studio de conception : décrivez vos objectifs, laissez l'IA générer le parcours, "
+        "publiez-le en Deep Link dans votre LMS et suivez l'engagement sans friction."
+    ),
+    "heroPrimaryCtaLabel": "Accéder au studio",
+    "heroSecondaryCtaLabel": "Déployer via LTI Deep Link",
+    "heroHighlights": [
+        {
+            "title": "Génération assistée",
+            "description": "Construisez une activité complète en quelques minutes : structure, consignes et rétroactions sont proposés automatiquement.",
+        },
+        {
+            "title": "Diffusion autoportante",
+            "description": "Chaque activité inclut les supports nécessaires pour être utilisée en autonomie ou intégrée à distance dans vos cours.",
+        },
+    ],
+    "heroBadgeLabel": "Nouveauté",
+    "heroBadgeTitle": "Génération IA + Deep Linking LTI",
+    "heroBadgeDescription": "Composez et distribuez vos activités autoportantes dans votre LMS en un clic.",
+    "heroIdealForTitle": "Pensé pour",
+    "heroIdealForItems": [
+        "Concepteurs pédagogiques et conseillers TIC",
+        "Responsables de formation continue",
+        "Équipes numériques des établissements",
+    ],
+    "experiencesEyebrow": "Canevas intelligents",
+    "experiencesTitle": "Des modèles autoportants qui transforment une intention en parcours complet.",
+    "experiencesDescription": (
+        "Chaque activité générée fournit un storyboard, des consignes adaptées et des livrables exportables, "
+        "sans dépendre d'un accompagnement manuel."
+    ),
+    "experiencesCards": [
+        {
+            "title": "Storyboard assisté",
+            "description": "L'IA suggère une progression alignée sur vos objectifs avec des moments d'interaction ciblés.",
+        },
+        {
+            "title": "Ressources intégrées",
+            "description": "Textes, rétroactions et exemples contextualisés sont préremplis et personnalisables.",
+        },
+        {
+            "title": "Suivi prêt à l'emploi",
+            "description": "Collectez les traces d'apprentissage et exportez les livrables vers vos outils institutionnels.",
+        },
+    ],
+    "experiencesCardCtaLabel": "Publier immédiatement",
+    "integrationsEyebrow": "Intégrations LTI",
+    "integrationsTitle": "Connectez vos activités autoportantes à n'importe quel environnement d'apprentissage.",
+    "integrationsDescription": (
+        "Le Deep Linking LTI diffuse vos créations vers le bon groupe tandis que les webhooks alimentent vos tableaux de bord."
+    ),
+    "integrationHighlights": [
+        {
+            "title": "Deep Link dynamique",
+            "description": "Insérez l'activité générée directement dans un cours via LTI 1.3, sans double saisie.",
+        },
+        {
+            "title": "Rôles synchronisés",
+            "description": "Les permissions enseignant et étudiant sont gérées automatiquement depuis votre LMS.",
+        },
+        {
+            "title": "Suivi consolidé",
+            "description": "Retrouvez l'engagement et les livrables dans vos outils analytiques existants.",
+        },
+    ],
+    "onboardingTitle": "Comment déployer ?",
+    "onboardingSteps": [
+        {
+            "title": "Configurer le studio",
+            "description": "Ajoutez le connecteur LTI et partagez la clé publique fournie par Formation IA.",
+        },
+        {
+            "title": "Générer l'activité",
+            "description": "Décrivez objectifs et livrables : l'IA compose un parcours autoportant prêt à l'emploi.",
+        },
+        {
+            "title": "Partager en Deep Link",
+            "description": "Sélectionnez l'activité générée et insérez-la dans vos cours via le flux LTI.",
+        },
+    ],
+    "onboardingCtaLabel": "Activer le déploiement LTI",
+    "closingTitle": "Passez de l'idée à l'activité livrable en quelques minutes.",
+    "closingDescription": (
+        "Nos spécialistes vous accompagnent pour configurer le studio, cadrer les usages responsables de l'IA "
+        "et déployer vos activités via LTI Deep Linking."
+    ),
+    "closingPrimaryCtaLabel": "Lancer le studio",
+    "closingSecondaryCtaLabel": "Planifier une démonstration",
+    "footerNote": "Formation IA – Studio autoportant du Cégep Limoilou.",
+    "footerLinks": [
+        {"label": "Studio", "href": "/activites"},
+        {"label": "Connexion", "href": "/connexion"},
+        {"label": "LTI Deep Link", "href": "#integrations"},
+    ],
+}
+
+
+def _default_hero_highlights() -> list[dict[str, str]]:
+    return [dict(item) for item in DEFAULT_LANDING_PAGE_CONFIG["heroHighlights"]]
+
+
+def _default_experiences_cards() -> list[dict[str, str]]:
+    return [dict(item) for item in DEFAULT_LANDING_PAGE_CONFIG["experiencesCards"]]
+
+
+def _default_integration_highlights() -> list[dict[str, str]]:
+    return [dict(item) for item in DEFAULT_LANDING_PAGE_CONFIG["integrationHighlights"]]
+
+
+def _default_onboarding_steps() -> list[dict[str, str]]:
+    return [dict(item) for item in DEFAULT_LANDING_PAGE_CONFIG["onboardingSteps"]]
+
+
+def _default_hero_ideal_for_items() -> list[str]:
+    return list(DEFAULT_LANDING_PAGE_CONFIG["heroIdealForItems"])
+
+
+def _default_footer_links() -> list[dict[str, str]]:
+    return [dict(item) for item in DEFAULT_LANDING_PAGE_CONFIG["footerLinks"]]
+
 MISSIONS_PATH = Path(__file__).resolve().parent.parent / "missions.json"
 
 
@@ -134,6 +261,78 @@ def _resolve_activities_config_path() -> Path:
 ACTIVITIES_CONFIG_PATH = _resolve_activities_config_path()
 
 _ACTIVITY_CONFIG_LOCK = Lock()
+
+
+def _resolve_landing_page_config_path() -> Path:
+    raw_path = os.getenv("LANDING_PAGE_CONFIG_PATH")
+    if raw_path:
+        candidate = Path(raw_path).expanduser()
+        treat_as_dir = raw_path.endswith(("/", "\\")) or (
+            candidate.exists() and candidate.is_dir()
+        )
+        if treat_as_dir:
+            candidate.mkdir(parents=True, exist_ok=True)
+            target = candidate / "landing_page_config.json"
+        else:
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            target = candidate
+        return target.resolve()
+
+    storage_dir = get_admin_storage_directory()
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    return (storage_dir / "landing_page_config.json").resolve()
+
+
+LANDING_PAGE_CONFIG_PATH = _resolve_landing_page_config_path()
+LANDING_PAGE_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+_LANDING_PAGE_CONFIG_LOCK = Lock()
+
+
+def _load_landing_page_config() -> dict[str, Any]:
+    if not LANDING_PAGE_CONFIG_PATH.exists():
+        return LandingPageConfig().model_dump(by_alias=True, exclude_none=True)
+
+    try:
+        with LANDING_PAGE_CONFIG_PATH.open("r", encoding="utf-8") as handle:
+            raw_data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="landing_page_config.json contient un JSON invalide.",
+        ) from exc
+
+    try:
+        config = LandingPageConfig.model_validate(raw_data or {})
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="landing_page_config.json contient une configuration invalide.",
+        ) from exc
+
+    return config.model_dump(by_alias=True, exclude_none=True)
+
+
+def _save_landing_page_config(config: Mapping[str, Any]) -> None:
+    try:
+        validated = LandingPageConfig.model_validate(config)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="landingPage doit contenir une configuration valide.",
+        ) from exc
+
+    payload = validated.model_dump(by_alias=True, exclude_none=True)
+
+    with _LANDING_PAGE_CONFIG_LOCK:
+        try:
+            with LANDING_PAGE_CONFIG_PATH.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2)
+        except Exception as exc:  # pragma: no cover - IO errors
+            raise HTTPException(
+                status_code=500,
+                detail=f"Impossible de sauvegarder la configuration de la page d'accueil: {str(exc)}",
+            ) from exc
 
 ADMIN_SESSION_COOKIE_NAME = os.getenv("ADMIN_SESSION_COOKIE_NAME", "formationia_admin_session")
 _ADMIN_SESSION_TTL = max(int(os.getenv("ADMIN_SESSION_TTL", "3600")), 60)
@@ -1569,6 +1768,247 @@ class ActivityProgressRequest(BaseModel):
     completed: bool = Field(default=True)
 
 
+class LandingPageHighlight(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    title: str = Field(..., min_length=1, max_length=160)
+    description: str = Field(..., min_length=1, max_length=800)
+
+
+class LandingPageStep(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    title: str = Field(..., min_length=1, max_length=160)
+    description: str = Field(..., min_length=1, max_length=800)
+
+
+class LandingPageLink(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    label: str = Field(..., min_length=1, max_length=160)
+    href: str = Field(..., min_length=1, max_length=400)
+
+
+class LandingPageConfig(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    brand_tagline: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["brandTagline"],
+        alias="brandTagline",
+        min_length=1,
+        max_length=160,
+    )
+    nav_activities_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["navActivitiesLabel"],
+        alias="navActivitiesLabel",
+        min_length=1,
+        max_length=160,
+    )
+    nav_integrations_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["navIntegrationsLabel"],
+        alias="navIntegrationsLabel",
+        min_length=1,
+        max_length=160,
+    )
+    nav_login_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["navLoginLabel"],
+        alias="navLoginLabel",
+        min_length=1,
+        max_length=160,
+    )
+    hero_eyebrow: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroEyebrow"],
+        alias="heroEyebrow",
+        min_length=1,
+        max_length=160,
+    )
+    hero_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroTitle"],
+        alias="heroTitle",
+        min_length=1,
+        max_length=200,
+    )
+    hero_description: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroDescription"],
+        alias="heroDescription",
+        min_length=1,
+        max_length=800,
+    )
+    hero_primary_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroPrimaryCtaLabel"],
+        alias="heroPrimaryCtaLabel",
+        min_length=1,
+        max_length=120,
+    )
+    hero_secondary_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroSecondaryCtaLabel"],
+        alias="heroSecondaryCtaLabel",
+        min_length=1,
+        max_length=160,
+    )
+    hero_highlights: list[LandingPageHighlight] = Field(
+        default_factory=_default_hero_highlights,
+        alias="heroHighlights",
+        min_length=1,
+        max_length=6,
+    )
+    hero_badge_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroBadgeLabel"],
+        alias="heroBadgeLabel",
+        min_length=1,
+        max_length=80,
+    )
+    hero_badge_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroBadgeTitle"],
+        alias="heroBadgeTitle",
+        min_length=1,
+        max_length=160,
+    )
+    hero_badge_description: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroBadgeDescription"],
+        alias="heroBadgeDescription",
+        min_length=1,
+        max_length=400,
+    )
+    hero_ideal_for_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["heroIdealForTitle"],
+        alias="heroIdealForTitle",
+        min_length=1,
+        max_length=120,
+    )
+    hero_ideal_for_items: list[str] = Field(
+        default_factory=_default_hero_ideal_for_items,
+        alias="heroIdealForItems",
+        min_length=1,
+        max_length=6,
+    )
+    experiences_eyebrow: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["experiencesEyebrow"],
+        alias="experiencesEyebrow",
+        min_length=1,
+        max_length=160,
+    )
+    experiences_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["experiencesTitle"],
+        alias="experiencesTitle",
+        min_length=1,
+        max_length=200,
+    )
+    experiences_description: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["experiencesDescription"],
+        alias="experiencesDescription",
+        min_length=1,
+        max_length=800,
+    )
+    experiences_cards: list[LandingPageHighlight] = Field(
+        default_factory=_default_experiences_cards,
+        alias="experiencesCards",
+        min_length=1,
+        max_length=6,
+    )
+    experiences_card_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["experiencesCardCtaLabel"],
+        alias="experiencesCardCtaLabel",
+        min_length=1,
+        max_length=160,
+    )
+    integrations_eyebrow: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["integrationsEyebrow"],
+        alias="integrationsEyebrow",
+        min_length=1,
+        max_length=160,
+    )
+    integrations_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["integrationsTitle"],
+        alias="integrationsTitle",
+        min_length=1,
+        max_length=200,
+    )
+    integrations_description: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["integrationsDescription"],
+        alias="integrationsDescription",
+        min_length=1,
+        max_length=800,
+    )
+    integration_highlights: list[LandingPageHighlight] = Field(
+        default_factory=_default_integration_highlights,
+        alias="integrationHighlights",
+        min_length=1,
+        max_length=6,
+    )
+    onboarding_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["onboardingTitle"],
+        alias="onboardingTitle",
+        min_length=1,
+        max_length=160,
+    )
+    onboarding_steps: list[LandingPageStep] = Field(
+        default_factory=_default_onboarding_steps,
+        alias="onboardingSteps",
+        min_length=1,
+        max_length=6,
+    )
+    onboarding_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["onboardingCtaLabel"],
+        alias="onboardingCtaLabel",
+        min_length=1,
+        max_length=160,
+    )
+    closing_title: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["closingTitle"],
+        alias="closingTitle",
+        min_length=1,
+        max_length=200,
+    )
+    closing_description: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["closingDescription"],
+        alias="closingDescription",
+        min_length=1,
+        max_length=800,
+    )
+    closing_primary_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["closingPrimaryCtaLabel"],
+        alias="closingPrimaryCtaLabel",
+        min_length=1,
+        max_length=160,
+    )
+    closing_secondary_cta_label: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["closingSecondaryCtaLabel"],
+        alias="closingSecondaryCtaLabel",
+        min_length=1,
+        max_length=160,
+    )
+    footer_note: str = Field(
+        default=DEFAULT_LANDING_PAGE_CONFIG["footerNote"],
+        alias="footerNote",
+        min_length=1,
+        max_length=240,
+    )
+    footer_links: list[LandingPageLink] = Field(
+        default_factory=_default_footer_links,
+        alias="footerLinks",
+        min_length=1,
+        max_length=6,
+    )
+
+    @model_validator(mode="after")
+    def _normalize_lists(self) -> "LandingPageConfig":
+        normalized_ideal_for: list[str] = []
+        for item in self.hero_ideal_for_items:
+            if isinstance(item, str):
+                trimmed = item.strip()
+                if trimmed and trimmed not in normalized_ideal_for:
+                    normalized_ideal_for.append(trimmed)
+        if not normalized_ideal_for:
+            normalized_ideal_for = _default_hero_ideal_for_items()
+        object.__setattr__(self, "hero_ideal_for_items", normalized_ideal_for)
+        return self
+
+
+class LandingPageConfigRequest(LandingPageConfig):
+    pass
+
+
 class ActivitySelectorHeader(BaseModel):
     eyebrow: str | None = None
     title: str | None = None
@@ -2788,6 +3228,13 @@ def get_activities_config() -> dict[str, Any]:
     return _load_activities_config()
 
 
+@app.get("/api/landing-page")
+@app.get("/landing-page")
+def get_landing_page_config_endpoint() -> dict[str, Any]:
+    """Endpoint public renvoyant la configuration de la page d'accueil."""
+    return _load_landing_page_config()
+
+
 @admin_router.get("/activities")
 def admin_get_activities_config(
     _: LocalUser = Depends(_require_admin_user),
@@ -2806,6 +3253,22 @@ def admin_save_activities_config(
     return {"ok": True, "message": "Configuration sauvegardée avec succès"}
 
 
+@admin_router.get("/landing-page")
+def admin_get_landing_page_config_endpoint(
+    _: LocalUser = Depends(_require_admin_user),
+) -> dict[str, Any]:
+    """Récupère la configuration de la page d'accueil."""
+    return _load_landing_page_config()
+
+
+@admin_router.post("/landing-page")
+def admin_save_landing_page_config_endpoint(
+    payload: LandingPageConfigRequest,
+    _: LocalUser = Depends(_require_admin_user),
+) -> dict[str, Any]:
+    """Sauvegarde la configuration de la page d'accueil."""
+    _save_landing_page_config(payload.model_dump(by_alias=True, exclude_none=True))
+    return {"ok": True, "message": "Configuration sauvegardée avec succès"}
 
 
 def _run_activity_generation_job(

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -384,6 +384,62 @@ export interface SaveActivityConfigResponse {
   message: string;
 }
 
+export interface LandingPageHighlight {
+  title: string;
+  description: string;
+}
+
+export interface LandingPageStep {
+  title: string;
+  description: string;
+}
+
+export interface LandingPageLink {
+  label: string;
+  href: string;
+}
+
+export interface LandingPageContent {
+  brandTagline: string;
+  navActivitiesLabel: string;
+  navIntegrationsLabel: string;
+  navLoginLabel: string;
+  heroEyebrow: string;
+  heroTitle: string;
+  heroDescription: string;
+  heroPrimaryCtaLabel: string;
+  heroSecondaryCtaLabel: string;
+  heroHighlights: LandingPageHighlight[];
+  heroBadgeLabel: string;
+  heroBadgeTitle: string;
+  heroBadgeDescription: string;
+  heroIdealForTitle: string;
+  heroIdealForItems: string[];
+  experiencesEyebrow: string;
+  experiencesTitle: string;
+  experiencesDescription: string;
+  experiencesCards: LandingPageHighlight[];
+  experiencesCardCtaLabel: string;
+  integrationsEyebrow: string;
+  integrationsTitle: string;
+  integrationsDescription: string;
+  integrationHighlights: LandingPageHighlight[];
+  onboardingTitle: string;
+  onboardingSteps: LandingPageStep[];
+  onboardingCtaLabel: string;
+  closingTitle: string;
+  closingDescription: string;
+  closingPrimaryCtaLabel: string;
+  closingSecondaryCtaLabel: string;
+  footerNote: string;
+  footerLinks: LandingPageLink[];
+}
+
+export interface SaveLandingPageConfigResponse {
+  ok: boolean;
+  message: string;
+}
+
 export interface ActivityGenerationDetailsPayload {
   theme?: string;
   audience?: string;
@@ -429,6 +485,11 @@ export interface ActivityGenerationJobOptions {
 export const activities = {
   getConfig: async (): Promise<ActivityConfigResponse> =>
     fetchJson<ActivityConfigResponse>(`${API_BASE_URL}/activities-config`),
+};
+
+export const landingPage = {
+  get: async (): Promise<LandingPageContent> =>
+    fetchJson<LandingPageContent>(`${API_BASE_URL}/landing-page`),
 };
 
 export const admin = {
@@ -484,6 +545,30 @@ export const admin = {
         withAdminCredentials(
           {
             signal: options?.signal,
+          },
+          token
+        )
+      ),
+  },
+  landingPage: {
+    get: async (token?: string | null): Promise<LandingPageContent> =>
+      fetchJson<LandingPageContent>(
+        `${API_BASE_URL}/admin/landing-page`,
+        withAdminCredentials({}, token)
+      ),
+    save: async (
+      payload: LandingPageContent,
+      token?: string | null
+    ): Promise<SaveLandingPageConfigResponse> =>
+      fetchJson<SaveLandingPageConfigResponse>(
+        `${API_BASE_URL}/admin/landing-page`,
+        withAdminCredentials(
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
           },
           token
         )

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,79 +1,202 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import logoPrincipal from "../assets/logo_principal.svg";
+import {
+  admin,
+  landingPage as landingPageClient,
+  type LandingPageContent,
+  type LandingPageLink,
+} from "../api";
 import { useLTI } from "../hooks/useLTI";
+import { useAdminAuth } from "../providers/AdminAuthProvider";
 
-const heroHighlights = [
-  {
-    title: "Ateliers guidés",
-    description:
-      "Quatre parcours prêts à l'emploi pour cadrer une demande, tester des prompts ou clarifier une consigne d'évaluation.",
-  },
-  {
-    title: "Accompagnement humain",
-    description:
-      "Chaque activité contient des repères pédagogiques et des rappels méthodologiques pour garder l'esprit critique face à l'IA.",
-  },
-];
+const DEFAULT_LANDING_PAGE_CONTENT: LandingPageContent = {
+  brandTagline: "Formation IA",
+  navActivitiesLabel: "Studio d'activités",
+  navIntegrationsLabel: "Intégrations",
+  navLoginLabel: "Se connecter",
+  heroEyebrow: "Créateur d'activités",
+  heroTitle: "Concevez des activités pédagogiques autoportantes alimentées par l'IA.",
+  heroDescription:
+    "Formation IA devient votre studio de conception : décrivez vos objectifs, laissez l'IA générer le parcours, publiez-le en Deep Link dans votre LMS et suivez l'engagement sans friction.",
+  heroPrimaryCtaLabel: "Accéder au studio",
+  heroSecondaryCtaLabel: "Déployer via LTI Deep Link",
+  heroHighlights: [
+    {
+      title: "Génération assistée",
+      description:
+        "Construisez une activité complète en quelques minutes : structure, consignes et rétroactions sont proposés automatiquement.",
+    },
+    {
+      title: "Diffusion autoportante",
+      description:
+        "Chaque activité inclut les supports nécessaires pour être utilisée en autonomie ou intégrée à distance dans vos cours.",
+    },
+  ],
+  heroBadgeLabel: "Nouveauté",
+  heroBadgeTitle: "Génération IA + Deep Linking LTI",
+  heroBadgeDescription:
+    "Composez et distribuez vos activités autoportantes dans votre LMS en un clic.",
+  heroIdealForTitle: "Pensé pour",
+  heroIdealForItems: [
+    "Concepteurs pédagogiques et conseillers TIC",
+    "Responsables de formation continue",
+    "Équipes numériques des établissements",
+  ],
+  experiencesEyebrow: "Canevas intelligents",
+  experiencesTitle:
+    "Des modèles autoportants qui transforment une intention en parcours complet.",
+  experiencesDescription:
+    "Chaque activité générée fournit un storyboard, des consignes adaptées et des livrables exportables, sans dépendre d'un accompagnement manuel.",
+  experiencesCards: [
+    {
+      title: "Storyboard assisté",
+      description:
+        "L'IA suggère une progression alignée sur vos objectifs avec des moments d'interaction ciblés.",
+    },
+    {
+      title: "Ressources intégrées",
+      description:
+        "Textes, rétroactions et exemples contextualisés sont préremplis et personnalisables.",
+    },
+    {
+      title: "Suivi prêt à l'emploi",
+      description:
+        "Collectez les traces d'apprentissage et exportez les livrables vers vos outils institutionnels.",
+    },
+  ],
+  experiencesCardCtaLabel: "Publier immédiatement",
+  integrationsEyebrow: "Intégrations LTI",
+  integrationsTitle:
+    "Connectez vos activités autoportantes à n'importe quel environnement d'apprentissage.",
+  integrationsDescription:
+    "Le Deep Linking LTI diffuse vos créations vers le bon groupe tandis que les webhooks alimentent vos tableaux de bord.",
+  integrationHighlights: [
+    {
+      title: "Deep Link dynamique",
+      description:
+        "Insérez l'activité générée directement dans un cours via LTI 1.3, sans double saisie.",
+    },
+    {
+      title: "Rôles synchronisés",
+      description:
+        "Les permissions enseignant et étudiant sont gérées automatiquement depuis votre LMS.",
+    },
+    {
+      title: "Suivi consolidé",
+      description:
+        "Retrouvez l'engagement et les livrables dans vos outils analytiques existants.",
+    },
+  ],
+  onboardingTitle: "Comment déployer ?",
+  onboardingSteps: [
+    {
+      title: "Configurer le studio",
+      description:
+        "Ajoutez le connecteur LTI et partagez la clé publique fournie par Formation IA.",
+    },
+    {
+      title: "Générer l'activité",
+      description:
+        "Décrivez objectifs et livrables : l'IA compose un parcours autoportant prêt à l'emploi.",
+    },
+    {
+      title: "Partager en Deep Link",
+      description:
+        "Sélectionnez l'activité générée et insérez-la dans vos cours via le flux LTI.",
+    },
+  ],
+  onboardingCtaLabel: "Activer le déploiement LTI",
+  closingTitle: "Passez de l'idée à l'activité livrable en quelques minutes.",
+  closingDescription:
+    "Nos spécialistes vous accompagnent pour configurer le studio, cadrer les usages responsables de l'IA et déployer vos activités via LTI Deep Linking.",
+  closingPrimaryCtaLabel: "Lancer le studio",
+  closingSecondaryCtaLabel: "Planifier une démonstration",
+  footerNote: "Formation IA – Studio autoportant du Cégep Limoilou.",
+  footerLinks: [
+    { label: "Studio", href: "/activites" },
+    { label: "Connexion", href: "/connexion" },
+    { label: "LTI Deep Link", href: "#integrations" },
+  ],
+};
 
-const featureCards = [
-  {
-    title: "Clarté d'abord",
-    description:
-      "Formalisez votre intention pédagogique en quelques étapes. L'interface suggère des formulations clés pour cadrer l'IA et éviter les dérives.",
-  },
-  {
-    title: "Prompt Dojo",
-    description:
-      "Comparez plusieurs prompts et mesurez leur impact. Les pistes d'amélioration sont affichées à chaque itération pour ancrer les bonnes pratiques.",
-  },
-  {
-    title: "Parcours de la clarté",
-    description:
-      "Un environnement ludique qui confronte l'étudiant à des cas ambigus et l'aide à cartographier ses choix argumentés.",
-  },
-];
+function cloneLandingContent(content: LandingPageContent): LandingPageContent {
+  return {
+    ...content,
+    heroHighlights: content.heroHighlights.map((item) => ({ ...item })),
+    heroIdealForItems: [...content.heroIdealForItems],
+    experiencesCards: content.experiencesCards.map((item) => ({ ...item })),
+    integrationHighlights: content.integrationHighlights.map((item) => ({ ...item })),
+    onboardingSteps: content.onboardingSteps.map((item) => ({ ...item })),
+    footerLinks: content.footerLinks.map((item) => ({ ...item })),
+  };
+}
 
-const integrationHighlights = [
-  {
-    title: "Connexion Moodle via LTI 1.3",
-    description:
-      "Déployez Formation IA comme activité externe sécurisée. LTI Advantage garantit l'échange automatique des identités et des rôles.",
-  },
-  {
-    title: "Deep Linking simplifié",
-    description:
-      "Insérez une activité Formation IA dans n'importe quel cours Moodle en deux clics. Les paramètres sont transmis automatiquement à vos étudiants.",
-  },
-  {
-    title: "Suivi des parcours",
-    description:
-      "Remontez les traces d'apprentissage dans Moodle : achèvements, activités consultées et progression par atelier.",
-  },
-];
+function normalizeLandingContent(raw?: LandingPageContent | null): LandingPageContent {
+  if (!raw) {
+    return cloneLandingContent(DEFAULT_LANDING_PAGE_CONTENT);
+  }
+  return cloneLandingContent({
+    ...DEFAULT_LANDING_PAGE_CONTENT,
+    ...raw,
+    heroHighlights: raw.heroHighlights ?? DEFAULT_LANDING_PAGE_CONTENT.heroHighlights,
+    heroIdealForItems:
+      raw.heroIdealForItems ?? DEFAULT_LANDING_PAGE_CONTENT.heroIdealForItems,
+    experiencesCards: raw.experiencesCards ?? DEFAULT_LANDING_PAGE_CONTENT.experiencesCards,
+    integrationHighlights:
+      raw.integrationHighlights ?? DEFAULT_LANDING_PAGE_CONTENT.integrationHighlights,
+    onboardingSteps: raw.onboardingSteps ?? DEFAULT_LANDING_PAGE_CONTENT.onboardingSteps,
+    footerLinks: raw.footerLinks ?? DEFAULT_LANDING_PAGE_CONTENT.footerLinks,
+  });
+}
 
-const onboardingSteps = [
-  {
-    title: "Configurer la plateforme",
-    description:
-      "Ajoutez Formation IA comme outil externe dans Moodle, importez la clé publique et choisissez les contextes autorisés.",
-  },
-  {
-    title: "Partager via Deep Link",
-    description:
-      "Depuis un cours, utilisez l'insertion LTI pour sélectionner l'activité désirée et personnaliser son intitulé.",
-  },
-  {
-    title: "Accompagner la cohorte",
-    description:
-      "Les apprenants accèdent instantanément aux parcours guidés et bénéficient des repères pédagogiques intégrés.",
-  },
-];
+type LandingPageStringField =
+  | "brandTagline"
+  | "navActivitiesLabel"
+  | "navIntegrationsLabel"
+  | "navLoginLabel"
+  | "heroEyebrow"
+  | "heroTitle"
+  | "heroDescription"
+  | "heroPrimaryCtaLabel"
+  | "heroSecondaryCtaLabel"
+  | "heroBadgeLabel"
+  | "heroBadgeTitle"
+  | "heroBadgeDescription"
+  | "heroIdealForTitle"
+  | "experiencesEyebrow"
+  | "experiencesTitle"
+  | "experiencesDescription"
+  | "experiencesCardCtaLabel"
+  | "integrationsEyebrow"
+  | "integrationsTitle"
+  | "integrationsDescription"
+  | "onboardingTitle"
+  | "onboardingCtaLabel"
+  | "closingTitle"
+  | "closingDescription"
+  | "closingPrimaryCtaLabel"
+  | "closingSecondaryCtaLabel"
+  | "footerNote";
 
 function LandingPage(): JSX.Element {
   const navigate = useNavigate();
   const { isLTISession, loading: ltiLoading } = useLTI();
+  const { status: adminStatus, user: adminUser, token, isEditMode, setEditMode } =
+    useAdminAuth();
+  const canEdit =
+    adminStatus === "authenticated" && (adminUser?.roles?.includes("admin") ?? false);
+
+  const [content, setContent] = useState<LandingPageContent>(() =>
+    cloneLandingContent(DEFAULT_LANDING_PAGE_CONTENT)
+  );
+  const [draft, setDraft] = useState<LandingPageContent>(() =>
+    cloneLandingContent(DEFAULT_LANDING_PAGE_CONTENT)
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (!ltiLoading && isLTISession) {
@@ -81,238 +204,734 @@ function LandingPage(): JSX.Element {
     }
   }, [isLTISession, ltiLoading, navigate]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadContent = async () => {
+      setLoading(true);
+      try {
+        const response = await landingPageClient.get();
+        if (cancelled) {
+          return;
+        }
+        const normalized = normalizeLandingContent(response);
+        setContent(normalized);
+        setDraft(normalized);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          console.warn("Impossible de charger la configuration de la page d'accueil", err);
+          const fallback = cloneLandingContent(DEFAULT_LANDING_PAGE_CONTENT);
+          setContent(fallback);
+          setDraft(fallback);
+          setError(
+            "Impossible de charger les textes personnalisés. Les valeurs par défaut sont utilisées."
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadContent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setDraft(cloneLandingContent(content));
+    }
+  }, [content, isEditMode]);
+
+  const displayContent = isEditMode ? draft : content;
+  const currentYear = new Date().getFullYear();
+
+  const handleStringChange = (field: LandingPageStringField) => (value: string) => {
+    if (!isEditMode) return;
+    setDraft((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleHighlightChange = (
+    section: "heroHighlights" | "experiencesCards" | "integrationHighlights",
+    index: number,
+    key: "title" | "description",
+    value: string
+  ) => {
+    if (!isEditMode) return;
+    setDraft((prev) => ({
+      ...prev,
+      [section]: prev[section].map((item, idx) =>
+        idx === index ? { ...item, [key]: value } : item
+      ),
+    }));
+  };
+
+  const handleOnboardingStepChange = (
+    index: number,
+    key: "title" | "description",
+    value: string
+  ) => {
+    if (!isEditMode) return;
+    setDraft((prev) => ({
+      ...prev,
+      onboardingSteps: prev.onboardingSteps.map((item, idx) =>
+        idx === index ? { ...item, [key]: value } : item
+      ),
+    }));
+  };
+
+  const handleIdealForChange = (index: number, value: string) => {
+    if (!isEditMode) return;
+    setDraft((prev) => {
+      const next = [...prev.heroIdealForItems];
+      next[index] = value;
+      return {
+        ...prev,
+        heroIdealForItems: next,
+      };
+    });
+  };
+
+  const handleFooterLinkChange = (
+    index: number,
+    key: "label" | "href",
+    value: string
+  ) => {
+    if (!isEditMode) return;
+    setDraft((prev) => ({
+      ...prev,
+      footerLinks: prev.footerLinks.map((link, idx) =>
+        idx === index ? { ...link, [key]: value } : link
+      ),
+    }));
+  };
+
+  const handleEnterEditMode = () => {
+    if (!canEdit) return;
+    setDraft(cloneLandingContent(content));
+    setEditMode(true);
+    setError(null);
+  };
+
+  const handleCancel = () => {
+    setDraft(cloneLandingContent(content));
+    setEditMode(false);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    if (!canEdit || !isEditMode || isSaving) return;
+
+    setIsSaving(true);
+    try {
+      await admin.landingPage.save(draft, token);
+      setContent(cloneLandingContent(draft));
+      setEditMode(false);
+      setError(null);
+    } catch (err) {
+      console.error("Erreur lors de la sauvegarde de la page d'accueil:", err);
+      alert("Erreur lors de la sauvegarde. Veuillez réessayer.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const renderFooterLink = (link: LandingPageLink, index: number) => {
+    const key = `${link.href}-${index}`;
+    if (!link.href) {
+      return (
+        <span key={key} className="text-[color:var(--brand-charcoal)]/80">
+          {link.label}
+        </span>
+      );
+    }
+    if (link.href.startsWith("/") ) {
+      return (
+        <Link key={key} to={link.href} className="hover:text-[color:var(--brand-red)]">
+          {link.label}
+        </Link>
+      );
+    }
+    return (
+      <a
+        key={key}
+        href={link.href}
+        className="hover:text-[color:var(--brand-red)]"
+      >
+        {link.label}
+      </a>
+    );
+  };
+
+  interface EditableTextProps {
+    value: string;
+    onChange: (value: string) => void;
+    as?: keyof JSX.IntrinsicElements;
+    className?: string;
+    placeholder?: string;
+    multiline?: boolean;
+    rows?: number;
+    type?: string;
+  }
+
+  const EditableText = ({
+    value,
+    onChange,
+    as = "span",
+    className = "",
+    placeholder,
+    multiline = false,
+    rows = 3,
+    type = "text",
+  }: EditableTextProps): JSX.Element => {
+    if (isEditMode) {
+      if (multiline) {
+        return (
+          <textarea
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            rows={rows}
+            className={`w-full resize-none rounded border border-orange-300 bg-white/90 p-2 focus:border-orange-500 focus:outline-none focus:ring-0 ${className}`}
+            placeholder={placeholder}
+          />
+        );
+      }
+      return (
+        <input
+          type={type}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          className={`w-full rounded border border-orange-300 bg-white/90 px-2 py-1 focus:border-orange-500 focus:outline-none focus:ring-0 ${className}`}
+          placeholder={placeholder}
+        />
+      );
+    }
+    const Element = as as keyof JSX.IntrinsicElements;
+    return <Element className={className}>{value}</Element>;
+  };
+
+  interface EditableButtonProps {
+    label: string;
+    onChange: (value: string) => void;
+    variant: "primary" | "light";
+    to?: string;
+    href?: string;
+  }
+
+  const EditableButton = ({
+    label,
+    onChange,
+    variant,
+    to,
+    href,
+  }: EditableButtonProps): JSX.Element => {
+    const baseClasses =
+      variant === "primary"
+        ? "cta-button cta-button--primary"
+        : "cta-button cta-button--light";
+    if (isEditMode) {
+      const editClasses =
+        variant === "primary"
+          ? "rounded-full border border-orange-300 bg-[color:var(--brand-red)]/90 px-4 py-2 text-sm font-semibold text-white focus:border-orange-500 focus:outline-none focus:ring-0"
+          : "rounded-full border border-orange-300 bg-white px-4 py-2 text-sm font-semibold text-[color:var(--brand-charcoal)] focus:border-orange-500 focus:outline-none focus:ring-0";
+      return (
+        <input
+          type="text"
+          value={label}
+          onChange={(event) => onChange(event.target.value)}
+          className={editClasses}
+        />
+      );
+    }
+    if (to) {
+      return (
+        <Link to={to} className={baseClasses}>
+          {label}
+        </Link>
+      );
+    }
+    return (
+      <a href={href} className={baseClasses}>
+        {label}
+      </a>
+    );
+  };
+
   return (
     <div className="landing-gradient min-h-screen px-4 pb-24 pt-10 text-[color:var(--brand-black)] sm:px-6">
       <div className="mx-auto flex max-w-6xl flex-col gap-16">
-        <header className="flex flex-col gap-6 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
-          <Link to="/" className="flex items-center gap-3">
-            <img
-              src={logoPrincipal}
-              alt="Formation IA"
-              className="h-10 w-auto md:h-12"
-            />
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/80">
-              Formation IA
-            </span>
-          </Link>
-          <nav className="flex flex-wrap items-center gap-3 text-sm font-semibold text-[color:var(--brand-charcoal)]/80">
-            <Link
-              to="/activites"
-              className="rounded-full border border-white/60 bg-white/60 px-4 py-2 transition hover:bg-white"
-            >
-              Parcours disponibles
+        <header className="rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur">
+          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+            <Link to="/" className="flex items-center gap-3">
+              <img src={logoPrincipal} alt="Formation IA" className="h-10 w-auto md:h-12" />
+              {isEditMode ? (
+                <input
+                  type="text"
+                  value={draft.brandTagline}
+                  onChange={(event) => handleStringChange("brandTagline")(event.target.value)}
+                  className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/80"
+                  placeholder="Nom de la plateforme"
+                />
+              ) : (
+                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/80">
+                  {displayContent.brandTagline}
+                </span>
+              )}
             </Link>
-            <a
-              href="#integrations"
-              className="rounded-full border border-white/60 bg-white/60 px-4 py-2 transition hover:bg-white"
-            >
-              Intégrations
-            </a>
-            <Link to="/connexion" className="cta-button cta-button--primary">
-              Se connecter
-            </Link>
-          </nav>
+            <div className="flex flex-col gap-3 md:items-end">
+              <nav className="flex flex-wrap items-center gap-3 text-sm font-semibold text-[color:var(--brand-charcoal)]/80 md:justify-end">
+                {isEditMode ? (
+                  <input
+                    type="text"
+                    value={draft.navActivitiesLabel}
+                    onChange={(event) => handleStringChange("navActivitiesLabel")(event.target.value)}
+                    className="min-w-[160px] rounded-full border border-orange-300 bg-white/90 px-4 py-2 focus:border-orange-500 focus:outline-none"
+                    placeholder="Libellé du studio"
+                  />
+                ) : (
+                  <Link
+                    to="/activites"
+                    className="rounded-full border border-white/60 bg-white/60 px-4 py-2 transition hover:bg-white"
+                  >
+                    {displayContent.navActivitiesLabel}
+                  </Link>
+                )}
+                {isEditMode ? (
+                  <input
+                    type="text"
+                    value={draft.navIntegrationsLabel}
+                    onChange={(event) => handleStringChange("navIntegrationsLabel")(event.target.value)}
+                    className="min-w-[140px] rounded-full border border-orange-300 bg-white/90 px-4 py-2 focus:border-orange-500 focus:outline-none"
+                    placeholder="Libellé des intégrations"
+                  />
+                ) : (
+                  <a
+                    href="#integrations"
+                    className="rounded-full border border-white/60 bg-white/60 px-4 py-2 transition hover:bg-white"
+                  >
+                    {displayContent.navIntegrationsLabel}
+                  </a>
+                )}
+                {isEditMode ? (
+                  <input
+                    type="text"
+                    value={draft.navLoginLabel}
+                    onChange={(event) => handleStringChange("navLoginLabel")(event.target.value)}
+                    className="min-w-[140px] rounded-full border border-orange-300 bg-white/90 px-4 py-2 focus:border-orange-500 focus:outline-none"
+                    placeholder="Libellé de connexion"
+                  />
+                ) : (
+                  <Link to="/connexion" className="cta-button cta-button--primary">
+                    {displayContent.navLoginLabel}
+                  </Link>
+                )}
+              </nav>
+              {canEdit && (
+                <div className="flex flex-wrap justify-end gap-2">
+                  {isEditMode ? (
+                    <>
+                      <button
+                        onClick={handleSave}
+                        disabled={isSaving}
+                        className="inline-flex items-center justify-center rounded-full border border-green-600/20 bg-green-50 px-4 py-2 text-xs font-medium text-green-700 transition hover:border-green-600/40 hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {isSaving ? "Sauvegarde..." : "Sauvegarder"}
+                      </button>
+                      <button
+                        onClick={handleCancel}
+                        disabled={isSaving}
+                        className="inline-flex items-center justify-center rounded-full border border-red-600/20 bg-red-50 px-4 py-2 text-xs font-medium text-red-700 transition hover:border-red-600/40 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Annuler
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      onClick={handleEnterEditMode}
+                      disabled={loading}
+                      className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-4 py-2 text-xs font-medium text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {loading ? "Chargement..." : "Mode édition"}
+                    </button>
+                  )}
+                </div>
+              )}
+              {canEdit && error ? (
+                <p className="text-xs font-medium text-red-600">{error}</p>
+              ) : null}
+            </div>
+          </div>
         </header>
 
         <main className="space-y-16">
           <section className="page-section landing-panel grid gap-12 bg-white/95 md:grid-cols-[2fr,1fr]">
             <div className="space-y-6">
-              <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-                Plateforme pédagogique
-              </span>
-              <h1 className="text-4xl font-semibold leading-tight md:text-5xl">
-                L'atelier pour apprendre à collaborer avec l'IA, pensé pour la formation supérieure.
-              </h1>
-              <p className="text-base leading-relaxed text-[color:var(--brand-charcoal)]">
-                Formation IA accompagne enseignants et apprenants dans la découverte responsable de l'intelligence artificielle générative. Chaque activité combine une progression scénarisée, des repères pédagogiques et des espaces de réflexion.
-              </p>
+              <EditableText
+                value={displayContent.heroEyebrow}
+                onChange={handleStringChange("heroEyebrow")}
+                as="span"
+                className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]"
+              />
+              <EditableText
+                value={displayContent.heroTitle}
+                onChange={handleStringChange("heroTitle")}
+                as="h1"
+                className="text-4xl font-semibold leading-tight md:text-5xl"
+              />
+              <EditableText
+                value={displayContent.heroDescription}
+                onChange={handleStringChange("heroDescription")}
+                as="p"
+                multiline
+                rows={4}
+                className="text-base leading-relaxed text-[color:var(--brand-charcoal)]"
+              />
               <div className="flex flex-col gap-3 sm:flex-row">
-                <Link to="/activites" className="cta-button cta-button--primary">
-                  Explorer les activités
-                </Link>
-                <Link to="/connexion" className="cta-button cta-button--light">
-                  Se connecter ou activer via Moodle
-                </Link>
+                <EditableButton
+                  label={displayContent.heroPrimaryCtaLabel}
+                  onChange={handleStringChange("heroPrimaryCtaLabel")}
+                  variant="primary"
+                  to="/activites"
+                />
+                <EditableButton
+                  label={displayContent.heroSecondaryCtaLabel}
+                  onChange={handleStringChange("heroSecondaryCtaLabel")}
+                  variant="light"
+                  to="/connexion"
+                />
               </div>
               <div className="grid gap-4 sm:grid-cols-2">
-                {heroHighlights.map((item) => (
+                {displayContent.heroHighlights.map((item, index) => (
                   <div
-                    key={item.title}
+                    key={`hero-highlight-${index}`}
                     className="rounded-2xl border border-white/80 bg-white/80 p-4 shadow-sm"
                   >
-                    <h3 className="text-sm font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
-                      {item.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                      {item.description}
-                    </p>
+                    <EditableText
+                      value={item.title}
+                      onChange={(value) =>
+                        handleHighlightChange("heroHighlights", index, "title", value)
+                      }
+                      as="h3"
+                      className="text-sm font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80"
+                    />
+                    <EditableText
+                      value={item.description}
+                      onChange={(value) =>
+                        handleHighlightChange("heroHighlights", index, "description", value)
+                      }
+                      as="p"
+                      multiline
+                      rows={3}
+                      className="mt-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]"
+                    />
                   </div>
                 ))}
               </div>
             </div>
             <div className="relative flex flex-col justify-between gap-6 rounded-3xl border border-[color:var(--brand-red)]/30 bg-[color:var(--brand-red)]/10 p-6 text-[color:var(--brand-charcoal)] shadow-inner">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-red)]/80">
-                  Nouveauté
-                </p>
-                <h2 className="mt-3 text-2xl font-semibold leading-snug">
-                  Intégration Moodle LTI + Deep Linking
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed">
-                  Distribuez les parcours Formation IA directement dans vos cours Moodle. Les enseignants publient, les étudiants se connectent, tout le monde apprend ensemble.
-                </p>
+                <EditableText
+                  value={displayContent.heroBadgeLabel}
+                  onChange={handleStringChange("heroBadgeLabel")}
+                  as="p"
+                  className="text-xs font-semibold uppercase tracking-[0.3em] text-[color:var(--brand-red)]/80"
+                />
+                <EditableText
+                  value={displayContent.heroBadgeTitle}
+                  onChange={handleStringChange("heroBadgeTitle")}
+                  as="h2"
+                  className="mt-3 text-2xl font-semibold leading-snug"
+                />
+                <EditableText
+                  value={displayContent.heroBadgeDescription}
+                  onChange={handleStringChange("heroBadgeDescription")}
+                  as="p"
+                  multiline
+                  rows={3}
+                  className="mt-2 text-sm leading-relaxed"
+                />
               </div>
               <div className="rounded-2xl border border-white/60 bg-white/70 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80">
-                  Idéal pour
-                </p>
+                <EditableText
+                  value={displayContent.heroIdealForTitle}
+                  onChange={handleStringChange("heroIdealForTitle")}
+                  as="p"
+                  className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/80"
+                />
                 <ul className="mt-3 space-y-2 text-sm text-[color:var(--brand-charcoal)]">
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--brand-red)]" aria-hidden="true" />
-                    Centres de formation collégiale
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--brand-red)]" aria-hidden="true" />
-                    Services pédagogiques universitaires
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <span className="mt-1 h-2 w-2 rounded-full bg-[color:var(--brand-red)]" aria-hidden="true" />
-                    Équipes innovation et transformation numérique
-                  </li>
+                  {displayContent.heroIdealForItems.map((item, index) => (
+                    <li key={`ideal-${index}`} className="flex items-start gap-2">
+                      <span
+                        className="mt-1 h-2 w-2 rounded-full bg-[color:var(--brand-red)]"
+                        aria-hidden="true"
+                      />
+                      {isEditMode ? (
+                        <input
+                          type="text"
+                          value={draft.heroIdealForItems[index]}
+                          onChange={(event) =>
+                            handleIdealForChange(index, event.target.value)
+                          }
+                          className="w-full rounded border border-orange-300 bg-white/90 px-2 py-1 text-sm focus:border-orange-500 focus:outline-none"
+                        />
+                      ) : (
+                        <span>{item}</span>
+                      )}
+                    </li>
+                  ))}
                 </ul>
               </div>
             </div>
           </section>
 
-          <section
-            id="activites"
-            className="page-section landing-panel space-y-8 bg-white/90"
-          >
+          <section id="activites" className="page-section landing-panel space-y-8 bg-white/90">
             <div className="space-y-3">
-              <span className="brand-chip bg-[color:var(--brand-black)] text-white">
-                Parcours immersifs
-              </span>
-              <h2 className="text-3xl font-semibold leading-tight">
-                Des expériences prêtes à l'emploi pour apprivoiser l'IA en classe.
-              </h2>
-              <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                Chaque activité propose une narration, des exemples annotés et des espaces d'analyse afin de faire émerger la stratégie numérique propre à votre établissement.
-              </p>
+              <EditableText
+                value={displayContent.experiencesEyebrow}
+                onChange={handleStringChange("experiencesEyebrow")}
+                as="span"
+                className="brand-chip bg-[color:var(--brand-black)] text-white"
+              />
+              <EditableText
+                value={displayContent.experiencesTitle}
+                onChange={handleStringChange("experiencesTitle")}
+                as="h2"
+                className="text-3xl font-semibold leading-tight"
+              />
+              <EditableText
+                value={displayContent.experiencesDescription}
+                onChange={handleStringChange("experiencesDescription")}
+                as="p"
+                multiline
+                rows={4}
+                className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]"
+              />
             </div>
             <div className="grid gap-4 md:grid-cols-3">
-              {featureCards.map((card) => (
+              {displayContent.experiencesCards.map((card, index) => (
                 <article
-                  key={card.title}
+                  key={`experience-card-${index}`}
                   className="flex h-full flex-col gap-3 rounded-3xl border border-white/80 bg-white/80 p-6 shadow-sm"
                 >
-                  <h3 className="text-xl font-semibold leading-snug">
-                    {card.title}
-                  </h3>
-                  <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                    {card.description}
-                  </p>
+                  <EditableText
+                    value={card.title}
+                    onChange={(value) =>
+                      handleHighlightChange("experiencesCards", index, "title", value)
+                    }
+                    as="h3"
+                    className="text-xl font-semibold leading-snug"
+                  />
+                  <EditableText
+                    value={card.description}
+                    onChange={(value) =>
+                      handleHighlightChange("experiencesCards", index, "description", value)
+                    }
+                    as="p"
+                    multiline
+                    rows={4}
+                    className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]"
+                  />
                   <div className="mt-auto flex items-center gap-2 text-sm font-semibold text-[color:var(--brand-red)]">
-                    <span aria-hidden="true">→</span> Disponible dans le catalogue
+                    <span aria-hidden="true">→</span>
+                    {isEditMode ? (
+                      <input
+                        type="text"
+                        value={draft.experiencesCardCtaLabel}
+                        onChange={(event) =>
+                          handleStringChange("experiencesCardCtaLabel")(event.target.value)
+                        }
+                        className="w-full rounded border border-orange-300 bg-white/90 px-2 py-1 focus:border-orange-500 focus:outline-none"
+                      />
+                    ) : (
+                      displayContent.experiencesCardCtaLabel
+                    )}
                   </div>
                 </article>
               ))}
             </div>
           </section>
 
-          <section
-            id="integrations"
-            className="page-section landing-panel space-y-8 bg-white/95"
-          >
+          <section id="integrations" className="page-section landing-panel space-y-8 bg-white/95">
             <div className="space-y-3">
-              <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-                Intégrations Moodle
-              </span>
-              <h2 className="text-3xl font-semibold leading-tight">
-                Connectez Formation IA à votre écosystème numérique en toute confiance.
-              </h2>
-              <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                LTI Advantage 1.3 assure l'authentification, le Deep Linking facilite la distribution et les webhooks permettent de suivre l'engagement. Aucun compte supplémentaire à créer pour vos communautés éducatives.
-              </p>
+              <EditableText
+                value={displayContent.integrationsEyebrow}
+                onChange={handleStringChange("integrationsEyebrow")}
+                as="span"
+                className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]"
+              />
+              <EditableText
+                value={displayContent.integrationsTitle}
+                onChange={handleStringChange("integrationsTitle")}
+                as="h2"
+                className="text-3xl font-semibold leading-tight"
+              />
+              <EditableText
+                value={displayContent.integrationsDescription}
+                onChange={handleStringChange("integrationsDescription")}
+                as="p"
+                multiline
+                rows={4}
+                className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]"
+              />
             </div>
             <div className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
               <div className="grid gap-4 md:grid-cols-2">
-                {integrationHighlights.map((item) => (
+                {displayContent.integrationHighlights.map((item, index) => (
                   <div
-                    key={item.title}
+                    key={`integration-${index}`}
                     className="rounded-3xl border border-white/80 bg-white/80 p-6 shadow-sm"
                   >
-                    <h3 className="text-lg font-semibold leading-snug text-[color:var(--brand-black)]">
-                      {item.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                      {item.description}
-                    </p>
+                    <EditableText
+                      value={item.title}
+                      onChange={(value) =>
+                        handleHighlightChange("integrationHighlights", index, "title", value)
+                      }
+                      as="h3"
+                      className="text-lg font-semibold leading-snug text-[color:var(--brand-black)]"
+                    />
+                    <EditableText
+                      value={item.description}
+                      onChange={(value) =>
+                        handleHighlightChange("integrationHighlights", index, "description", value)
+                      }
+                      as="p"
+                      multiline
+                      rows={4}
+                      className="mt-2 text-sm leading-relaxed text-[color:var(--brand-charcoal)]"
+                    />
                   </div>
                 ))}
               </div>
               <div className="flex flex-col gap-4 rounded-3xl border border-white/80 bg-white/70 p-6 shadow-sm">
-                <h3 className="text-lg font-semibold leading-snug text-[color:var(--brand-black)]">
-                  Comment démarrer ?
-                </h3>
+                <EditableText
+                  value={displayContent.onboardingTitle}
+                  onChange={handleStringChange("onboardingTitle")}
+                  as="h3"
+                  className="text-lg font-semibold leading-snug text-[color:var(--brand-black)]"
+                />
                 <ol className="space-y-3 text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                  {onboardingSteps.map((step, index) => (
-                    <li key={step.title} className="flex gap-3">
+                  {displayContent.onboardingSteps.map((step, index) => (
+                    <li key={`onboarding-${index}`} className="flex gap-3">
                       <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[color:var(--brand-red)]/10 text-sm font-semibold text-[color:var(--brand-red)]">
                         {index + 1}
                       </span>
-                      <div>
-                        <p className="font-semibold text-[color:var(--brand-black)]">
-                          {step.title}
-                        </p>
-                        <p className="text-[color:var(--brand-charcoal)]/80">
-                          {step.description}
-                        </p>
+                      <div className="space-y-1">
+                        <EditableText
+                          value={step.title}
+                          onChange={(value) =>
+                            handleOnboardingStepChange(index, "title", value)
+                          }
+                          as="p"
+                          className="font-semibold text-[color:var(--brand-black)]"
+                        />
+                        <EditableText
+                          value={step.description}
+                          onChange={(value) =>
+                            handleOnboardingStepChange(index, "description", value)
+                          }
+                          as="p"
+                          multiline
+                          rows={3}
+                          className="text-[color:var(--brand-charcoal)]/80"
+                        />
                       </div>
                     </li>
                   ))}
                 </ol>
-                <Link to="/connexion" className="cta-button cta-button--primary">
-                  Activer l'authentification LTI
-                </Link>
+                <EditableButton
+                  label={displayContent.onboardingCtaLabel}
+                  onChange={handleStringChange("onboardingCtaLabel")}
+                  variant="primary"
+                  to="/connexion"
+                />
               </div>
             </div>
           </section>
 
           <section className="page-section landing-panel space-y-6 bg-white/90">
             <div className="flex flex-col gap-4 text-center">
-              <h2 className="text-3xl font-semibold leading-tight">
-                Prêts à faire rayonner l'innovation pédagogique ?
-              </h2>
-              <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)] md:text-base">
-                Les équipes Formation IA vous accompagnent pour paramétrer votre première cohorte, adapter les parcours à votre discipline et partager les meilleures pratiques issues de la communauté.
-              </p>
+              <EditableText
+                value={displayContent.closingTitle}
+                onChange={handleStringChange("closingTitle")}
+                as="h2"
+                className="text-3xl font-semibold leading-tight"
+              />
+              <EditableText
+                value={displayContent.closingDescription}
+                onChange={handleStringChange("closingDescription")}
+                as="p"
+                multiline
+                rows={4}
+                className="text-sm leading-relaxed text-[color:var(--brand-charcoal)] md:text-base"
+              />
               <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-                <Link to="/activites" className="cta-button cta-button--primary">
-                  Découvrir le catalogue complet
-                </Link>
-                <a
+                <EditableButton
+                  label={displayContent.closingPrimaryCtaLabel}
+                  onChange={handleStringChange("closingPrimaryCtaLabel")}
+                  variant="primary"
+                  to="/activites"
+                />
+                <EditableButton
+                  label={displayContent.closingSecondaryCtaLabel}
+                  onChange={handleStringChange("closingSecondaryCtaLabel")}
+                  variant="light"
                   href="mailto:innovation@cegeplimoilou.ca"
-                  className="cta-button cta-button--light"
-                >
-                  Contacter l'équipe
-                </a>
+                />
               </div>
             </div>
           </section>
         </main>
 
         <footer className="flex flex-col items-center gap-2 text-center text-xs text-[color:var(--brand-charcoal)]/80 md:flex-row md:justify-between">
-          <p>© {new Date().getFullYear()} Formation IA – Cégep Limoilou.</p>
+          {isEditMode ? (
+            <div className="flex items-center gap-2">
+              <span>© {currentYear}</span>
+              <input
+                type="text"
+                value={draft.footerNote}
+                onChange={(event) => handleStringChange("footerNote")(event.target.value)}
+                className="w-full rounded border border-orange-300 bg-white/90 px-2 py-1 focus:border-orange-500 focus:outline-none"
+              />
+            </div>
+          ) : (
+            <p>© {currentYear} {displayContent.footerNote}</p>
+          )}
           <div className="flex flex-wrap justify-center gap-3">
-            <Link to="/activites" className="hover:text-[color:var(--brand-red)]">
-              Activités
-            </Link>
-            <Link to="/connexion" className="hover:text-[color:var(--brand-red)]">
-              Connexion
-            </Link>
-            <a href="#integrations" className="hover:text-[color:var(--brand-red)]">
-              LTI &amp; Deep Link
-            </a>
+            {isEditMode
+              ? draft.footerLinks.map((link, index) => (
+                  <div
+                    key={`footer-edit-${index}`}
+                    className="flex flex-col gap-1 rounded-lg border border-orange-200 bg-white/70 p-2"
+                  >
+                    <input
+                      type="text"
+                      value={link.label}
+                      onChange={(event) =>
+                        handleFooterLinkChange(index, "label", event.target.value)
+                      }
+                      className="rounded border border-orange-300 bg-white/90 px-2 py-1 text-xs focus:border-orange-500 focus:outline-none"
+                      placeholder="Libellé"
+                    />
+                    <input
+                      type="text"
+                      value={link.href}
+                      onChange={(event) =>
+                        handleFooterLinkChange(index, "href", event.target.value)
+                      }
+                      className="rounded border border-orange-300 bg-white/90 px-2 py-1 text-xs focus:border-orange-500 focus:outline-none"
+                      placeholder="Lien"
+                    />
+                  </div>
+                ))
+              : displayContent.footerLinks.map(renderFooterLink)}
           </div>
         </footer>
       </div>


### PR DESCRIPTION
## Summary
- introduce a landing page configuration store on the backend with defaults for the new autoportant activity builder messaging
- expose public and admin endpoints to load and save landing page content, and extend the frontend API client accordingly
- refactor the landing page to load content dynamically, support admin edit mode with inline inputs, and update copy to describe the AI-powered autoportant activity creator with LTI deep linking

## Testing
- npm run build *(fails: missing hls.js resolution in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c168d7588322ae336223f9516cfa