### PR TITLE
Scroll to top when navigating between steps

### DIFF
--- a/frontend/src/modules/step-sequence/StepSequenceRenderer.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceRenderer.tsx
@@ -103,6 +103,14 @@ export function StepSequenceRenderer({
     [currentIndex, onStepConfigChange, steps]
   );
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [currentIndex]);
+
   const goToStep = useCallback(
     (target: number | string) => {
       if (steps.length === 0) {


### PR DESCRIPTION
## Summary
- scroll back to the top of the viewport when switching between step sequence screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80b1e94188322a1a0841d82767ee3