### PR TITLE
Avoid duplicating rich content titles

### DIFF
--- a/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
@@ -173,6 +173,9 @@ export function StepSequenceActivity({
         }
       }
 
+      const shouldShowHeaderTitle =
+        StepComponent.stepSequenceHideTitleInHeader !== true;
+
       return (
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
           <header className="space-y-3 text-center">
@@ -185,7 +188,7 @@ export function StepSequenceActivity({
                 style={{ width: `${progressPercent}%` }}
               />
             </div>
-            {stepTitle ? (
+            {shouldShowHeaderTitle && stepTitle ? (
               <h2 className="text-2xl font-semibold text-slate-900">
                 {stepTitle}
               </h2>

--- a/frontend/src/modules/step-sequence/modules/RichContentStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/RichContentStep.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useCallback, useContext, useMemo } from "react";
 
-import type { StepComponentProps } from "../types";
+import type { StepComponentProps, StepComponentWithMetadata } from "../types";
 import { StepSequenceContext } from "../types";
 
 export interface RichContentMediaItem {
@@ -608,3 +608,5 @@ export function RichContentStep({
     </div>
   );
 }
+
+(RichContentStep as StepComponentWithMetadata).stepSequenceHideTitleInHeader = true;

--- a/frontend/src/modules/step-sequence/types.ts
+++ b/frontend/src/modules/step-sequence/types.ts
@@ -77,6 +77,7 @@ export interface StepSequenceActivityContextBridge {
 export type StepComponentWithMetadata = ComponentType<StepComponentProps> & {
   stepSequenceWrapper?: StepSequenceWrapperPreference;
   stepSequenceLayoutOverrides?: StepSequenceLayoutOverrides;
+  stepSequenceHideTitleInHeader?: boolean;
 };
 
 export type StepRegistry = Record<string, StepComponentWithMetadata>;


### PR DESCRIPTION
## Summary
- add metadata hook so step components can opt out of header title rendering
- mark the rich-content step to hide the shared header title to avoid duplicates

## Testing
- npm run test --prefix frontend *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d82480f2f48322aa6a089d7d0e23e2