### PR TITLE
feat: add activity import/export and per-activity storage

### DIFF
--- a/backend/storage/activities/atelier.json
+++ b/backend/storage/activities/atelier.json
@@ -1,0 +1,68 @@
+{
+  "id": "atelier",
+  "componentKey": "step-sequence",
+  "path": "/atelier",
+  "completionId": "atelier",
+  "enabled": true,
+  "header": {
+    "eyebrow": "Atelier comparatif IA",
+    "title": "Cadrez, comparez, synthétisez vos essais IA",
+    "subtitle": "Suivez une progression claire pour préparer votre contexte, explorer deux profils IA en flux continu puis transformer les sorties en ressources réutilisables.",
+    "badge": "Trois étapes guidées"
+  },
+  "layout": {
+    "activityId": "atelier",
+    "headerClassName": "space-y-8",
+    "contentClassName": "space-y-12"
+  },
+  "card": {
+    "title": "Atelier comparatif IA",
+    "description": "Objectif : cadrer ta demande, comparer deux configurations IA et capitaliser sur les essais.",
+    "highlights": [
+      "Définir le contexte et les attentes",
+      "Tester modèle, verbosité et raisonnement",
+      "Assembler une synthèse réutilisable"
+    ],
+    "cta": {
+      "label": "Lancer l’atelier",
+      "to": "/atelier"
+    }
+  },
+  "stepSequence": [
+    {
+      "id": "workshop-prepare-context",
+      "type": "workshop-context",
+      "component": "workshop-context",
+      "config": {
+        "defaultText": "L'automatisation est particulièrement utile pour structurer des notes de cours, créer des rappels et générer des résumés ciblés. Les étudiantes et étudiants qui savent dialoguer avec l'IA peuvent obtenir des analyses précises, du survol rapide jusqu'à des synthèses détaillées. Comprendre comment ajuster les paramètres du modèle aide à mieux contrôler la production, à gagner du temps et à repérer les limites de l'outil."
+      }
+    },
+    {
+      "id": "workshop-compare-models",
+      "type": "workshop-comparison",
+      "component": "workshop-comparison",
+      "config": {
+        "contextStepId": "workshop-prepare-context",
+        "defaultConfigA": {
+          "model": "gpt-5-nano",
+          "verbosity": "medium",
+          "thinking": "minimal"
+        },
+        "defaultConfigB": {
+          "model": "gpt-5-mini",
+          "verbosity": "high",
+          "thinking": "high"
+        }
+      }
+    },
+    {
+      "id": "workshop-synthesis",
+      "type": "workshop-synthesis",
+      "component": "workshop-synthesis",
+      "config": {
+        "contextStepId": "workshop-prepare-context",
+        "comparisonStepId": "workshop-compare-models"
+      }
+    }
+  ]
+}

