### PR TITLE
Adjust clarity map tiles and remove target shuffle control

### DIFF
--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -44,20 +44,22 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
                 return (
                   <div
                     key={key}
-                    className={`relative border border-white/40 ${
+                    className={`relative overflow-hidden border border-white/40 ${
                       isVisited ? "bg-[color:var(--brand-yellow)]/30" : "bg-white/60"
                     }`}
                   >
                     {isBlocked && (
-                      <span className="absolute inset-0 flex items-center justify-center text-xs text-[color:var(--brand-red)]">🧱</span>
+                      <span className="absolute inset-0 flex items-center justify-center bg-[color:var(--brand-red)]/70 text-sm font-semibold text-white">
+                        🧱
+                      </span>
                     )}
                     {isStart && (
-                      <span className="absolute left-1 top-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]">
+                      <span className="absolute left-1 top-1 z-[1] text-[10px] font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]">
                         Start
                       </span>
                     )}
                     {isTarget && (
-                      <span className="absolute right-1 top-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--brand-red)]">
+                      <span className="absolute right-1 top-1 z-[1] text-[10px] font-semibold uppercase tracking-wide text-[color:var(--brand-red)]">
                         Goal
                       </span>
                     )}

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -626,15 +626,6 @@ export function ClarityMapStep({
     [applyConfigPatch]
   );
 
-  const handleShuffleTarget = useCallback(() => {
-    setTarget((previous) => {
-      const next = createRandomTarget(previous);
-      setBlocked(createRandomObstacles(next, obstacleCount));
-      setRunId(createRunId());
-      return next;
-    });
-  }, [obstacleCount]);
-
   const handleShuffleObstacles = useCallback(() => {
     setBlocked(createRandomObstacles(target, obstacleCount));
     setRunId(createRunId());
@@ -881,13 +872,6 @@ export function ClarityMapStep({
             <ClarityGrid player={playerPosition} target={target} blocked={blocked} visited={visited} />
           </div>
           <div className="flex flex-wrap gap-3">
-            <button
-              type="button"
-              onClick={handleShuffleTarget}
-              className="inline-flex items-center justify-center rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-[color:var(--brand-red)] shadow-sm transition hover:bg-white"
-            >
-              Nouvelle cible
-            </button>
             <button
               type="button"
               onClick={handleShuffleObstacles}


### PR DESCRIPTION
## Summary
- enlarge clarity grid obstacle tiles so the brick indicator fills each cell and keep start/goal labels visible
- remove the "Nouvelle cible" shuffle control from the clarity map step configuration

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: existing duplicate declaration error in ExplorateurIA.tsx and missing hls.js import)*

------
https://chatgpt.com/codex/tasks/task_e_68d82f7852188322a44c82061cc0725b