### PR TITLE
Déplacer le bouton Mode édition en bas de la page activités

### DIFF
--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -1793,15 +1793,7 @@ function ActivitySelector(): JSX.Element {
             Annuler
           </button>
         </>
-      ) : (
-        <button
-          onClick={() => setEditMode(true)}
-          disabled={isLoading}
-          className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-4 py-2 text-xs font-medium text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {isLoading ? "Chargement..." : "Mode édition"}
-        </button>
-      )}
+      ) : null}
       <Link
         to="/admin"
         className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
@@ -2274,6 +2266,17 @@ function ActivitySelector(): JSX.Element {
         ) : null}
       </div>
       </ActivityLayout>
+      {canShowAdminButton && !isEditMode ? (
+        <div className="flex justify-center px-4 pb-10 sm:px-6">
+          <button
+            onClick={() => setEditMode(true)}
+            disabled={isLoading}
+            className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-5 py-2 text-sm font-semibold text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? "Chargement..." : "Mode édition"}
+          </button>
+        </div>
+      ) : null}
       <AdminModal
         open={Boolean(stepSequenceEditorActivityId)}
         onClose={handleCloseStepSequenceEditor}


### PR DESCRIPTION
## Summary
- retirer le bouton Mode édition des actions de l’en-tête de la page Activités
- ajouter un bouton Mode édition dédié en bas de page, hors du conteneur principal

## Testing
- npm run lint *(échoue : script manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68d8266580108322bd0c3a66218c9090