--- a/backend/storage/activities/clarity.json
+++ b/backend/storage/activities/clarity.json
@@ -1,0 +1,95 @@
+{
+  "id": "clarity",
+  "componentKey": "clarity-path",
+  "path": "/parcours-clarte",
+  "completionId": "clarity",
+  "enabled": true,
+  "header": {
+    "eyebrow": "Parcours de la clarté",
+    "title": "Guide le bonhomme avec une consigne limpide",
+    "subtitle": "Écris une instruction en langue naturelle. Le backend demande au modèle gpt-5-nano un plan complet, valide la trajectoire puis te montre l’exécution pas à pas.",
+    "badge": "Mode jeu"
+  },
+  "layout": {
+    "innerClassName": "relative",
+    "contentAs": "div",
+    "contentClassName": "gap-10"
+  },
+  "card": {
+    "title": "Parcours de la clarté",
+    "description": "Objectif : expérimenter la précision des consignes sur un parcours 10×10.",
+    "highlights": [
+      "Plan d’action IA généré avant l’animation",
+      "Visualisation pas à pas avec obstacles",
+      "Analyse des tentatives et du surcoût"
+    ],
+    "cta": {
+      "label": "Tester la clarté",
+      "to": "/parcours-clarte"
+    }
+  },
+  "stepSequence": [
+    {
+      "id": "clarity:introduction",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Écris une consigne limpide pour guider le personnage",
+        "body": "Observe la grille 10×10. Ta mission consiste à formuler une instruction assez claire pour que l’IA trace un trajet optimal sans se cogner aux obstacles. Utilise les étapes suivantes pour positionner la cible, visualiser un plan puis rédiger ta consigne finale.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Conseils express",
+          "tips": [
+            "Indique la direction et la distance plutôt que de vagues intentions.",
+            "Mentionne les obstacles importants afin d’éviter les collisions.",
+            "Utilise un vocabulaire simple : haut, bas, gauche, droite, nombre de cases."
+          ]
+        }
+      }
+    },
+    {
+      "id": "clarity:map",
+      "type": "clarity-map",
+      "component": "clarity-map",
+      "config": {
+        "obstacleCount": 6,
+        "initialTarget": { "x": 7, "y": 3 },
+        "promptStepId": "clarity:instruction",
+        "allowInstructionInput": true,
+        "instructionLabel": "Consigne transmise à l’IA",
+        "instructionPlaceholder": "Depuis le départ, avance de deux cases vers le bas, contourne l’obstacle par la droite puis remonte jusqu’à la cible…"
+      }
+    },
+    {
+      "id": "clarity:instruction",
+      "type": "clarity-prompt",
+      "component": "clarity-prompt",
+      "config": {
+        "promptLabel": "Rédige ta consigne finale",
+        "promptPlaceholder": "Exemple : ‘Depuis la case de départ, descends de trois cases, va deux cases à droite, monte de deux cases puis avance une case à droite pour atteindre la cible.’",
+        "model": "gpt-5-mini",
+        "verbosity": "medium",
+        "thinking": "medium",
+        "settingsMode": "read-only"
+      }
+    },
+    {
+      "id": "clarity:debrief",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Débrief et pistes d’amélioration",
+        "body": "Analyse les statistiques générées : nombre d’essais, surcoût de parcours et fidélité au plan. Si le personnage se bloque, identifie les zones ambiguës de ta consigne (direction manquante, distance imprécise, obstacle oublié). Réécris ensuite l’instruction et relance une exécution jusqu’à atteindre la cible sans détour.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Pour aller plus loin",
+          "tips": [
+            "Teste une version plus concise de ta consigne pour voir l’impact sur le plan.",
+            "Ajoute des contraintes bonus (ex : passer par une case particulière) et vérifie le comportement.",
+            "Compare deux consignes différentes dans l’atelier pour voir laquelle est la plus efficace."
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/storage/activities/clarte-dabord.json
+++ b/backend/storage/activities/clarte-dabord.json
@@ -1,0 +1,143 @@
+{
+  "id": "clarte-dabord",
+  "componentKey": "clarte-dabord",
+  "path": "/clarte-dabord",
+  "completionId": "clarte-dabord",
+  "enabled": true,
+  "header": {
+    "eyebrow": "Clarté d'abord !",
+    "title": "Identifie ce qu'il fallait dire dès la première consigne",
+    "subtitle": "Tu joues l'IA : l'usager précise son besoin manche après manche. Observe ce qui manquait au brief initial et retiens la checklist idéale.",
+    "badge": "Trois manches guidées"
+  },
+  "layout": {
+    "contentAs": "div",
+    "contentClassName": "gap-10"
+  },
+  "card": {
+    "title": "Clarté d’abord !",
+    "description": "Objectif : mesurer l’impact d’un brief incomplet et révéler la checklist idéale.",
+    "highlights": [
+      "Deux missions thématiques en trois manches",
+      "Champs guidés avec validations pédagogiques",
+      "Révélation finale et export JSON du menu"
+    ],
+    "cta": {
+      "label": "Lancer Clarté d’abord !",
+      "to": "/clarte-dabord"
+    }
+  },
+  "stepSequence": [
+    {
+      "id": "clarte-dabord:introduction",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Clarifie la demande dès la première manche",
+        "body": "Tu joues l’IA : l’usager formule une requête incomplète pour préparer un menu étudiant. Trois manches successives apportent des précisions. Ton objectif est d’améliorer ta réponse à chaque étape tout en notant ce qu’il aurait fallu demander dès le départ.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Approche recommandée",
+          "tips": [
+            "Repère les informations manquantes dès la première manche.",
+            "Structure tes réponses dans les tableaux proposés pour éviter les oublis.",
+            "À la fin, rédige ta checklist idéale pour guider l’usager la prochaine fois."
+          ]
+        }
+      }
+    },
+    {
+      "id": "clarte-dabord:stage-1",
+      "type": "form",
+      "component": "form",
+      "config": {
+        "submitLabel": "Valider la manche 1",
+        "allowEmpty": false,
+        "fields": [
+          {
+            "id": "menu_jour1_idees",
+            "label": "Jour 1 — Idées de plats (1–3 puces)",
+            "type": "bulleted_list",
+            "minBullets": 1,
+            "maxBullets": 3,
+            "maxWordsPerBullet": 6,
+            "mustContainAny": ["pain", "pâtes", "tomates", "pommes", "lait", "poulet"]
+          },
+          {
+            "id": "menu_jour2_idees",
+            "label": "Jour 2 — Idées de plats (1–3 puces)",
+            "type": "bulleted_list",
+            "minBullets": 1,
+            "maxBullets": 3,
+            "maxWordsPerBullet": 6,
+            "mustContainAny": ["pain", "pâtes", "tomates", "pommes", "lait", "poulet"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "clarte-dabord:stage-2",
+      "type": "form",
+      "component": "form",
+      "config": {
+        "submitLabel": "Valider la manche 2",
+        "allowEmpty": false,
+        "fields": [
+          {
+            "id": "menu_jour1_table",
+            "label": "Jour 1 — 3 repas (plat uniquement)",
+            "type": "table_menu_day",
+            "meals": ["Déjeuner", "Dîner", "Souper"]
+          },
+          {
+            "id": "menu_jour2_table",
+            "label": "Jour 2 — 3 repas (plat uniquement)",
+            "type": "table_menu_day",
+            "meals": ["Déjeuner", "Dîner", "Souper"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "clarte-dabord:stage-3",
+      "type": "form",
+      "component": "form",
+      "config": {
+        "submitLabel": "Valider la manche 3",
+        "allowEmpty": false,
+        "fields": [
+          {
+            "id": "menu_jour1_complet",
+            "label": "Jour 1 — plat / boisson / dessert",
+            "type": "table_menu_full",
+            "meals": ["Déjeuner", "Dîner", "Souper"]
+          },
+          {
+            "id": "menu_jour2_complet",
+            "label": "Jour 2 — plat / boisson / dessert",
+            "type": "table_menu_full",
+            "meals": ["Déjeuner", "Dîner", "Souper"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "clarte-dabord:debrief",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Révèle la checklist idéale",
+        "body": "Ce qui aurait dû être demandé dès le départ :\n- Crée un menu complet de 2 jours.\n- Chaque jour doit comporter 3 repas : déjeuner, dîner, souper.\n- Chaque repas doit inclure un plat, une boisson et un dessert.\n- Utilise uniquement les aliments listés : pain, pâtes, tomates, pommes, lait, poulet.\n- Présente le tout en JSON structuré : jour → repas → {plat, boisson, dessert}.",
+        "sidebar": {
+          "type": "tips",
+          "title": "À retenir",
+          "tips": [
+            "Une bonne consigne précise le format (ici : tableau JSON structuré).",
+            "Mentionne les contraintes incontournables (ingrédients, nombre de repas, éléments à inclure).",
+            "Teste ta checklist sur un autre scénario pour vérifier qu’elle fonctionne vraiment."
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/storage/activities/explorateur-ia.json
+++ b/backend/storage/activities/explorateur-ia.json
@@ -1,80 +1,975 @@
 {
-  "id": "explorateur-ia",
-  "componentKey": "explorateur-ia",
-  "path": "/explorateur-ia",
-  "completionId": "explorateur-ia",
-  "enabled": true,
-  "header": {
-    "eyebrow": "Activité 5",
-    "title": "L’Explorateur IA",
-    "subtitle": "Parcours une mini-ville façon Game Boy pour valider quatre compétences IA sans jamais taper au clavier.",
-    "badge": "Ville interactive"
-  },
-  "layout": {
-    "outerClassName": "flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden px-0 pt-0 pb-0",
-    "innerClassName": "flex h-full min-h-0 flex-1 w-full max-w-none gap-0",
-    "headerClassName": "hidden",
-    "contentClassName": "flex h-full min-h-0 flex-1 flex-col space-y-0",
-    "withLandingGradient": false,
-    "useDynamicViewportHeight": true,
-    "withBasePadding": false,
-    "withBaseContentSpacing": false,
-    "withBaseInnerGap": false
-  },
-  "card": {
-    "title": "L’Explorateur IA",
-    "description": "Objectif : compléter un parcours ludique mêlant quiz, drag-and-drop, décisions et dilemmes éthiques.",
-    "highlights": [
-      "Déplacements façon jeu vidéo et interactions à la souris",
-      "Quatre mini-activités pédagogiques sans saisie de texte",
-      "Export JSON immédiat et impression PDF du bilan"
-    ],
-    "cta": {
-      "label": "Entrer dans la ville",
-      "to": "/explorateur-ia"
-    }
-  },
-  "stepSequence": [
-    {
-      "id": "explorateur:introduction",
-      "type": "rich-content",
-      "component": "rich-content",
-      "config": {
-        "title": "Prépare ton exploration pixelisée",
-        "body": "Bienvenue dans Tiny Town, une mini-ville en pixel art où chaque quartier correspond à une compétence IA.\n\n• Déplace-toi avec les flèches du clavier ou les touches WASD. Sur mobile, utilise le joystick flottant.\n• Clique sur un bâtiment pour lancer la mission associée et suis les consignes à l'écran.\n• Termine les quatre quartiers thématiques pour débloquer la mairie et valider ton parcours.",
-        "sidebar": {
-          "type": "tips",
-          "title": "Astuces de navigation",
-          "tips": [
-            "Observe les couleurs des bâtiments : elles rappellent la compétence évaluée.",
-            "Rouvre un quartier quand tu veux pour compléter un objectif manquant.",
-            "L’inventaire en haut à droite conserve tes objets de mission."
-          ]
-        }
-      }
+    "id": "explorateur-ia",
+    "componentKey": "explorateur-ia",
+    "path": "/explorateur-ia",
+    "completionId": "explorateur-ia",
+    "enabled": true,
+    "header": {
+        "eyebrow": "Activit\u00e9 5",
+        "title": "L\u2019Explorateur IA",
+        "subtitle": "Parcours une mini-ville fa\u00e7on Game Boy pour valider quatre comp\u00e9tences IA sans jamais taper au clavier.",
+        "badge": "Ville interactive"
     },
-    {
-      "id": "explorateur:world",
-      "type": "explorateur-world",
-      "component": "explorateur-world"
+    "layout": {
+        "outerClassName": "flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden px-0 pt-0 pb-0",
+        "innerClassName": "flex h-full min-h-0 flex-1 w-full max-w-none gap-0",
+        "headerClassName": "hidden",
+        "contentClassName": "flex h-full min-h-0 flex-1 flex-col space-y-0",
+        "withLandingGradient": false,
+        "useDynamicViewportHeight": true,
+        "withBasePadding": false,
+        "withBaseContentSpacing": false,
+        "withBaseInnerGap": false
     },
-    {
-      "id": "explorateur:debrief",
-      "type": "rich-content",
-      "component": "rich-content",
-      "config": {
-        "title": "Capture ton bilan d’explorateur ou d’exploratrice",
-        "body": "Bravo pour cette exploration !\n\nDepuis la ville, ouvre la mairie pour afficher ta carte de compétences. Utilise les boutons JSON et PDF pour exporter ton rapport, l’ajouter à ton portfolio ou le partager avec ton équipe.\n\nTu peux revenir dans n’importe quel quartier pour améliorer un score ou récolter les idées à transformer en prompts.",
-        "sidebar": {
-          "type": "tips",
-          "title": "Et après ?",
-          "tips": [
-            "Note trois apprentissages clés dans ton portfolio.",
-            "Transforme les meilleures stratégies en consignes prêtes à réutiliser.",
-            "Anime un atelier en montrant comment tu as débloqué la mairie."
-          ]
+    "card": {
+        "title": "L\u2019Explorateur IA",
+        "description": "Objectif : compl\u00e9ter un parcours ludique m\u00ealant quiz, drag-and-drop, d\u00e9cisions et dilemmes \u00e9thiques.",
+        "highlights": [
+            "D\u00e9placements fa\u00e7on jeu vid\u00e9o et interactions \u00e0 la souris",
+            "Quatre mini-activit\u00e9s p\u00e9dagogiques sans saisie de texte",
+            "Export JSON imm\u00e9diat et impression PDF du bilan"
+        ],
+        "cta": {
+            "label": "Entrer dans la ville",
+            "to": "/explorateur-ia"
         }
-      }
-    }
-  ]
+    },
+    "stepSequence": [
+        {
+            "id": "explorateur:introduction",
+            "type": "rich-content",
+            "component": "rich-content",
+            "config": {
+                "title": "Pr\u00e9pare ton exploration pixelis\u00e9e",
+                "body": "Bienvenue dans Tiny Town, une mini-ville en pixel art o\u00f9 chaque quartier correspond \u00e0 une comp\u00e9tence IA.\n\n\u2022 D\u00e9place-toi avec les fl\u00e8ches du clavier ou les touches WASD. Sur mobile, utilise le joystick flottant.\n\u2022 Clique sur un b\u00e2timent pour lancer la mission associ\u00e9e et suis les consignes \u00e0 l'\u00e9cran.\n\u2022 Termine les quatre quartiers th\u00e9matiques pour d\u00e9bloquer la mairie et valider ton parcours.",
+                "sidebar": {
+                    "type": "tips",
+                    "title": "Astuces de navigation",
+                    "tips": [
+                        "Observe les couleurs des b\u00e2timents : elles rappellent la comp\u00e9tence \u00e9valu\u00e9e.",
+                        "Rouvre un quartier quand tu veux pour compl\u00e9ter un objectif manquant.",
+                        "L\u2019inventaire en haut \u00e0 droite conserve tes objets de mission."
+                    ]
+                }
+            }
+        },
+        {
+            "id": "explorateur:world",
+            "type": "explorateur-world",
+            "component": "explorateur-world",
+            "config": {
+                "terrain": {
+                    "themeId": "sand",
+                    "seed": 1247
+                },
+                "steps": [
+                    {
+                        "id": "clarte:intro",
+                        "type": "rich-content",
+                        "component": "rich-content",
+                        "config": {
+                            "title": "Bienvenue au quartier Clart\u00e9",
+                            "body": "Explorez ce qui rend une consigne pr\u00e9cise et actionnable avant de tester vos choix.",
+                            "sidebar": {
+                                "type": "tips",
+                                "title": "Checklist clart\u00e9",
+                                "tips": [
+                                    "Pr\u00e9ciser le r\u00e9sultat attendu",
+                                    "Indiquer le format et la longueur",
+                                    "Contextualiser pour le public cible"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "id": "clarte:video",
+                        "type": "video",
+                        "component": "video",
+                        "config": {
+                            "sources": [
+                                {
+                                    "type": "mp4",
+                                    "url": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+                                }
+                            ],
+                            "expectedDuration": 45,
+                            "autoAdvanceOnEnd": false,
+                            "poster": "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=800&q=80"
+                        }
+                    },
+                    {
+                        "id": "clarte:quiz",
+                        "type": "custom",
+                        "component": "custom",
+                        "config": {
+                            "type": "clarte-quiz",
+                            "title": "Choisissez la consigne la plus claire",
+                            "question": "Quel est le meilleur \u00e9nonc\u00e9 pour obtenir un plan clair?",
+                            "options": [
+                                {
+                                    "id": "A",
+                                    "label": "\u00c9cris un plan.",
+                                    "explanation": "Trop vague : objectifs, sections, longueur\u2026 manquent.",
+                                    "score": 0
+                                },
+                                {
+                                    "id": "B",
+                                    "label": "Donne un plan en 5 sections sur l'\u00e9nergie solaire pour d\u00e9butants, avec titres et 2 sous-points chacun.",
+                                    "explanation": "Pr\u00e9cis, contraint et adapt\u00e9 au public cible.",
+                                    "score": 100
+                                },
+                                {
+                                    "id": "C",
+                                    "label": "Plan \u00e9nergie solaire?",
+                                    "explanation": "Formulation t\u00e9l\u00e9graphique, ambigu\u00eb.",
+                                    "score": 10
+                                }
+                            ],
+                            "validateLabel": "Valider"
+                        }
+                    },
+                    {
+                        "id": "creation:intro",
+                        "type": "rich-content",
+                        "component": "rich-content",
+                        "config": {
+                            "title": "Quartier Cr\u00e9ation",
+                            "body": "Assemblez une consigne sur-mesure en combinant action, m\u00e9dia, style et th\u00e8me.",
+                            "sidebar": {
+                                "type": "checklist",
+                                "title": "\u00c9tapes",
+                                "items": [
+                                    {
+                                        "id": "select-action",
+                                        "label": "S\u00e9lectionner un verbe d'action",
+                                        "checked": false
+                                    },
+                                    {
+                                        "id": "select-media",
+                                        "label": "Choisir un m\u00e9dia adapt\u00e9",
+                                        "checked": false
+                                    },
+                                    {
+                                        "id": "select-style",
+                                        "label": "D\u00e9finir le ton et le style",
+                                        "checked": false
+                                    },
+                                    {
+                                        "id": "select-theme",
+                                        "label": "Associer un th\u00e8me",
+                                        "checked": false
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "id": "creation:builder",
+                        "type": "custom",
+                        "component": "custom",
+                        "config": {
+                            "type": "creation-builder",
+                            "title": "Assemblez votre d\u00e9fi de cr\u00e9ation",
+                            "instructions": "Choisissez un verbe d'action, un m\u00e9dia, un style et un th\u00e8me pour g\u00e9n\u00e9rer une consigne personnalis\u00e9e.",
+                            "pools": {
+                                "action": [
+                                    "cr\u00e9er",
+                                    "r\u00e9diger",
+                                    "composer"
+                                ],
+                                "media": [
+                                    "affiche",
+                                    "article",
+                                    "capsule audio"
+                                ],
+                                "style": [
+                                    "cartoon",
+                                    "acad\u00e9mique",
+                                    "minimaliste"
+                                ],
+                                "theme": [
+                                    "\u00e9nergie",
+                                    "ville intelligente",
+                                    "biodiversit\u00e9"
+                                ]
+                            },
+                            "submitLabel": "Valider ma consigne"
+                        }
+                    },
+                    {
+                        "id": "creation:reflection",
+                        "type": "form",
+                        "component": "form",
+                        "config": {
+                            "submitLabel": "Enregistrer ma synth\u00e8se",
+                            "fields": [
+                                {
+                                    "id": "audience",
+                                    "label": "D\u00e9crivez le public cible",
+                                    "type": "textarea_with_counter",
+                                    "minWords": 10,
+                                    "maxWords": 80
+                                },
+                                {
+                                    "id": "outcome",
+                                    "label": "Quels livrables attendez-vous ?",
+                                    "type": "bulleted_list",
+                                    "minBullets": 2,
+                                    "maxBullets": 4,
+                                    "maxWordsPerBullet": 12
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "decision:intro",
+                        "type": "rich-content",
+                        "component": "rich-content",
+                        "config": {
+                            "title": "Quartier D\u00e9cision",
+                            "body": "Exp\u00e9rimentez diff\u00e9rentes strat\u00e9gies et observez leurs compromis pour mener votre projet."
+                        }
+                    },
+                    {
+                        "id": "decision:path",
+                        "type": "custom",
+                        "component": "custom",
+                        "config": {
+                            "type": "decision-path",
+                            "title": "Tracez votre parcours de d\u00e9cision",
+                            "introduction": "Chaque choix r\u00e9v\u00e8le des compromis diff\u00e9rents. Exp\u00e9rimentez plusieurs trajectoires pour comparer les impacts.",
+                            "steps": [
+                                {
+                                    "id": "announce",
+                                    "prompt": "Votre \u00e9quipe doit annoncer un nouveau projet. Quelle strat\u00e9gie choisissez-vous ?",
+                                    "options": [
+                                        {
+                                            "id": "A",
+                                            "title": "Annonce rapide",
+                                            "impact": "+ vitesse / \u2013 profondeur",
+                                            "next": "follow-up"
+                                        },
+                                        {
+                                            "id": "B",
+                                            "title": "Annonce \u00e9quilibr\u00e9e",
+                                            "impact": "+ clart\u00e9 / \u2013 temps",
+                                            "next": "follow-up"
+                                        },
+                                        {
+                                            "id": "C",
+                                            "title": "Annonce personnalis\u00e9e",
+                                            "impact": "+ pertinence / \u2013 effort",
+                                            "next": "follow-up"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "follow-up",
+                                    "prompt": "Le public r\u00e9agit vivement. Quelle action de suivi priorisez-vous ?",
+                                    "options": [
+                                        {
+                                            "id": "A",
+                                            "title": "FAQ automatis\u00e9e",
+                                            "impact": "+ \u00e9chelle / \u2013 nuance",
+                                            "next": null
+                                        },
+                                        {
+                                            "id": "B",
+                                            "title": "Atelier interactif",
+                                            "impact": "+ engagement / \u2013 logistique",
+                                            "next": null
+                                        },
+                                        {
+                                            "id": "C",
+                                            "title": "Messages cibl\u00e9s",
+                                            "impact": "+ efficacit\u00e9 / \u2013 donn\u00e9es",
+                                            "next": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "ethique:intro",
+                        "type": "rich-content",
+                        "component": "rich-content",
+                        "config": {
+                            "title": "Quartier \u00c9thique",
+                            "body": "Chaque sc\u00e9nario illustre une d\u00e9rive potentielle. S\u00e9lectionnez la r\u00e9ponse qui prot\u00e8ge au mieux les usagers."
+                        }
+                    },
+                    {
+                        "id": "ethique:dilemmas",
+                        "type": "custom",
+                        "component": "custom",
+                        "config": {
+                            "type": "ethics-dilemmas",
+                            "title": "R\u00e9agissez \u00e0 des dilemmes \u00e9thiques",
+                            "introduction": "Choisissez la meilleure r\u00e9ponse pour limiter les d\u00e9rives et renforcer la responsabilit\u00e9.",
+                            "dilemmas": [
+                                {
+                                    "id": "bias",
+                                    "scenario": "Un outil g\u00e9n\u00e8re un r\u00e9sum\u00e9 contenant des st\u00e9r\u00e9otypes.",
+                                    "options": [
+                                        {
+                                            "id": "ignore",
+                                            "label": "Ignorer",
+                                            "feedback": "Risque d'amplifier le biais et de diffuser une erreur.",
+                                            "score": 0
+                                        },
+                                        {
+                                            "id": "correct",
+                                            "label": "Corriger et justifier",
+                                            "feedback": "Bonne pratique: signalez et corrigez les biais.",
+                                            "score": 100
+                                        },
+                                        {
+                                            "id": "question",
+                                            "label": "Demander des explications",
+                                            "feedback": "Utile, mais sans correction le risque demeure.",
+                                            "score": 60
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "sensitive",
+                                    "scenario": "Un mod\u00e8le r\u00e9v\u00e8le des donn\u00e9es sensibles dans un exemple.",
+                                    "options": [
+                                        {
+                                            "id": "ignore",
+                                            "label": "Ignorer",
+                                            "feedback": "Non conforme \u00e0 la protection des donn\u00e9es.",
+                                            "score": 0
+                                        },
+                                        {
+                                            "id": "remove",
+                                            "label": "Supprimer et anonymiser",
+                                            "feedback": "Conforme aux bonnes pratiques.",
+                                            "score": 100
+                                        },
+                                        {
+                                            "id": "ask",
+                                            "label": "Demander justification",
+                                            "feedback": "Insuffisant sans retrait imm\u00e9diat.",
+                                            "score": 40
+                                        }
+                                    ]
+                                }
+                            ],
+                            "concludeLabel": "Voir mon score"
+                        }
+                    },
+                    {
+                        "id": "ethique:commitment",
+                        "type": "form",
+                        "component": "form",
+                        "config": {
+                            "submitLabel": "Formuler mon engagement",
+                            "allowEmpty": false,
+                            "fields": [
+                                {
+                                    "id": "guardrail",
+                                    "label": "Quelles pratiques mettrez-vous en place pour limiter les biais ?",
+                                    "type": "two_bullets",
+                                    "maxWordsPerBullet": 16
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "mairie:intro",
+                        "type": "rich-content",
+                        "component": "rich-content",
+                        "config": {
+                            "title": "Mairie \u2014 Synth\u00e8se",
+                            "body": "Rassemblez vos apprentissages et pr\u00e9parez l'export de votre badge Explorateur IA."
+                        }
+                    },
+                    {
+                        "id": "mairie:feedback",
+                        "type": "form",
+                        "component": "form",
+                        "config": {
+                            "submitLabel": "Valider mon bilan",
+                            "allowEmpty": false,
+                            "fields": [
+                                {
+                                    "id": "takeaway",
+                                    "label": "Quelle pratique garderez-vous en priorit\u00e9 ?",
+                                    "type": "textarea_with_counter",
+                                    "minWords": 12,
+                                    "maxWords": 120
+                                },
+                                {
+                                    "id": "confidence",
+                                    "label": "Niveau de confiance actuel (0-100%)",
+                                    "type": "reference_line"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "quarterDesignerSteps": {
+                    "clarte": [
+                        {
+                            "id": "clarte:designer:basics",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-basics",
+                                "quarterId": "clarte",
+                                "label": "Quartier Clart\u00e9",
+                                "color": "#06d6a0",
+                                "buildingNumber": 1,
+                                "isGoal": false
+                            }
+                        },
+                        {
+                            "id": "clarte:intro",
+                            "type": "rich-content",
+                            "component": "rich-content",
+                            "config": {
+                                "title": "Bienvenue au quartier Clart\u00e9",
+                                "body": "Explorez ce qui rend une consigne pr\u00e9cise et actionnable avant de tester vos choix.",
+                                "sidebar": {
+                                    "type": "tips",
+                                    "title": "Checklist clart\u00e9",
+                                    "tips": [
+                                        "Pr\u00e9ciser le r\u00e9sultat attendu",
+                                        "Indiquer le format et la longueur",
+                                        "Contextualiser pour le public cible"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "id": "clarte:video",
+                            "type": "video",
+                            "component": "video",
+                            "config": {
+                                "sources": [
+                                    {
+                                        "type": "mp4",
+                                        "url": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+                                    }
+                                ],
+                                "expectedDuration": 45,
+                                "autoAdvanceOnEnd": false,
+                                "poster": "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=800&q=80"
+                            }
+                        },
+                        {
+                            "id": "clarte:quiz",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "clarte-quiz",
+                                "title": "Choisissez la consigne la plus claire",
+                                "question": "Quel est le meilleur \u00e9nonc\u00e9 pour obtenir un plan clair?",
+                                "options": [
+                                    {
+                                        "id": "A",
+                                        "label": "\u00c9cris un plan.",
+                                        "explanation": "Trop vague : objectifs, sections, longueur\u2026 manquent.",
+                                        "score": 0
+                                    },
+                                    {
+                                        "id": "B",
+                                        "label": "Donne un plan en 5 sections sur l'\u00e9nergie solaire pour d\u00e9butants, avec titres et 2 sous-points chacun.",
+                                        "explanation": "Pr\u00e9cis, contraint et adapt\u00e9 au public cible.",
+                                        "score": 100
+                                    },
+                                    {
+                                        "id": "C",
+                                        "label": "Plan \u00e9nergie solaire?",
+                                        "explanation": "Formulation t\u00e9l\u00e9graphique, ambigu\u00eb.",
+                                        "score": 10
+                                    }
+                                ],
+                                "validateLabel": "Valider"
+                            }
+                        },
+                        {
+                            "id": "clarte:designer:inventory",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-inventory",
+                                "quarterId": "clarte",
+                                "enabled": true,
+                                "title": "Boussole de clart\u00e9",
+                                "description": "Une boussole calibr\u00e9e pour pointer vers les consignes les plus limpides.",
+                                "hint": "R\u00e9ussissez le d\u00e9fi Clart\u00e9 pour l'ajouter \u00e0 votre sac.",
+                                "icon": "\ud83e\udded"
+                            }
+                        }
+                    ],
+                    "creation": [
+                        {
+                            "id": "creation:designer:basics",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-basics",
+                                "quarterId": "creation",
+                                "label": "Quartier Cr\u00e9ation",
+                                "color": "#118ab2",
+                                "buildingNumber": 2,
+                                "isGoal": false
+                            }
+                        },
+                        {
+                            "id": "creation:intro",
+                            "type": "rich-content",
+                            "component": "rich-content",
+                            "config": {
+                                "title": "Quartier Cr\u00e9ation",
+                                "body": "Assemblez une consigne sur-mesure en combinant action, m\u00e9dia, style et th\u00e8me.",
+                                "sidebar": {
+                                    "type": "checklist",
+                                    "title": "\u00c9tapes",
+                                    "items": [
+                                        {
+                                            "id": "select-action",
+                                            "label": "S\u00e9lectionner un verbe d'action",
+                                            "checked": false
+                                        },
+                                        {
+                                            "id": "select-media",
+                                            "label": "Choisir un m\u00e9dia adapt\u00e9",
+                                            "checked": false
+                                        },
+                                        {
+                                            "id": "select-style",
+                                            "label": "D\u00e9finir le ton et le style",
+                                            "checked": false
+                                        },
+                                        {
+                                            "id": "select-theme",
+                                            "label": "Associer un th\u00e8me",
+                                            "checked": false
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "id": "creation:builder",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "creation-builder",
+                                "title": "Assemblez votre d\u00e9fi de cr\u00e9ation",
+                                "instructions": "Choisissez un verbe d'action, un m\u00e9dia, un style et un th\u00e8me pour g\u00e9n\u00e9rer une consigne personnalis\u00e9e.",
+                                "pools": {
+                                    "action": [
+                                        "cr\u00e9er",
+                                        "r\u00e9diger",
+                                        "composer"
+                                    ],
+                                    "media": [
+                                        "affiche",
+                                        "article",
+                                        "capsule audio"
+                                    ],
+                                    "style": [
+                                        "cartoon",
+                                        "acad\u00e9mique",
+                                        "minimaliste"
+                                    ],
+                                    "theme": [
+                                        "\u00e9nergie",
+                                        "ville intelligente",
+                                        "biodiversit\u00e9"
+                                    ]
+                                },
+                                "submitLabel": "Valider ma consigne"
+                            }
+                        },
+                        {
+                            "id": "creation:reflection",
+                            "type": "form",
+                            "component": "form",
+                            "config": {
+                                "submitLabel": "Enregistrer ma synth\u00e8se",
+                                "fields": [
+                                    {
+                                        "id": "audience",
+                                        "label": "D\u00e9crivez le public cible",
+                                        "type": "textarea_with_counter",
+                                        "minWords": 10,
+                                        "maxWords": 80
+                                    },
+                                    {
+                                        "id": "outcome",
+                                        "label": "Quels livrables attendez-vous ?",
+                                        "type": "bulleted_list",
+                                        "minBullets": 2,
+                                        "maxBullets": 4,
+                                        "maxWordsPerBullet": 12
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "creation:designer:inventory",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-inventory",
+                                "quarterId": "creation",
+                                "enabled": true,
+                                "title": "Palette synth\u00e9tique",
+                                "description": "Un set modulable pour combiner styles, m\u00e9dias et tonalit\u00e9s \u00e0 la demande.",
+                                "hint": "Terminez le d\u00e9fi Cr\u00e9ation pour d\u00e9bloquer cet outil.",
+                                "icon": "\ud83c\udfa8"
+                            }
+                        }
+                    ],
+                    "decision": [
+                        {
+                            "id": "decision:designer:basics",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-basics",
+                                "quarterId": "decision",
+                                "label": "Quartier D\u00e9cision",
+                                "color": "#ef476f",
+                                "buildingNumber": 3,
+                                "isGoal": false
+                            }
+                        },
+                        {
+                            "id": "decision:intro",
+                            "type": "rich-content",
+                            "component": "rich-content",
+                            "config": {
+                                "title": "Quartier D\u00e9cision",
+                                "body": "Exp\u00e9rimentez diff\u00e9rentes strat\u00e9gies et observez leurs compromis pour mener votre projet."
+                            }
+                        },
+                        {
+                            "id": "decision:path",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "decision-path",
+                                "title": "Tracez votre parcours de d\u00e9cision",
+                                "introduction": "Chaque choix r\u00e9v\u00e8le des compromis diff\u00e9rents. Exp\u00e9rimentez plusieurs trajectoires pour comparer les impacts.",
+                                "steps": [
+                                    {
+                                        "id": "announce",
+                                        "prompt": "Votre \u00e9quipe doit annoncer un nouveau projet. Quelle strat\u00e9gie choisissez-vous ?",
+                                        "options": [
+                                            {
+                                                "id": "A",
+                                                "title": "Annonce rapide",
+                                                "impact": "+ vitesse / \u2013 profondeur",
+                                                "next": "follow-up"
+                                            },
+                                            {
+                                                "id": "B",
+                                                "title": "Annonce \u00e9quilibr\u00e9e",
+                                                "impact": "+ clart\u00e9 / \u2013 temps",
+                                                "next": "follow-up"
+                                            },
+                                            {
+                                                "id": "C",
+                                                "title": "Annonce personnalis\u00e9e",
+                                                "impact": "+ pertinence / \u2013 effort",
+                                                "next": "follow-up"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "follow-up",
+                                        "prompt": "Le public r\u00e9agit vivement. Quelle action de suivi priorisez-vous ?",
+                                        "options": [
+                                            {
+                                                "id": "A",
+                                                "title": "FAQ automatis\u00e9e",
+                                                "impact": "+ \u00e9chelle / \u2013 nuance",
+                                                "next": null
+                                            },
+                                            {
+                                                "id": "B",
+                                                "title": "Atelier interactif",
+                                                "impact": "+ engagement / \u2013 logistique",
+                                                "next": null
+                                            },
+                                            {
+                                                "id": "C",
+                                                "title": "Messages cibl\u00e9s",
+                                                "impact": "+ efficacit\u00e9 / \u2013 donn\u00e9es",
+                                                "next": null
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "decision:designer:inventory",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-inventory",
+                                "quarterId": "decision",
+                                "enabled": true,
+                                "title": "Balance d'arbitrage",
+                                "description": "Une balance portative qui r\u00e9v\u00e8le instantan\u00e9ment impacts et compromis.",
+                                "hint": "Gagnez le d\u00e9fi D\u00e9cision pour la remporter.",
+                                "icon": "\u2696\ufe0f"
+                            }
+                        }
+                    ],
+                    "ethique": [
+                        {
+                            "id": "ethique:designer:basics",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-basics",
+                                "quarterId": "ethique",
+                                "label": "Quartier \u00c9thique",
+                                "color": "#8338ec",
+                                "buildingNumber": 4,
+                                "isGoal": false
+                            }
+                        },
+                        {
+                            "id": "ethique:intro",
+                            "type": "rich-content",
+                            "component": "rich-content",
+                            "config": {
+                                "title": "Quartier \u00c9thique",
+                                "body": "Chaque sc\u00e9nario illustre une d\u00e9rive potentielle. S\u00e9lectionnez la r\u00e9ponse qui prot\u00e8ge au mieux les usagers."
+                            }
+                        },
+                        {
+                            "id": "ethique:dilemmas",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "ethics-dilemmas",
+                                "title": "R\u00e9agissez \u00e0 des dilemmes \u00e9thiques",
+                                "introduction": "Choisissez la meilleure r\u00e9ponse pour limiter les d\u00e9rives et renforcer la responsabilit\u00e9.",
+                                "dilemmas": [
+                                    {
+                                        "id": "bias",
+                                        "scenario": "Un outil g\u00e9n\u00e8re un r\u00e9sum\u00e9 contenant des st\u00e9r\u00e9otypes.",
+                                        "options": [
+                                            {
+                                                "id": "ignore",
+                                                "label": "Ignorer",
+                                                "feedback": "Risque d'amplifier le biais et de diffuser une erreur.",
+                                                "score": 0
+                                            },
+                                            {
+                                                "id": "correct",
+                                                "label": "Corriger et justifier",
+                                                "feedback": "Bonne pratique: signalez et corrigez les biais.",
+                                                "score": 100
+                                            },
+                                            {
+                                                "id": "question",
+                                                "label": "Demander des explications",
+                                                "feedback": "Utile, mais sans correction le risque demeure.",
+                                                "score": 60
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "sensitive",
+                                        "scenario": "Un mod\u00e8le r\u00e9v\u00e8le des donn\u00e9es sensibles dans un exemple.",
+                                        "options": [
+                                            {
+                                                "id": "ignore",
+                                                "label": "Ignorer",
+                                                "feedback": "Non conforme \u00e0 la protection des donn\u00e9es.",
+                                                "score": 0
+                                            },
+                                            {
+                                                "id": "remove",
+                                                "label": "Supprimer et anonymiser",
+                                                "feedback": "Conforme aux bonnes pratiques.",
+                                                "score": 100
+                                            },
+                                            {
+                                                "id": "ask",
+                                                "label": "Demander justification",
+                                                "feedback": "Insuffisant sans retrait imm\u00e9diat.",
+                                                "score": 40
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "concludeLabel": "Voir mon score"
+                            }
+                        },
+                        {
+                            "id": "ethique:commitment",
+                            "type": "form",
+                            "component": "form",
+                            "config": {
+                                "submitLabel": "Formuler mon engagement",
+                                "allowEmpty": false,
+                                "fields": [
+                                    {
+                                        "id": "guardrail",
+                                        "label": "Quelles pratiques mettrez-vous en place pour limiter les biais ?",
+                                        "type": "two_bullets",
+                                        "maxWordsPerBullet": 16
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "ethique:designer:inventory",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-inventory",
+                                "quarterId": "ethique",
+                                "enabled": true,
+                                "title": "Lanterne d\u00e9ontique",
+                                "description": "Une lanterne qui \u00e9claire les zones d'ombre pour garder le cap \u00e9thique.",
+                                "hint": "Relevez le d\u00e9fi \u00c9thique pour la r\u00e9cup\u00e9rer.",
+                                "icon": "\ud83d\udd6f\ufe0f"
+                            }
+                        }
+                    ],
+                    "mairie": [
+                        {
+                            "id": "mairie:designer:basics",
+                            "type": "custom",
+                            "component": "custom",
+                            "config": {
+                                "type": "explorateur-quarter-basics",
+                                "quarterId": "mairie",
+                                "label": "Mairie (Bilan)",
+                                "color": "#ffd166",
+                                "buildingNumber": null,
+                                "isGoal": true
+                            }
+                        },
+                        {
+                            "id": "mairie:intro",
+                            "type": "rich-content",
+                            "component": "rich-content",
+                            "config": {
+                                "title": "Mairie \u2014 Synth\u00e8se",
+                                "body": "Rassemblez vos apprentissages et pr\u00e9parez l'export de votre badge Explorateur IA."
+                            }
+                        },
+                        {
+                            "id": "mairie:feedback",
+                            "type": "form",
+                            "component": "form",
+                            "config": {
+                                "submitLabel": "Valider mon bilan",
+                                "allowEmpty": false,
+                                "fields": [
+                                    {
+                                        "id": "takeaway",
+                                        "label": "Quelle pratique garderez-vous en priorit\u00e9 ?",
+                                        "type": "textarea_with_counter",
+                                        "minWords": 12,
+                                        "maxWords": 120
+                                    },
+                                    {
+                                        "id": "confidence",
+                                        "label": "Niveau de confiance actuel (0-100%)",
+                                        "type": "reference_line"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "quarters": [
+                    {
+                        "id": "clarte",
+                        "label": "Quartier Clart\u00e9",
+                        "color": "#06d6a0",
+                        "buildingNumber": 1,
+                        "isGoal": false,
+                        "inventory": {
+                            "title": "Boussole de clart\u00e9",
+                            "description": "Une boussole calibr\u00e9e pour pointer vers les consignes les plus limpides.",
+                            "hint": "R\u00e9ussissez le d\u00e9fi Clart\u00e9 pour l'ajouter \u00e0 votre sac.",
+                            "icon": "\ud83e\udded"
+                        }
+                    },
+                    {
+                        "id": "creation",
+                        "label": "Quartier Cr\u00e9ation",
+                        "color": "#118ab2",
+                        "buildingNumber": 2,
+                        "isGoal": false,
+                        "inventory": {
+                            "title": "Palette synth\u00e9tique",
+                            "description": "Un set modulable pour combiner styles, m\u00e9dias et tonalit\u00e9s \u00e0 la demande.",
+                            "hint": "Terminez le d\u00e9fi Cr\u00e9ation pour d\u00e9bloquer cet outil.",
+                            "icon": "\ud83c\udfa8"
+                        }
+                    },
+                    {
+                        "id": "decision",
+                        "label": "Quartier D\u00e9cision",
+                        "color": "#ef476f",
+                        "buildingNumber": 3,
+                        "isGoal": false,
+                        "inventory": {
+                            "title": "Balance d'arbitrage",
+                            "description": "Une balance portative qui r\u00e9v\u00e8le instantan\u00e9ment impacts et compromis.",
+                            "hint": "Gagnez le d\u00e9fi D\u00e9cision pour la remporter.",
+                            "icon": "\u2696\ufe0f"
+                        }
+                    },
+                    {
+                        "id": "ethique",
+                        "label": "Quartier \u00c9thique",
+                        "color": "#8338ec",
+                        "buildingNumber": 4,
+                        "isGoal": false,
+                        "inventory": {
+                            "title": "Lanterne d\u00e9ontique",
+                            "description": "Une lanterne qui \u00e9claire les zones d'ombre pour garder le cap \u00e9thique.",
+                            "hint": "Relevez le d\u00e9fi \u00c9thique pour la r\u00e9cup\u00e9rer.",
+                            "icon": "\ud83d\udd6f\ufe0f"
+                        }
+                    },
+                    {
+                        "id": "mairie",
+                        "label": "Mairie (Bilan)",
+                        "color": "#ffd166",
+                        "buildingNumber": null,
+                        "isGoal": true,
+                        "inventory": null
+                    }
+                ]
+            }
+        },
+        {
+            "id": "explorateur:debrief",
+            "type": "rich-content",
+            "component": "rich-content",
+            "config": {
+                "title": "Capture ton bilan d\u2019explorateur ou d\u2019exploratrice",
+                "body": "Bravo pour cette exploration !\n\nDepuis la ville, ouvre la mairie pour afficher ta carte de comp\u00e9tences. Utilise les boutons JSON et PDF pour exporter ton rapport, l\u2019ajouter \u00e0 ton portfolio ou le partager avec ton \u00e9quipe.\n\nTu peux revenir dans n\u2019importe quel quartier pour am\u00e9liorer un score ou r\u00e9colter les id\u00e9es \u00e0 transformer en prompts.",
+                "sidebar": {
+                    "type": "tips",
+                    "title": "Et apr\u00e8s ?",
+                    "tips": [
+                        "Note trois apprentissages cl\u00e9s dans ton portfolio.",
+                        "Transforme les meilleures strat\u00e9gies en consignes pr\u00eates \u00e0 r\u00e9utiliser.",
+                        "Anime un atelier en montrant comment tu as d\u00e9bloqu\u00e9 la mairie."
+                    ]
+                }
+            }
+        }
+    ]
 }

--- a/backend/storage/activities/explorateur-ia.json
+++ b/backend/storage/activities/explorateur-ia.json
@@ -1,0 +1,80 @@
+{
+  "id": "explorateur-ia",
+  "componentKey": "explorateur-ia",
+  "path": "/explorateur-ia",
+  "completionId": "explorateur-ia",
+  "enabled": true,
+  "header": {
+    "eyebrow": "Activité 5",
+    "title": "L’Explorateur IA",
+    "subtitle": "Parcours une mini-ville façon Game Boy pour valider quatre compétences IA sans jamais taper au clavier.",
+    "badge": "Ville interactive"
+  },
+  "layout": {
+    "outerClassName": "flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden px-0 pt-0 pb-0",
+    "innerClassName": "flex h-full min-h-0 flex-1 w-full max-w-none gap-0",
+    "headerClassName": "hidden",
+    "contentClassName": "flex h-full min-h-0 flex-1 flex-col space-y-0",
+    "withLandingGradient": false,
+    "useDynamicViewportHeight": true,
+    "withBasePadding": false,
+    "withBaseContentSpacing": false,
+    "withBaseInnerGap": false
+  },
+  "card": {
+    "title": "L’Explorateur IA",
+    "description": "Objectif : compléter un parcours ludique mêlant quiz, drag-and-drop, décisions et dilemmes éthiques.",
+    "highlights": [
+      "Déplacements façon jeu vidéo et interactions à la souris",
+      "Quatre mini-activités pédagogiques sans saisie de texte",
+      "Export JSON immédiat et impression PDF du bilan"
+    ],
+    "cta": {
+      "label": "Entrer dans la ville",
+      "to": "/explorateur-ia"
+    }
+  },
+  "stepSequence": [
+    {
+      "id": "explorateur:introduction",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Prépare ton exploration pixelisée",
+        "body": "Bienvenue dans Tiny Town, une mini-ville en pixel art où chaque quartier correspond à une compétence IA.\n\n• Déplace-toi avec les flèches du clavier ou les touches WASD. Sur mobile, utilise le joystick flottant.\n• Clique sur un bâtiment pour lancer la mission associée et suis les consignes à l'écran.\n• Termine les quatre quartiers thématiques pour débloquer la mairie et valider ton parcours.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Astuces de navigation",
+          "tips": [
+            "Observe les couleurs des bâtiments : elles rappellent la compétence évaluée.",
+            "Rouvre un quartier quand tu veux pour compléter un objectif manquant.",
+            "L’inventaire en haut à droite conserve tes objets de mission."
+          ]
+        }
+      }
+    },
+    {
+      "id": "explorateur:world",
+      "type": "explorateur-world",
+      "component": "explorateur-world"
+    },
+    {
+      "id": "explorateur:debrief",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Capture ton bilan d’explorateur ou d’exploratrice",
+        "body": "Bravo pour cette exploration !\n\nDepuis la ville, ouvre la mairie pour afficher ta carte de compétences. Utilise les boutons JSON et PDF pour exporter ton rapport, l’ajouter à ton portfolio ou le partager avec ton équipe.\n\nTu peux revenir dans n’importe quel quartier pour améliorer un score ou récolter les idées à transformer en prompts.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Et après ?",
+          "tips": [
+            "Note trois apprentissages clés dans ton portfolio.",
+            "Transforme les meilleures stratégies en consignes prêtes à réutiliser.",
+            "Anime un atelier en montrant comment tu as débloqué la mairie."
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/storage/activities/prompt-dojo.json
+++ b/backend/storage/activities/prompt-dojo.json
@@ -1,0 +1,173 @@
+{
+  "id": "prompt-dojo",
+  "componentKey": "prompt-dojo",
+  "path": "/prompt-dojo",
+  "completionId": "prompt-dojo",
+  "enabled": true,
+  "header": {
+    "eyebrow": "Prompt Dojo",
+    "title": "Affûte ton prompt mission par mission",
+    "subtitle": "Choisis un défi parmi les missions et franchis les étapes pour décrocher ton badge en atteignant le score IA visé.",
+    "badge": "Mode entraînement"
+  },
+  "layout": {
+    "contentAs": "div",
+    "contentClassName": "gap-0"
+  },
+  "card": {
+    "title": "Prompt Dojo — Mission débutant",
+    "description": "Objectif : t’entraîner à affiner une consigne en suivant des défis progressifs.",
+    "highlights": [
+      "Défis à difficulté graduelle",
+      "Retour immédiat sur la qualité du prompt",
+      "Construction d’une version finale personnalisée"
+    ],
+    "cta": {
+      "label": "Entrer dans le dojo",
+      "to": "/prompt-dojo"
+    }
+  },
+  "stepSequence": [
+    {
+      "id": "prompt-dojo:introduction",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Affûte ta consigne mission par mission",
+        "body": "Chaque mission te plonge dans un contexte différent. Tu disposes d’un briefing, de points de contrôle et d’un score cible à atteindre. Parcours les cartes ci-dessous, choisis la mission qui te motive puis prépare ton brief dans la zone guidée avant d’évaluer ton prompt final.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Comment progresser ?",
+          "tips": [
+            "Observe les objectifs et contraintes propres à chaque mission.",
+            "Note les points à vérifier dans ton prompt avant l’évaluation IA.",
+            "Révise ton texte jusqu’à dépasser le score cible indiqué."
+          ]
+        }
+      }
+    },
+    {
+      "id": "prompt-dojo:missions",
+      "type": "info-cards",
+      "component": "info-cards",
+      "config": {
+        "eyebrow": "Sélectionne un défi",
+        "title": "Trois missions inspirées du Prompt Dojo",
+        "description": "Compare les badges et niveaux pour choisir le défi correspondant à ta maîtrise actuelle. Les cibles de score te donnent un repère pour itérer.",
+        "columns": 3,
+        "cards": [
+          {
+            "title": "🎯 Clarté Mission 1 · Atelier campus",
+            "description": "Préparer un atelier de révision pour aider la cohorte de Techniques de l’informatique à réussir l’intra.",
+            "tone": "sand",
+            "items": [
+              "Objectif : Construire un plan d’atelier d’une heure incluant une activité d’ouverture, un segment pratique et une conclusion claire.",
+              "Contexte : Tu es pair-aidant au centre d’aide. L’atelier aura lieu en fin de journée avec 18 collègues un peu fatigués.",
+              "Score cible : 75%"
+            ]
+          },
+          {
+            "title": "🧭 Adaptation Mission 2 · Résumé associatif",
+            "description": "Rédiger un résumé pour l’infolettre de l’association étudiante à partir d’un article sur le sommeil et les écrans.",
+            "tone": "sand",
+            "items": [
+              "Objectif : Synthétiser l’article en trois points faciles à lire et proposer une mini-action pour la vie de campus.",
+              "Contexte : Le résumé sera envoyé par courriel à des étudiantes et étudiants de première année. Temps de lecture cible : 4 minutes.",
+              "Score cible : 82%"
+            ]
+          },
+          {
+            "title": "🚀 Créativité Mission 3 · Courriel de stage",
+            "description": "Annonce un léger retard à ton superviseur de stage tout en proposant un plan d’action crédible.",
+            "tone": "sand",
+            "items": [
+              "Objectif : Informer d’un retard de trois jours sur le rapport de stage en rassurant sur les étapes suivantes.",
+              "Contexte : Tu es en Techniques de laboratoire. L’accès au labo a été restreint, d’où le retard.",
+              "Score cible : 88%"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": "prompt-dojo:draft",
+      "type": "form",
+      "component": "form",
+      "config": {
+        "submitLabel": "Enregistrer mon brief",
+        "allowEmpty": false,
+        "fields": [
+          {
+            "id": "mission",
+            "label": "Choisis la mission que tu veux relever",
+            "type": "single_choice",
+            "options": [
+              {
+                "value": "brief-clarity",
+                "label": "Mission 1 · Atelier campus (Débutant)",
+                "description": "Préparer un atelier de révision pour aider la cohorte de Techniques de l’informatique à réussir l’intra."
+              },
+              {
+                "value": "audience-adapt",
+                "label": "Mission 2 · Résumé associatif (Intermédiaire)",
+                "description": "Rédiger un résumé pour l’infolettre de l’association étudiante à partir d’un article sur le sommeil et les écrans."
+              },
+              {
+                "value": "creative-brief",
+                "label": "Mission 3 · Courriel de stage (Avancé)",
+                "description": "Annonce un léger retard à ton superviseur de stage tout en proposant un plan d’action crédible."
+              }
+            ]
+          },
+          {
+            "id": "objectif",
+            "label": "Formule ton objectif en 40 à 90 mots",
+            "type": "textarea_with_counter",
+            "minWords": 40,
+            "maxWords": 90,
+            "tone": "professionnel et motivant"
+          },
+          {
+            "id": "checklist",
+            "label": "Checklist du prompt final (3 à 5 puces)",
+            "type": "bulleted_list",
+            "minBullets": 3,
+            "maxBullets": 5,
+            "maxWordsPerBullet": 12,
+            "mustContainAny": ["ton", "format", "contrainte", "objectif"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "prompt-dojo:evaluate",
+      "type": "prompt-evaluation",
+      "component": "prompt-evaluation",
+      "config": {
+        "defaultText": "Rôle: Tu es un tuteur pair qui anime un atelier dynamique.\nTâche: Proposer un plan d’atelier de 60 minutes pour revoir les structures de données avant l’intra.\nPublic: Étudiantes et étudiants de première année au cégep.\nContraintes: Prévoir trois segments (accroche, pratique guidée, conclusion). Mentionner un outil collaboratif utilisé.\nFormat attendu: Liste numérotée avec durées estimées.\nRéponds uniquement avec le plan.",
+        "developerMessage": "Tu es un évaluateur pédagogique spécialisé dans la rédaction de prompts. Analyse le prompt suivant et attribue un score global ainsi que quatre sous-scores (0-100). Réponds uniquement avec un JSON strict, sans commentaire supplémentaire.\n\nFormat attendu (JSON strict): {\"total\":int,\"clarity\":int,\"specificity\":int,\"structure\":int,\"length\":int,\"comments\":\"string\",\"advice\":[\"string\",...]}.\n- \"comments\" : synthèse en 2 phrases max.\n- \"advice\" : pistes concrètes (3 max).\n- Utilise des entiers pour les scores.\n- Pas d’autre texte hors du JSON.",
+        "model": "gpt-5-mini",
+        "verbosity": "medium",
+        "thinking": "medium"
+      }
+    },
+    {
+      "id": "prompt-dojo:debrief",
+      "type": "rich-content",
+      "component": "rich-content",
+      "config": {
+        "title": "Analyse ton score IA",
+        "body": "Utilise le rapport pour comprendre où ton prompt excelle et où il reste flou. Ajuste ensuite ton brief : reformule les consignes manquantes, précise les contraintes ou ajoute un exemple. Quand tu dépasses la cible de la mission, exporte ton prompt gagnant pour ton portfolio.",
+        "sidebar": {
+          "type": "tips",
+          "title": "Prochaines étapes",
+          "tips": [
+            "Refais la mission avec un autre niveau pour varier les contextes.",
+            "Compare deux prompts différents dans l’atelier pour voir l’impact des paramètres.",
+            "Note les tournures qui te donnent systématiquement de bons scores."
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/backend/storage/activities_config.json
+++ b/backend/storage/activities_config.json
@@ -1,0 +1,605 @@
+{
+  "activities": [
+    {
+      "id": "atelier",
+      "componentKey": "step-sequence",
+      "path": "/atelier",
+      "completionId": "atelier",
+      "enabled": true,
+      "header": {
+        "eyebrow": "Atelier comparatif IA",
+        "title": "Cadrez, comparez, synthétisez vos essais IA",
+        "subtitle": "Suivez une progression claire pour préparer votre contexte, explorer deux profils IA en flux continu puis transformer les sorties en ressources réutilisables.",
+        "badge": "Trois étapes guidées"
+      },
+      "layout": {
+        "activityId": "atelier",
+        "headerClassName": "space-y-8",
+        "contentClassName": "space-y-12"
+      },
+      "card": {
+        "title": "Atelier comparatif IA",
+        "description": "Objectif : cadrer ta demande, comparer deux configurations IA et capitaliser sur les essais.",
+        "highlights": [
+          "Définir le contexte et les attentes",
+          "Tester modèle, verbosité et raisonnement",
+          "Assembler une synthèse réutilisable"
+        ],
+        "cta": {
+          "label": "Lancer l’atelier",
+          "to": "/atelier"
+        }
+      },
+      "stepSequence": [
+        {
+          "id": "workshop-prepare-context",
+          "type": "workshop-context",
+          "component": "workshop-context",
+          "config": {
+            "defaultText": "L'automatisation est particulièrement utile pour structurer des notes de cours, créer des rappels et générer des résumés ciblés. Les étudiantes et étudiants qui savent dialoguer avec l'IA peuvent obtenir des analyses précises, du survol rapide jusqu'à des synthèses détaillées. Comprendre comment ajuster les paramètres du modèle aide à mieux contrôler la production, à gagner du temps et à repérer les limites de l'outil."
+          }
+        },
+        {
+          "id": "workshop-compare-models",
+          "type": "workshop-comparison",
+          "component": "workshop-comparison",
+          "config": {
+            "contextStepId": "workshop-prepare-context",
+            "defaultConfigA": {
+              "model": "gpt-5-nano",
+              "verbosity": "medium",
+              "thinking": "minimal"
+            },
+            "defaultConfigB": {
+              "model": "gpt-5-mini",
+              "verbosity": "high",
+              "thinking": "high"
+            }
+          }
+        },
+        {
+          "id": "workshop-synthesis",
+          "type": "workshop-synthesis",
+          "component": "workshop-synthesis",
+          "config": {
+            "contextStepId": "workshop-prepare-context",
+            "comparisonStepId": "workshop-compare-models"
+          }
+        }
+      ]
+    },
+    {
+      "id": "prompt-dojo",
+      "componentKey": "prompt-dojo",
+      "path": "/prompt-dojo",
+      "completionId": "prompt-dojo",
+      "enabled": true,
+      "header": {
+        "eyebrow": "Prompt Dojo",
+        "title": "Affûte ton prompt mission par mission",
+        "subtitle": "Choisis un défi parmi les missions et franchis les étapes pour décrocher ton badge en atteignant le score IA visé.",
+        "badge": "Mode entraînement"
+      },
+      "layout": {
+        "contentAs": "div",
+        "contentClassName": "gap-0"
+      },
+      "card": {
+        "title": "Prompt Dojo — Mission débutant",
+        "description": "Objectif : t’entraîner à affiner une consigne en suivant des défis progressifs.",
+        "highlights": [
+          "Défis à difficulté graduelle",
+          "Retour immédiat sur la qualité du prompt",
+          "Construction d’une version finale personnalisée"
+        ],
+        "cta": {
+          "label": "Entrer dans le dojo",
+          "to": "/prompt-dojo"
+        }
+      },
+      "stepSequence": [
+        {
+          "id": "prompt-dojo:introduction",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Affûte ta consigne mission par mission",
+            "body": "Chaque mission te plonge dans un contexte différent. Tu disposes d’un briefing, de points de contrôle et d’un score cible à atteindre. Parcours les cartes ci-dessous, choisis la mission qui te motive puis prépare ton brief dans la zone guidée avant d’évaluer ton prompt final.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Comment progresser ?",
+              "tips": [
+                "Observe les objectifs et contraintes propres à chaque mission.",
+                "Note les points à vérifier dans ton prompt avant l’évaluation IA.",
+                "Révise ton texte jusqu’à dépasser le score cible indiqué."
+              ]
+            }
+          }
+        },
+        {
+          "id": "prompt-dojo:missions",
+          "type": "info-cards",
+          "component": "info-cards",
+          "config": {
+            "eyebrow": "Sélectionne un défi",
+            "title": "Trois missions inspirées du Prompt Dojo",
+            "description": "Compare les badges et niveaux pour choisir le défi correspondant à ta maîtrise actuelle. Les cibles de score te donnent un repère pour itérer.",
+            "columns": 3,
+            "cards": [
+              {
+                "title": "🎯 Clarté Mission 1 · Atelier campus",
+                "description": "Préparer un atelier de révision pour aider la cohorte de Techniques de l’informatique à réussir l’intra.",
+                "tone": "sand",
+                "items": [
+                  "Objectif : Construire un plan d’atelier d’une heure incluant une activité d’ouverture, un segment pratique et une conclusion claire.",
+                  "Contexte : Tu es pair-aidant au centre d’aide. L’atelier aura lieu en fin de journée avec 18 collègues un peu fatigués.",
+                  "Score cible : 75%"
+                ]
+              },
+              {
+                "title": "🧭 Adaptation Mission 2 · Résumé associatif",
+                "description": "Rédiger un résumé pour l’infolettre de l’association étudiante à partir d’un article sur le sommeil et les écrans.",
+                "tone": "sand",
+                "items": [
+                  "Objectif : Synthétiser l’article en trois points faciles à lire et proposer une mini-action pour la vie de campus.",
+                  "Contexte : Le résumé sera envoyé par courriel à des étudiantes et étudiants de première année. Temps de lecture cible : 4 minutes.",
+                  "Score cible : 82%"
+                ]
+              },
+              {
+                "title": "🚀 Créativité Mission 3 · Courriel de stage",
+                "description": "Annonce un léger retard à ton superviseur de stage tout en proposant un plan d’action crédible.",
+                "tone": "sand",
+                "items": [
+                  "Objectif : Informer d’un retard de trois jours sur le rapport de stage en rassurant sur les étapes suivantes.",
+                  "Contexte : Tu es en Techniques de laboratoire. L’accès au labo a été restreint, d’où le retard.",
+                  "Score cible : 88%"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "prompt-dojo:draft",
+          "type": "form",
+          "component": "form",
+          "config": {
+            "submitLabel": "Enregistrer mon brief",
+            "allowEmpty": false,
+            "fields": [
+              {
+                "id": "mission",
+                "label": "Choisis la mission que tu veux relever",
+                "type": "single_choice",
+                "options": [
+                  {
+                    "value": "brief-clarity",
+                    "label": "Mission 1 · Atelier campus (Débutant)",
+                    "description": "Préparer un atelier de révision pour aider la cohorte de Techniques de l’informatique à réussir l’intra."
+                  },
+                  {
+                    "value": "audience-adapt",
+                    "label": "Mission 2 · Résumé associatif (Intermédiaire)",
+                    "description": "Rédiger un résumé pour l’infolettre de l’association étudiante à partir d’un article sur le sommeil et les écrans."
+                  },
+                  {
+                    "value": "creative-brief",
+                    "label": "Mission 3 · Courriel de stage (Avancé)",
+                    "description": "Annonce un léger retard à ton superviseur de stage tout en proposant un plan d’action crédible."
+                  }
+                ]
+              },
+              {
+                "id": "objectif",
+                "label": "Formule ton objectif en 40 à 90 mots",
+                "type": "textarea_with_counter",
+                "minWords": 40,
+                "maxWords": 90,
+                "tone": "professionnel et motivant"
+              },
+              {
+                "id": "checklist",
+                "label": "Checklist du prompt final (3 à 5 puces)",
+                "type": "bulleted_list",
+                "minBullets": 3,
+                "maxBullets": 5,
+                "maxWordsPerBullet": 12,
+                "mustContainAny": [
+                  "ton",
+                  "format",
+                  "contrainte",
+                  "objectif"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "prompt-dojo:evaluate",
+          "type": "prompt-evaluation",
+          "component": "prompt-evaluation",
+          "config": {
+            "defaultText": "Rôle: Tu es un tuteur pair qui anime un atelier dynamique.\nTâche: Proposer un plan d’atelier de 60 minutes pour revoir les structures de données avant l’intra.\nPublic: Étudiantes et étudiants de première année au cégep.\nContraintes: Prévoir trois segments (accroche, pratique guidée, conclusion). Mentionner un outil collaboratif utilisé.\nFormat attendu: Liste numérotée avec durées estimées.\nRéponds uniquement avec le plan.",
+            "developerMessage": "Tu es un évaluateur pédagogique spécialisé dans la rédaction de prompts. Analyse le prompt suivant et attribue un score global ainsi que quatre sous-scores (0-100). Réponds uniquement avec un JSON strict, sans commentaire supplémentaire.\n\nFormat attendu (JSON strict): {\"total\":int,\"clarity\":int,\"specificity\":int,\"structure\":int,\"length\":int,\"comments\":\"string\",\"advice\":[\"string\",...]}.\n- \"comments\" : synthèse en 2 phrases max.\n- \"advice\" : pistes concrètes (3 max).\n- Utilise des entiers pour les scores.\n- Pas d’autre texte hors du JSON.",
+            "model": "gpt-5-mini",
+            "verbosity": "medium",
+            "thinking": "medium"
+          }
+        },
+        {
+          "id": "prompt-dojo:debrief",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Analyse ton score IA",
+            "body": "Utilise le rapport pour comprendre où ton prompt excelle et où il reste flou. Ajuste ensuite ton brief : reformule les consignes manquantes, précise les contraintes ou ajoute un exemple. Quand tu dépasses la cible de la mission, exporte ton prompt gagnant pour ton portfolio.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Prochaines étapes",
+              "tips": [
+                "Refais la mission avec un autre niveau pour varier les contextes.",
+                "Compare deux prompts différents dans l’atelier pour voir l’impact des paramètres.",
+                "Note les tournures qui te donnent systématiquement de bons scores."
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "clarity",
+      "componentKey": "clarity-path",
+      "path": "/parcours-clarte",
+      "completionId": "clarity",
+      "enabled": true,
+      "header": {
+        "eyebrow": "Parcours de la clarté",
+        "title": "Guide le bonhomme avec une consigne limpide",
+        "subtitle": "Écris une instruction en langue naturelle. Le backend demande au modèle gpt-5-nano un plan complet, valide la trajectoire puis te montre l’exécution pas à pas.",
+        "badge": "Mode jeu"
+      },
+      "layout": {
+        "innerClassName": "relative",
+        "contentAs": "div",
+        "contentClassName": "gap-10"
+      },
+      "card": {
+        "title": "Parcours de la clarté",
+        "description": "Objectif : expérimenter la précision des consignes sur un parcours 10×10.",
+        "highlights": [
+          "Plan d’action IA généré avant l’animation",
+          "Visualisation pas à pas avec obstacles",
+          "Analyse des tentatives et du surcoût"
+        ],
+        "cta": {
+          "label": "Tester la clarté",
+          "to": "/parcours-clarte"
+        }
+      },
+      "stepSequence": [
+        {
+          "id": "clarity:introduction",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Écris une consigne limpide pour guider le personnage",
+            "body": "Observe la grille 10×10. Ta mission consiste à formuler une instruction assez claire pour que l’IA trace un trajet optimal sans se cogner aux obstacles. Utilise les étapes suivantes pour positionner la cible, visualiser un plan puis rédiger ta consigne finale.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Conseils express",
+              "tips": [
+                "Indique la direction et la distance plutôt que de vagues intentions.",
+                "Mentionne les obstacles importants afin d’éviter les collisions.",
+                "Utilise un vocabulaire simple : haut, bas, gauche, droite, nombre de cases."
+              ]
+            }
+          }
+        },
+        {
+          "id": "clarity:map",
+          "type": "clarity-map",
+          "component": "clarity-map",
+          "config": {
+            "obstacleCount": 6,
+            "initialTarget": {
+              "x": 7,
+              "y": 3
+            },
+            "promptStepId": "clarity:instruction",
+            "allowInstructionInput": true,
+            "instructionLabel": "Consigne transmise à l’IA",
+            "instructionPlaceholder": "Depuis le départ, avance de deux cases vers le bas, contourne l’obstacle par la droite puis remonte jusqu’à la cible…"
+          }
+        },
+        {
+          "id": "clarity:instruction",
+          "type": "clarity-prompt",
+          "component": "clarity-prompt",
+          "config": {
+            "promptLabel": "Rédige ta consigne finale",
+            "promptPlaceholder": "Exemple : ‘Depuis la case de départ, descends de trois cases, va deux cases à droite, monte de deux cases puis avance une case à droite pour atteindre la cible.’",
+            "model": "gpt-5-mini",
+            "verbosity": "medium",
+            "thinking": "medium",
+            "settingsMode": "read-only"
+          }
+        },
+        {
+          "id": "clarity:debrief",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Débrief et pistes d’amélioration",
+            "body": "Analyse les statistiques générées : nombre d’essais, surcoût de parcours et fidélité au plan. Si le personnage se bloque, identifie les zones ambiguës de ta consigne (direction manquante, distance imprécise, obstacle oublié). Réécris ensuite l’instruction et relance une exécution jusqu’à atteindre la cible sans détour.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Pour aller plus loin",
+              "tips": [
+                "Teste une version plus concise de ta consigne pour voir l’impact sur le plan.",
+                "Ajoute des contraintes bonus (ex : passer par une case particulière) et vérifie le comportement.",
+                "Compare deux consignes différentes dans l’atelier pour voir laquelle est la plus efficace."
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "clarte-dabord",
+      "componentKey": "clarte-dabord",
+      "path": "/clarte-dabord",
+      "completionId": "clarte-dabord",
+      "enabled": true,
+      "header": {
+        "eyebrow": "Clarté d'abord !",
+        "title": "Identifie ce qu'il fallait dire dès la première consigne",
+        "subtitle": "Tu joues l'IA : l'usager précise son besoin manche après manche. Observe ce qui manquait au brief initial et retiens la checklist idéale.",
+        "badge": "Trois manches guidées"
+      },
+      "layout": {
+        "contentAs": "div",
+        "contentClassName": "gap-10"
+      },
+      "card": {
+        "title": "Clarté d’abord !",
+        "description": "Objectif : mesurer l’impact d’un brief incomplet et révéler la checklist idéale.",
+        "highlights": [
+          "Deux missions thématiques en trois manches",
+          "Champs guidés avec validations pédagogiques",
+          "Révélation finale et export JSON du menu"
+        ],
+        "cta": {
+          "label": "Lancer Clarté d’abord !",
+          "to": "/clarte-dabord"
+        }
+      },
+      "stepSequence": [
+        {
+          "id": "clarte-dabord:introduction",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Clarifie la demande dès la première manche",
+            "body": "Tu joues l’IA : l’usager formule une requête incomplète pour préparer un menu étudiant. Trois manches successives apportent des précisions. Ton objectif est d’améliorer ta réponse à chaque étape tout en notant ce qu’il aurait fallu demander dès le départ.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Approche recommandée",
+              "tips": [
+                "Repère les informations manquantes dès la première manche.",
+                "Structure tes réponses dans les tableaux proposés pour éviter les oublis.",
+                "À la fin, rédige ta checklist idéale pour guider l’usager la prochaine fois."
+              ]
+            }
+          }
+        },
+        {
+          "id": "clarte-dabord:stage-1",
+          "type": "form",
+          "component": "form",
+          "config": {
+            "submitLabel": "Valider la manche 1",
+            "allowEmpty": false,
+            "fields": [
+              {
+                "id": "menu_jour1_idees",
+                "label": "Jour 1 — Idées de plats (1–3 puces)",
+                "type": "bulleted_list",
+                "minBullets": 1,
+                "maxBullets": 3,
+                "maxWordsPerBullet": 6,
+                "mustContainAny": [
+                  "pain",
+                  "pâtes",
+                  "tomates",
+                  "pommes",
+                  "lait",
+                  "poulet"
+                ]
+              },
+              {
+                "id": "menu_jour2_idees",
+                "label": "Jour 2 — Idées de plats (1–3 puces)",
+                "type": "bulleted_list",
+                "minBullets": 1,
+                "maxBullets": 3,
+                "maxWordsPerBullet": 6,
+                "mustContainAny": [
+                  "pain",
+                  "pâtes",
+                  "tomates",
+                  "pommes",
+                  "lait",
+                  "poulet"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "clarte-dabord:stage-2",
+          "type": "form",
+          "component": "form",
+          "config": {
+            "submitLabel": "Valider la manche 2",
+            "allowEmpty": false,
+            "fields": [
+              {
+                "id": "menu_jour1_table",
+                "label": "Jour 1 — 3 repas (plat uniquement)",
+                "type": "table_menu_day",
+                "meals": [
+                  "Déjeuner",
+                  "Dîner",
+                  "Souper"
+                ]
+              },
+              {
+                "id": "menu_jour2_table",
+                "label": "Jour 2 — 3 repas (plat uniquement)",
+                "type": "table_menu_day",
+                "meals": [
+                  "Déjeuner",
+                  "Dîner",
+                  "Souper"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "clarte-dabord:stage-3",
+          "type": "form",
+          "component": "form",
+          "config": {
+            "submitLabel": "Valider la manche 3",
+            "allowEmpty": false,
+            "fields": [
+              {
+                "id": "menu_jour1_complet",
+                "label": "Jour 1 — plat / boisson / dessert",
+                "type": "table_menu_full",
+                "meals": [
+                  "Déjeuner",
+                  "Dîner",
+                  "Souper"
+                ]
+              },
+              {
+                "id": "menu_jour2_complet",
+                "label": "Jour 2 — plat / boisson / dessert",
+                "type": "table_menu_full",
+                "meals": [
+                  "Déjeuner",
+                  "Dîner",
+                  "Souper"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "clarte-dabord:debrief",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Révèle la checklist idéale",
+            "body": "Ce qui aurait dû être demandé dès le départ :\n- Crée un menu complet de 2 jours.\n- Chaque jour doit comporter 3 repas : déjeuner, dîner, souper.\n- Chaque repas doit inclure un plat, une boisson et un dessert.\n- Utilise uniquement les aliments listés : pain, pâtes, tomates, pommes, lait, poulet.\n- Présente le tout en JSON structuré : jour → repas → {plat, boisson, dessert}.",
+            "sidebar": {
+              "type": "tips",
+              "title": "À retenir",
+              "tips": [
+                "Une bonne consigne précise le format (ici : tableau JSON structuré).",
+                "Mentionne les contraintes incontournables (ingrédients, nombre de repas, éléments à inclure).",
+                "Teste ta checklist sur un autre scénario pour vérifier qu’elle fonctionne vraiment."
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "explorateur-ia",
+      "componentKey": "explorateur-ia",
+      "path": "/explorateur-ia",
+      "completionId": "explorateur-ia",
+      "enabled": true,
+      "header": {
+        "eyebrow": "Activité 5",
+        "title": "L’Explorateur IA",
+        "subtitle": "Parcours une mini-ville façon Game Boy pour valider quatre compétences IA sans jamais taper au clavier.",
+        "badge": "Ville interactive"
+      },
+      "layout": {
+        "outerClassName": "flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden px-0 pt-0 pb-0",
+        "innerClassName": "flex h-full min-h-0 flex-1 w-full max-w-none gap-0",
+        "headerClassName": "hidden",
+        "contentClassName": "flex h-full min-h-0 flex-1 flex-col space-y-0",
+        "withLandingGradient": false,
+        "useDynamicViewportHeight": true,
+        "withBasePadding": false,
+        "withBaseContentSpacing": false,
+        "withBaseInnerGap": false
+      },
+      "card": {
+        "title": "L’Explorateur IA",
+        "description": "Objectif : compléter un parcours ludique mêlant quiz, drag-and-drop, décisions et dilemmes éthiques.",
+        "highlights": [
+          "Déplacements façon jeu vidéo et interactions à la souris",
+          "Quatre mini-activités pédagogiques sans saisie de texte",
+          "Export JSON immédiat et impression PDF du bilan"
+        ],
+        "cta": {
+          "label": "Entrer dans la ville",
+          "to": "/explorateur-ia"
+        }
+      },
+      "stepSequence": [
+        {
+          "id": "explorateur:introduction",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Prépare ton exploration pixelisée",
+            "body": "Bienvenue dans Tiny Town, une mini-ville en pixel art où chaque quartier correspond à une compétence IA.\n\n• Déplace-toi avec les flèches du clavier ou les touches WASD. Sur mobile, utilise le joystick flottant.\n• Clique sur un bâtiment pour lancer la mission associée et suis les consignes à l'écran.\n• Termine les quatre quartiers thématiques pour débloquer la mairie et valider ton parcours.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Astuces de navigation",
+              "tips": [
+                "Observe les couleurs des bâtiments : elles rappellent la compétence évaluée.",
+                "Rouvre un quartier quand tu veux pour compléter un objectif manquant.",
+                "L’inventaire en haut à droite conserve tes objets de mission."
+              ]
+            }
+          }
+        },
+        {
+          "id": "explorateur:world",
+          "type": "explorateur-world",
+          "component": "explorateur-world"
+        },
+        {
+          "id": "explorateur:debrief",
+          "type": "rich-content",
+          "component": "rich-content",
+          "config": {
+            "title": "Capture ton bilan d’explorateur ou d’exploratrice",
+            "body": "Bravo pour cette exploration !\n\nDepuis la ville, ouvre la mairie pour afficher ta carte de compétences. Utilise les boutons JSON et PDF pour exporter ton rapport, l’ajouter à ton portfolio ou le partager avec ton équipe.\n\nTu peux revenir dans n’importe quel quartier pour améliorer un score ou récolter les idées à transformer en prompts.",
+            "sidebar": {
+              "type": "tips",
+              "title": "Et après ?",
+              "tips": [
+                "Note trois apprentissages clés dans ton portfolio.",
+                "Transforme les meilleures stratégies en consignes prêtes à réutiliser.",
+                "Anime un atelier en montrant comment tu as débloqué la mairie."
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "activityGeneration": {
+    "systemMessage": "Tu es un concepteur pédagogique francophone spécialisé en intelligence artificielle générative. Tu proposes des activités engageantes et structurées pour des professionnels en formation continue.",
+    "developerMessage": "Utilise exclusivement les fonctions fournies pour construire une activité StepSequence cohérente.\nCommence par create_step_sequence_activity pour initialiser l'activité, enchaîne avec les create_* adaptées pour définir chaque étape, puis finalise en appelant build_step_sequence_activity lorsque la configuration est complète.\nChaque étape doit rester alignée avec les objectifs fournis et renseigne la carte d'activité ainsi que le header avec des formulations concises, inclusives et professionnelles.\n\nExigences de conception :\n- Génère 3 à 5 étapes maximum en privilégiant la progression pédagogique (accroche, exploration guidée, consolidation).\n- Utilise uniquement les composants disponibles : rich-content, form, video, simulation-chat, info-cards, prompt-evaluation, ai-comparison, clarity-map, clarity-prompt, explorateur-world ou composite.\n- Propose des identifiants d'étape courts en minuscules séparés par des tirets.\n- Les formulaires doivent comporter des consignes explicites et des contraintes adaptées (nombre de mots, choix, etc.).\n- Complète la carte d'activité (titre, description, highlights, CTA) et le header avec des textes synthétiques.\n- Si aucun chemin spécifique n'est requis, oriente le CTA vers /activites/{activityId}."
+  }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -384,6 +384,12 @@ export interface SaveActivityConfigResponse {
   message: string;
 }
 
+export interface ImportActivityResponse {
+  ok: boolean;
+  activity: Record<string, unknown>;
+  message?: string;
+}
+
 export interface ActivityGenerationDetailsPayload {
   theme?: string;
   audience?: string;
@@ -454,6 +460,31 @@ export const admin = {
           },
           token
         )
+      ),
+    import: async (
+      activity: Record<string, unknown>,
+      token?: string | null
+    ): Promise<ImportActivityResponse> =>
+      fetchJson<ImportActivityResponse>(
+        `${API_BASE_URL}/admin/activities/import`,
+        withAdminCredentials(
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ activity }),
+          },
+          token
+        )
+      ),
+    export: async (
+      activityId: string,
+      token?: string | null
+    ): Promise<Record<string, unknown>> =>
+      fetchJson<Record<string, unknown>>(
+        `${API_BASE_URL}/admin/activities/${encodeURIComponent(activityId)}/export`,
+        withAdminCredentials({}, token)
       ),
     generate: async (
       payload: GenerateActivityPayload,

--- a/frontend/tests/pages/ActivitySelector.spec.tsx
+++ b/frontend/tests/pages/ActivitySelector.spec.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getProgressMock = vi.fn();
 const getConfigMock = vi.fn();
 const saveMock = vi.fn();
+const importMock = vi.fn();
+const exportMock = vi.fn();
 const setEditModeMock = vi.fn();
 
 vi.mock("../../src/api", () => ({
@@ -15,6 +17,8 @@ vi.mock("../../src/api", () => ({
   admin: {
     activities: {
       save: saveMock,
+      import: importMock,
+      export: exportMock,
     },
   },
 }));
@@ -42,6 +46,8 @@ describe("ActivitySelector StepSequence designer", () => {
     getProgressMock.mockResolvedValue({ activities: {} });
     getConfigMock.mockResolvedValue({ activities: [], activitySelectorHeader: null });
     saveMock.mockResolvedValue(undefined);
+    importMock.mockResolvedValue({ ok: true, activity: {} });
+    exportMock.mockResolvedValue({});
   });
 
   it("allows creating a StepSequence activity and editing its steps", async () => {


### PR DESCRIPTION
## Summary
- persist each StepSequence activity as an individual JSON file with an index alongside activities_config.json
- expose admin API endpoints to import and export a single activity and add regression tests for the new storage layout
- wire the admin UI to import/export actions, updating the API client and ActivitySelector to surface status messages

## Testing
- pytest backend/tests/test_admin_activities_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c0562c8083228a57860f44954f8f