### PR TITLE
feat: intégrer l’éditeur Explorateur IA dédié

### DIFF
--- a/frontend/src/modules/step-sequence/README.md
+++ b/frontend/src/modules/step-sequence/README.md
@@ -114,3 +114,11 @@ const activityPayload = STEP_SEQUENCE_TOOLS.build_step_sequence_activity.handler
 ```
 
 L’utilitaire `generateStepId` est également disponible pour dériver des identifiants compatibles avec les conventions existantes (`workshop-…`, `step-…`, etc.).
+
+## Modules avec éditeur dédié
+
+Certains composants peuvent nécessiter un environnement d’édition sur mesure (plein écran, navigation multi-panneaux, etc.). L’étape `explorateur-world` en est l’exemple actuel : dans l’interface d’administration (`ActivitySelector`), le panneau de configuration affiche un résumé et ouvre l’éditeur complet dans une superposition qui embarque `StepSequenceRenderer`. La configuration émise par cet éditeur est systématiquement normalisée via `sanitizeExplorateurWorldConfig` puis filtrée pour ne conserver que des modules StepSequence enregistrés dans `STEP_COMPONENT_REGISTRY`. Toute future intégration qui requiert un éditeur complexe peut réutiliser cette approche en :
+
+1. Fournissant un aperçu compact côté `ActivitySelector`.
+2. Rendant l’éditeur dédié dans une modale/panneau plein écran qui enveloppe `StepSequenceRenderer` (ce qui garantit l’appel à `onUpdateConfig`).
+3. Appliquant le même filtrage de composants pour s’assurer que seules des étapes StepSequence valides sont stockées (important pour l’import/export JSON).


### PR DESCRIPTION
## Summary
- ouvre un éditeur plein écran dédié pour les étapes `explorateur-world` dans l’ActivitySelector
- nettoie et restreint les configurations Explorateur IA aux modules StepSequence enregistrés
- documente le flux d’intégration pour les modules StepSequence nécessitant un éditeur spécialisé

## Testing
- npm run build *(échoue : dépendance optionnelle `hls.js/dist/hls.mjs` manquante dans la configuration actuelle)*

------
https://chatgpt.com/codex/tasks/task_e_68d806c1f1108322b09d781456412832