### PR TITLE
Improve Clarity map responsiveness and remove manual command section

### DIFF
--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -22,8 +22,8 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
 
   return (
     <div className="relative mx-auto w-full max-w-[480px]">
-      <div className="flex items-end gap-4">
-        <div className="flex h-[360px] flex-col justify-between pb-4 text-xs font-semibold text-[color:var(--brand-charcoal)]/70">
+      <div className="flex items-end gap-3 md:gap-4">
+        <div className="flex h-[clamp(220px,80vw,360px)] flex-col justify-between pb-3 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:pb-4 md:text-xs">
           {axis.map((value) => (
             <span key={`row-${value}`} className="text-right">
               {value}
@@ -31,7 +31,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           ))}
         </div>
         <div className="relative">
-          <div className="relative aspect-square h-[360px] rounded-3xl border border-white/60 bg-white/70 p-2 shadow-inner">
+          <div className="relative aspect-square h-[clamp(220px,80vw,360px)] rounded-3xl border border-white/60 bg-white/70 p-2 shadow-inner">
             <div className="grid h-full w-full grid-cols-10 grid-rows-10 overflow-hidden rounded-2xl border border-white/40">
               {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, index) => {
                 const x = index % GRID_SIZE;
@@ -87,7 +87,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           </div>
         </div>
       </div>
-      <div className="mt-2 flex justify-center gap-[34px] text-xs font-semibold text-[color:var(--brand-charcoal)]/70">
+      <div className="mt-2 flex justify-center gap-[24px] text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:gap-[34px] md:text-xs">
         {axis.map((value) => (
           <span key={`col-${value}`}>{value}</span>
         ))}

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -548,10 +548,6 @@ export function ClarityMapStep({
     }
   }, [effectiveStatus]);
 
-  const shouldShowInstructionPanel = Boolean(
-    normalizedConfig.allowInstructionInput && promptInstruction === null
-  );
-
   const blockedSignature = useMemo(
     () => blocked.map((cell) => gridKey(cell)).sort().join("|"),
     [blocked]
@@ -606,13 +602,6 @@ export function ClarityMapStep({
   const handlePromptIdChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       applyConfigPatch({ promptStepId: event.target.value });
-    },
-    [applyConfigPatch]
-  );
-
-  const handleAllowInputToggle = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      applyConfigPatch({ allowInstructionInput: event.target.checked });
     },
     [applyConfigPatch]
   );
@@ -839,17 +828,6 @@ export function ClarityMapStep({
                 />
               </label>
             </div>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={normalizedConfig.allowInstructionInput}
-                onChange={handleAllowInputToggle}
-                className="h-4 w-4 rounded border-white/60 text-[color:var(--brand-red)] focus:ring-[color:var(--brand-red)]"
-              />
-              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
-                Autoriser la saisie manuelle
-              </span>
-            </label>
           </div>
         </fieldset>
       )}
@@ -877,27 +855,6 @@ export function ClarityMapStep({
           </div>
         </div>
         <div className="space-y-3">
-          {shouldShowInstructionPanel && (
-            <div className="flex flex-col gap-3">
-              <label className="flex flex-col gap-2">
-                <span className="text-sm font-semibold text-[color:var(--brand-black)]">
-                  {normalizedConfig.instructionLabel}
-                </span>
-                <textarea
-                  rows={6}
-                  value={instruction}
-                  onChange={(event) => setInstruction(event.target.value)}
-                  placeholder={normalizedConfig.instructionPlaceholder}
-                  readOnly={!normalizedConfig.allowInstructionInput && promptInstruction !== null}
-                  className={`min-h-[160px] rounded-2xl border border-white/60 px-4 py-3 text-base text-[color:var(--brand-charcoal)] shadow-sm placeholder:text-[color:var(--brand-charcoal)]/50 focus:border-[color:var(--brand-red)] focus:outline-none ${
-                    !normalizedConfig.allowInstructionInput && promptInstruction !== null
-                      ? "bg-white/70 text-[color:var(--brand-charcoal)]/80"
-                      : "bg-white"
-                  }`}
-                />
-              </label>
-            </div>
-          )}
           {(isExecuting || effectiveMessage) && (
             <p className={`text-sm ${messageToneClass}`}>
               {effectiveMessage || "L’IA calcule le trajet…"}
@@ -911,7 +868,7 @@ export function ClarityMapStep({
         <p className="text-sm text-white/70">
           {shouldAutoPublish
             ? "Le module carte met à jour son payload automatiquement dans le composite."
-            : "Valide cette configuration pour continuer et transmettre la commande."}
+            : "Valide cette configuration pour continuer."}
         </p>
         {!shouldAutoPublish && (
           <button


### PR DESCRIPTION
## Summary
- adapt the Clarity map grid layout to clamp its height and spacing so it fits smaller mobile screens
- remove the manual "Commande transmise" textarea section from the Clarity map step and update the helper copy accordingly

## Testing
- npm run build *(fails: missing dependency hls.js/dist/hls.mjs referenced by VideoStep.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d8072e9b208322a46c82cb64a4ee2b