### PR TITLE
Masquer le panneau supérieur des activités tout en conservant l’édition admin

### DIFF
--- a/frontend/src/components/ActivityLayout.tsx
+++ b/frontend/src/components/ActivityLayout.tsx
@@ -27,6 +27,7 @@ interface ActivityLayoutProps {
   contentClassName?: string;
   contentAs?: ContentElement;
   titleAlign?: "left" | "center";
+  showHeader?: boolean;
   withLandingGradient?: boolean;
   useDynamicViewportHeight?: boolean;
   withBasePadding?: boolean;
@@ -56,6 +57,7 @@ function ActivityLayout({
   contentClassName,
   contentAs = "main",
   titleAlign = "left",
+  showHeader = true,
   onHeaderEdit,
   activityConfig,
   onSaveActivity,
@@ -87,6 +89,7 @@ function ActivityLayout({
   const ContentTag = contentAs as ContentElement;
   const titleContainerClass =
     titleAlign === "center" ? "text-center" : "text-center md:text-left";
+  const shouldRenderHeader = showHeader !== false;
 
   return (
     <div
@@ -107,105 +110,114 @@ function ActivityLayout({
         )}
       >
         {beforeHeader}
-        <header
-          className={combineClasses(
-            "space-y-6 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur",
-            headerClassName,
-            isEditMode && onHeaderEdit ? "border-orange-200 ring-2 ring-orange-100" : ""
-          )}
-        >
-          {isEditMode && onHeaderEdit && (
-            <div className="mb-4 rounded-lg border border-orange-200 bg-orange-50 p-3">
-              <div className="flex items-center justify-between">
-                <p className="text-xs font-medium text-orange-700 uppercase tracking-wider">
-                  Mode édition activé - Modifier les textes de l'en-tête
-                </p>
-                {onSaveActivity && (
-                  <button
-                    onClick={handleSave}
-                    disabled={isSaving}
-                    className="text-xs px-3 py-1 bg-orange-600 text-white rounded hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {isSaving ? 'Sauvegarde...' : 'Sauvegarder'}
-                  </button>
-                )}
-              </div>
+        {!shouldRenderHeader && actions ? (
+          <div className="flex justify-end">
+            <div className="rounded-full border border-white/70 bg-white/90 px-4 py-2 shadow-sm backdrop-blur">
+              {actions}
             </div>
-          )}
-          <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
-            <Link
-              to={isAuthenticated ? "/activites" : "/"}
-              className="flex items-center gap-3"
-            >
-              <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-16" />
-              {isEditMode && onHeaderEdit ? (
-                <input
-                  type="text"
-                  value={eyebrow}
-                  onChange={(e) => onHeaderEdit('eyebrow', e.target.value)}
-                  className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70 bg-transparent border-b border-orange-300 focus:border-orange-500 focus:outline-none min-w-[120px]"
-                  placeholder="Eyebrow"
-                />
-              ) : (
-                <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
-                  {eyebrow}
-                </span>
-              )}
-            </Link>
-            {(badge || actions) && (
-              <div className="flex flex-col items-center gap-2 md:flex-row md:items-center">
-                {badge ? (
-                  isEditMode && onHeaderEdit ? (
-                    <input
-                      type="text"
-                      value={badge}
-                      onChange={(e) => onHeaderEdit('badge', e.target.value)}
-                      className="brand-chip bg-orange-50 border border-orange-300 focus:border-orange-500 focus:outline-none text-orange-700 min-w-[100px]"
-                      placeholder="Badge"
-                    />
-                  ) : (
-                    <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
-                      {badge}
-                    </span>
-                  )
-                ) : null}
-                {actions}
+          </div>
+        ) : null}
+        {shouldRenderHeader ? (
+          <header
+            className={combineClasses(
+              "space-y-6 rounded-3xl border border-white/70 bg-white/90 p-8 shadow-sm backdrop-blur",
+              headerClassName,
+              isEditMode && onHeaderEdit ? "border-orange-200 ring-2 ring-orange-100" : ""
+            )}
+          >
+            {isEditMode && onHeaderEdit && (
+              <div className="mb-4 rounded-lg border border-orange-200 bg-orange-50 p-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-medium text-orange-700 uppercase tracking-wider">
+                    Mode édition activé - Modifier les textes de l'en-tête
+                  </p>
+                  {onSaveActivity && (
+                    <button
+                      onClick={handleSave}
+                      disabled={isSaving}
+                      className="text-xs px-3 py-1 bg-orange-600 text-white rounded hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {isSaving ? 'Sauvegarde...' : 'Sauvegarder'}
+                    </button>
+                  )}
+                </div>
               </div>
             )}
-          </div>
-          <div className={combineClasses("space-y-3", titleContainerClass)}>
-            {isEditMode && onHeaderEdit ? (
-              <>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => onHeaderEdit('title', e.target.value)}
-                  className="w-full text-3xl font-semibold leading-tight md:text-4xl bg-transparent border-b-2 border-orange-300 focus:border-orange-500 focus:outline-none"
-                  placeholder="Titre de l'activité"
-                />
-                {subtitle !== undefined && (
-                  <textarea
-                    value={subtitle}
-                    onChange={(e) => onHeaderEdit('subtitle', e.target.value)}
-                    rows={2}
-                    className="w-full text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base bg-transparent border border-orange-300 rounded p-2 focus:border-orange-500 focus:outline-none resize-none"
-                    placeholder="Sous-titre (optionnel)"
+            <div className="flex flex-col items-center justify-between gap-4 md:flex-row">
+              <Link
+                to={isAuthenticated ? "/activites" : "/"}
+                className="flex items-center gap-3"
+              >
+                <img src={logoPrincipal} alt="Cégep Limoilou" className="h-12 w-auto md:h-16" />
+                {isEditMode && onHeaderEdit ? (
+                  <input
+                    type="text"
+                    value={eyebrow}
+                    onChange={(e) => onHeaderEdit('eyebrow', e.target.value)}
+                    className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70 bg-transparent border-b border-orange-300 focus:border-orange-500 focus:outline-none min-w-[120px]"
+                    placeholder="Eyebrow"
                   />
+                ) : (
+                  <span className="text-xs uppercase tracking-[0.3em] text-[color:var(--brand-charcoal)]/70">
+                    {eyebrow}
+                  </span>
                 )}
-              </>
-            ) : (
-              <>
-                <h1 className="text-3xl font-semibold leading-tight md:text-4xl">{title}</h1>
-                {subtitle ? (
-                  <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base">
-                    {subtitle}
-                  </p>
-                ) : null}
-              </>
-            )}
-          </div>
-          {headerChildren}
-        </header>
+              </Link>
+              {(badge || actions) && (
+                <div className="flex flex-col items-center gap-2 md:flex-row md:items-center">
+                  {badge ? (
+                    isEditMode && onHeaderEdit ? (
+                      <input
+                        type="text"
+                        value={badge}
+                        onChange={(e) => onHeaderEdit('badge', e.target.value)}
+                        className="brand-chip bg-orange-50 border border-orange-300 focus:border-orange-500 focus:outline-none text-orange-700 min-w-[100px]"
+                        placeholder="Badge"
+                      />
+                    ) : (
+                      <span className="brand-chip bg-[color:var(--brand-red)]/10 text-[color:var(--brand-red)]">
+                        {badge}
+                      </span>
+                    )
+                  ) : null}
+                  {actions}
+                </div>
+              )}
+            </div>
+            <div className={combineClasses("space-y-3", titleContainerClass)}>
+              {isEditMode && onHeaderEdit ? (
+                <>
+                  <input
+                    type="text"
+                    value={title}
+                    onChange={(e) => onHeaderEdit('title', e.target.value)}
+                    className="w-full text-3xl font-semibold leading-tight md:text-4xl bg-transparent border-b-2 border-orange-300 focus:border-orange-500 focus:outline-none"
+                    placeholder="Titre de l'activité"
+                  />
+                  {subtitle !== undefined && (
+                    <textarea
+                      value={subtitle}
+                      onChange={(e) => onHeaderEdit('subtitle', e.target.value)}
+                      rows={2}
+                      className="w-full text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base bg-transparent border border-orange-300 rounded p-2 focus:border-orange-500 focus:outline-none resize-none"
+                      placeholder="Sous-titre (optionnel)"
+                    />
+                  )}
+                </>
+              ) : (
+                <>
+                  <h1 className="text-3xl font-semibold leading-tight md:text-4xl">{title}</h1>
+                  {subtitle ? (
+                    <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]/90 md:text-base">
+                      {subtitle}
+                    </p>
+                  ) : null}
+                </>
+              )}
+            </div>
+            {headerChildren}
+          </header>
+        ) : null}
         <ContentTag
           className={combineClasses(
             withBaseContentSpacing ? "space-y-10" : "",

--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -449,6 +449,7 @@ export interface ActivityLayoutOptions {
   headerClassName?: string;
   contentClassName?: string;
   contentAs?: keyof JSX.IntrinsicElements;
+  showHeader?: boolean;
   withLandingGradient?: boolean;
   useDynamicViewportHeight?: boolean;
   withBasePadding?: boolean;
@@ -776,6 +777,7 @@ const SERIALIZABLE_LAYOUT_KEYS: Array<keyof ActivityLayoutOptions> = [
   "headerClassName",
   "contentClassName",
   "contentAs",
+  "showHeader",
   "withLandingGradient",
   "useDynamicViewportHeight",
   "withBasePadding",
@@ -1335,6 +1337,7 @@ function buildBaseLayout(definition: ActivityDefinition): ActivityLayoutConfig {
     headerClassName: definition.layout?.headerClassName,
     contentClassName: definition.layout?.contentClassName,
     contentAs: definition.layout?.contentAs,
+    showHeader: definition.layout?.showHeader ?? false,
     withLandingGradient: definition.layout?.withLandingGradient,
     useDynamicViewportHeight: definition.layout?.useDynamicViewportHeight,
     withBasePadding: definition.layout?.withBasePadding,


### PR DESCRIPTION
## Summary
- ajoute l’option `showHeader` au layout des activités et la désactive par défaut pour masquer le panneau supérieur
- adapte `ActivityLayout` pour afficher le bouton d’édition hors de l’en-tête lorsque celui-ci est masqué

## Testing
- npm --prefix frontend run build *(échoue : dépendance hls.js introuvable dans VideoStep.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d80b5228548322847d48af2e5ff57d