### PR TITLE
Allow removing StepSequence steps from saved overrides

### DIFF
--- a/frontend/tests/config/stepSequence.activities.test.ts
+++ b/frontend/tests/config/stepSequence.activities.test.ts
@@ -60,6 +60,23 @@ describe("Step sequence activities", () => {
     ]);
   });
 
+  it("removes catalog defaults when override requests replacement", () => {
+    const entry: ActivityConfigEntry = {
+      id: TEST_ACTIVITY_ID,
+      overrides: {
+        stepSequence: [
+          { id: "practice", component: "practice", __replaceSequence: true },
+        ],
+      },
+    };
+
+    const definition = resolveActivityDefinition(entry);
+
+    expect(definition.stepSequence).toEqual([
+      { id: "practice", component: "practice", config: { order: 1 } },
+    ]);
+  });
+
   it("serializes changes to the step sequence", () => {
     const baseDefinition = resolveActivityDefinition({ id: TEST_ACTIVITY_ID });
     const updatedSteps: StepDefinition[] = [
@@ -75,6 +92,11 @@ describe("Step sequence activities", () => {
 
     const serialized = serializeActivityDefinition(updatedDefinition);
 
-    expect(serialized.overrides?.stepSequence).toEqual(updatedSteps);
+    const expectedSteps = updatedSteps.map((step) => ({
+      ...step,
+      __replaceSequence: true,
+    }));
+
+    expect(serialized.overrides?.stepSequence).toEqual(expectedSteps);
   });
 });


### PR DESCRIPTION
## Summary
- adjust step sequence persistence to keep metadata about full replacements
- update merging logic so overrides flagged for replacement drop catalog defaults
- extend tests to cover replacement behaviour and updated serialization output

## Testing
- npm test -- config/stepSequence.activities.test.ts *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d800422b0083229d28d89c6ab69d4f