### PR TITLE
Fix Vite build failure caused by HLS path resolution

### DIFF
--- a/frontend/src/modules/step-sequence/modules/VideoStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/VideoStep.tsx
@@ -54,15 +54,9 @@ type HlsModule = {
 
 type HlsModuleLoader = () => Promise<HlsModule>;
 
-const HLS_DIST_GLOB = import.meta.glob<HlsModule>([
-  "/node_modules/hls.js/dist/hls.mjs",
-  "/node_modules/hls.js/dist/hls.min.mjs",
-  "/node_modules/hls.js/dist/hls.light.mjs",
-]);
-
 const HLS_MODULE_LOADERS: HlsModuleLoader[] = [
-  ...Object.values(HLS_DIST_GLOB),
   () => import("hls.js/dist/hls.mjs") as Promise<HlsModule>,
+  () => import("hls.js/dist/hls.light.mjs") as Promise<HlsModule>,
   () => import(/* @vite-ignore */ "hls.js") as Promise<HlsModule>,
 ];
 


### PR DESCRIPTION
## Summary
- replace the glob-based HLS loader with explicit dynamic imports that Vite can statically resolve
- drop references to non-existent hls.js artefacts so the build no longer fails on missing files

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d848bb26948322a7485f961126342c