### PR TITLE
Make clarity map and simulation chat modules non-blocking

### DIFF
--- a/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
@@ -38,11 +38,9 @@ function isCompositeConfig(value: unknown): value is CompositeStepConfig {
 
 const COMPLETION_REQUIRED_COMPONENTS = new Set<string>([
   "form",
-  "simulation-chat",
   "video",
   "prompt-evaluation",
   "ai-comparison",
-  "clarity-map",
   "clarity-prompt",
   "explorateur-world",
   "workshop-context",


### PR DESCRIPTION
## Summary
- remove the clarity map and simulation chat modules from the composite step completion-required list so they no longer block progression

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88d4008708322bafb5016e74882a6