### PR TITLE
Adjust edit mode controls placement

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -1358,15 +1358,6 @@ export function buildActivityElement(
       user: adminUser,
     } = useAdminAuth();
 
-    const baseDefinition = useMemo(
-      () => resolveActivityDefinition({ id: configEntry.id }),
-      [configEntry.id]
-    );
-    const baseLayout = useMemo(
-      () => buildBaseLayout(baseDefinition),
-      [baseDefinition]
-    );
-
     const [overrides, setOverrides] =
       useState<Partial<ActivityLayoutConfig>>({});
     const [currentDefinition, setCurrentDefinition] = useState<ActivityDefinition>(
@@ -1445,29 +1436,6 @@ export function buildActivityElement(
     const mergedLayout: ActivityLayoutConfig = {
       ...currentBaseLayout,
       ...overrides,
-      actions: canShowAdminButton
-        ? (
-            <div className="flex items-center gap-2">
-              {isEditMode ? (
-                <>
-                  <button
-                    onClick={() => setEditMode(false)}
-                    className="inline-flex items-center justify-center rounded-full border border-red-600/20 bg-red-50 px-4 py-2 text-xs font-medium text-red-700 transition hover:border-red-600/40 hover:bg-red-100"
-                  >
-                    Quitter l'édition
-                  </button>
-                </>
-              ) : (
-                <button
-                  onClick={() => setEditMode(true)}
-                  className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-4 py-2 text-xs font-medium text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100"
-                >
-                  Mode édition
-                </button>
-              )}
-            </div>
-          )
-        : baseLayout.actions,
     };
     const mergedBeforeHeader = mergedLayout.beforeHeader;
 
@@ -1507,6 +1475,21 @@ export function buildActivityElement(
       },
       []
     );
+
+    const editButtonClassName = isEditMode
+      ? "inline-flex items-center justify-center rounded-full border border-red-600/20 bg-red-50 px-4 py-2 text-xs font-medium text-red-700 transition hover:border-red-600/40 hover:bg-red-100"
+      : "inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-4 py-2 text-xs font-medium text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100";
+
+    const adminEditButton = canShowAdminButton ? (
+      <div className="mt-12 flex justify-center">
+        <button
+          onClick={() => setEditMode(!isEditMode)}
+          className={editButtonClassName}
+        >
+          {isEditMode ? "Quitter l'édition" : "Mode édition"}
+        </button>
+      </div>
+    ) : null;
 
     const handleSaveActivity = useCallback(async () => {
       const headerOverrides = extractHeaderOverrides(overrides);
@@ -1621,6 +1604,7 @@ export function buildActivityElement(
             </p>
           </div>
         )}
+        {adminEditButton}
       </ActivityLayout>
     );
   };

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -1793,7 +1793,15 @@ function ActivitySelector(): JSX.Element {
             Annuler
           </button>
         </>
-      ) : null}
+      ) : (
+        <button
+          onClick={() => setEditMode(true)}
+          disabled={isLoading}
+          className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-4 py-2 text-xs font-medium text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isLoading ? "Chargement..." : "Mode édition"}
+        </button>
+      )}
       <Link
         to="/admin"
         className="inline-flex items-center justify-center rounded-full border border-[color:var(--brand-charcoal)]/20 px-4 py-2 text-xs font-medium text-[color:var(--brand-charcoal)] transition hover:border-[color:var(--brand-red)]/40 hover:text-[color:var(--brand-red)]"
@@ -2266,17 +2274,6 @@ function ActivitySelector(): JSX.Element {
         ) : null}
       </div>
       </ActivityLayout>
-      {canShowAdminButton && !isEditMode ? (
-        <div className="flex justify-center px-4 pb-10 sm:px-6">
-          <button
-            onClick={() => setEditMode(true)}
-            disabled={isLoading}
-            className="inline-flex items-center justify-center rounded-full border border-orange-600/20 bg-orange-50 px-5 py-2 text-sm font-semibold text-orange-700 transition hover:border-orange-600/40 hover:bg-orange-100 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {isLoading ? "Chargement..." : "Mode édition"}
-          </button>
-        </div>
-      ) : null}
       <AdminModal
         open={Boolean(stepSequenceEditorActivityId)}
         onClose={handleCloseStepSequenceEditor}

--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -5482,22 +5482,6 @@ export default function ExplorateurIA({
                   <span aria-hidden="true">←</span>
                   <span className="sr-only">Revenir à la liste des activités</span>
                 </button>
-                {canToggleEditMode && (
-                  <button
-                    type="button"
-                    onClick={handleToggleEditMode}
-                    className={classNames(
-                      "flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold shadow-sm backdrop-blur",
-                      isEditMode
-                        ? "border-red-500/30 bg-red-50 text-red-700"
-                        : "border-orange-400/30 bg-orange-50 text-orange-700",
-                      isMobile ? "active:scale-95" : "hover:bg-white/90"
-                    )}
-                    aria-pressed={isEditMode}
-                  >
-                    {isEditMode ? "Quitter l'édition" : "Mode édition"}
-                  </button>
-                )}
                 {isEditMode && (
                   <button
                     type="button"
@@ -6617,6 +6601,25 @@ function ExplorateurIAConfigDesigner({
           })}
         </div>
       </section>
+      {canToggleEditMode ? (
+        <div className="px-4 pb-6 pt-6 sm:px-6">
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleToggleEditMode}
+              className={classNames(
+                "inline-flex items-center justify-center rounded-full border px-5 py-2 text-sm font-semibold transition",
+                isEditMode
+                  ? "border-red-500/30 bg-red-50 text-red-700 hover:border-red-500/50 hover:bg-red-100"
+                  : "border-orange-400/30 bg-orange-50 text-orange-700 hover:border-orange-400/50 hover:bg-orange-100"
+              )}
+              aria-pressed={isEditMode}
+            >
+              {isEditMode ? "Quitter l'édition" : "Mode édition"}
+            </button>
+          </div>
+        </div>
+      ) : null}
       <Modal
         open={Boolean(openQuarter)}
         onClose={handleCloseDesigner}


### PR DESCRIPTION
## Summary
- move the activity selector edit toggle into the header action group with other admin controls
- relocate activity edit mode toggles to the bottom of activity pages, including generic layouts and Explorateur IA

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d8283b814483229f0943878f30aea1