### PR TITLE
Remove HLS video playback support

### DIFF
--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -85,7 +85,7 @@ def _strict_object_schema(
     }
 
 
-VIDEO_SOURCE_TYPE_ENUM = ["mp4", "hls", "youtube"]
+VIDEO_SOURCE_TYPE_ENUM = ["mp4", "youtube"]
 
 
 VIDEO_SOURCE_SCHEMA = _strict_object_schema(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "formationia-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "hls.js": "^1.6.13",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.0"
@@ -2920,12 +2919,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/hls.js": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.13.tgz",
-      "integrity": "sha512-hNEzjZNHf5bFrUNvdS4/1RjIanuJ6szpWNfTaX5I6WfGynWXGT7K/YQLYtemSvFExzeMdgdE4SsyVLJbd5PcZA==",
-      "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "hls.js": "^1.6.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0"

--- a/frontend/src/modules/step-sequence/tools.ts
+++ b/frontend/src/modules/step-sequence/tools.ts
@@ -683,7 +683,7 @@ const videoSourceSchema: JsonSchema = {
   additionalProperties: false,
   required: ["type", "url"],
   properties: {
-    type: { type: "string", enum: ["mp4", "hls", "youtube"] },
+    type: { type: "string", enum: ["mp4", "youtube"] },
     url: { type: "string" },
   },
 };

--- a/frontend/tests/step-sequence/tools.test.ts
+++ b/frontend/tests/step-sequence/tools.test.ts
@@ -87,7 +87,6 @@ describe("STEP_SEQUENCE_TOOLS", () => {
       idHint: "video-de-demo",
       sources: [
         { type: "mp4", url: "https://example.com/demo.mp4" },
-        { type: "hls", url: "https://example.com/demo.m3u8" },
       ],
       captions: [
         { src: "https://example.com/demo.vtt", srclang: "fr" },


### PR DESCRIPTION
## Summary
- drop the HLS source type from the StepSequence backend schema and tooling definitions
- simplify the VideoStep component to only manage MP4 files or YouTube embeds and remove the HLS configuration field
- remove the hls.js dependency and update tests to reflect the supported source types

## Testing
- npm run test --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d870cce74c832299fc10bc8f2da48f