### PR TITLE
feat: allow hiding developer instructions in prompt evaluation step

### DIFF
--- a/frontend/src/modules/step-sequence/tools.ts
+++ b/frontend/src/modules/step-sequence/tools.ts
@@ -1073,6 +1073,7 @@ const CLARITY_START_POSITION = { x: 0, y: 0 } as const;
 interface CreatePromptEvaluationStepInput extends ToolBaseInput {
   defaultText?: string;
   developerMessage?: string;
+  showDeveloperMessage?: boolean;
   model?: string;
   verbosity?: VerbosityChoice;
   thinking?: ThinkingChoice;
@@ -1100,6 +1101,7 @@ const createPromptEvaluationStep: StepSequenceFunctionTool<
         },
         defaultText: { type: "string" },
         developerMessage: { type: "string" },
+        showDeveloperMessage: { type: "boolean" },
         model: { type: "string" },
         verbosity: { type: "string", enum: Array.from(VERBOSITY_CHOICES) },
         thinking: { type: "string", enum: Array.from(THINKING_CHOICES) },
@@ -1116,6 +1118,10 @@ const createPromptEvaluationStep: StepSequenceFunctionTool<
       DEFAULT_PROMPT_EVALUATION_DEVELOPER,
       { allowEmpty: false }
     );
+    const showDeveloperMessage =
+      typeof input.showDeveloperMessage === "boolean"
+        ? input.showDeveloperMessage
+        : true;
     const model = sanitizeString(input.model, DEFAULT_MODEL, { allowEmpty: false });
     const verbosity =
       typeof input.verbosity === "string" && VERBOSITY_CHOICES.has(input.verbosity)
@@ -1129,6 +1135,7 @@ const createPromptEvaluationStep: StepSequenceFunctionTool<
     const config: PromptEvaluationStepConfig = {
       defaultText,
       developerMessage,
+      showDeveloperMessage,
       model,
       verbosity,
       thinking,


### PR DESCRIPTION
## Summary
- add a configuration toggle so editors can hide the developer message card while keeping the system prompt active
- remove the in-step comment block and manual continue button while wiring a manual advance handler for payload persistence
- extend the prompt evaluation step tool to accept the new visibility flag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d88ced30cc83228a8b70a8effd4e46