### PR TITLE
Adjust simulation chat history layout for mobile

### DIFF
--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -872,7 +872,7 @@ export function SimulationChatStep({
 
         <section className="space-y-6">
           <div className="rounded-3xl border border-white/70 bg-white/90 p-6 shadow-sm">
-            <div className="flex max-h-[60vh] flex-col gap-5 overflow-y-auto pr-2">
+            <div className="flex max-h-none flex-col gap-5 overflow-visible pr-2 lg:max-h-[60vh] lg:overflow-y-auto">
               {historyEntries.map((entry) => {
                 const stageTemplate = activeConfig.stages[entry.stageIndex];
                 return (


### PR DESCRIPTION
## Summary
- let the simulation chat history expand normally on small screens instead of forcing a fixed-height scroll area
- keep the large-screen scrollable layout with responsive overflow and max-height classes

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d88c54125c83228efc075cf259ed38