### PR TITLE
Adjust video step layout for mobile screens

### DIFF
--- a/frontend/src/modules/step-sequence/modules/VideoStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/VideoStep.tsx
@@ -619,9 +619,9 @@ export function VideoStep({
             </p>
           ) : null}
         </header>
-        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+        <div className="rounded-none border-0 bg-transparent p-0 sm:rounded-lg sm:border sm:bg-slate-50 sm:p-4">
           {youtubeEmbedUrl ? (
-            <div className="relative aspect-video w-full overflow-hidden rounded-md bg-black">
+            <div className="relative aspect-video w-full overflow-hidden rounded-none bg-black sm:rounded-md">
               <iframe
                 key={youtubeEmbedUrl}
                 className="absolute left-0 top-0 h-full w-full"
@@ -636,7 +636,7 @@ export function VideoStep({
           ) : hasVideoElementSource ? (
             <video
               ref={videoRef}
-              className="h-auto w-full rounded-md bg-black"
+              className="h-auto w-full rounded-none bg-black sm:rounded-md"
               controls
               playsInline
               poster={content.poster}


### PR DESCRIPTION
## Summary
- remove padding and rounded container styles on small screens so the video can use the full mobile width
- keep the existing desktop styling by reapplying rounded borders from the small breakpoint upward

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d88191b2048322ae372fef0bba4117