### PR TITLE
Fix Clarity map continue button availability

### DIFF
--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -396,7 +396,19 @@ export function ClarityMapStep({
 }: StepComponentProps): JSX.Element {
   const sequenceContext = useContext(StepSequenceContext);
   const activeStepId = sequenceContext?.steps?.[sequenceContext.stepIndex]?.id;
-  const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
+  const isModuleInActiveComposite = useMemo(() => {
+    if (!sequenceContext || !activeStepId || activeStepId === definition.id) {
+      return false;
+    }
+
+    const modules = sequenceContext.compositeModules?.[activeStepId];
+    if (!Array.isArray(modules)) {
+      return false;
+    }
+
+    return modules.some((module) => module.id === definition.id);
+  }, [activeStepId, definition.id, sequenceContext]);
+  const shouldAutoPublish = Boolean(sequenceContext) && !isModuleInActiveComposite && activeStepId !== definition.id;
   const sequencePayloads = sequenceContext?.payloads ?? null;
   const compositeModules = sequenceContext?.compositeModules ?? null;
 


### PR DESCRIPTION
## Summary
- update the auto-publish detection in the Clarity map step to keep the manual Continue button when the composite step is active

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d88361072c83229213602ba74002b7