### PR TITLE
Fix Prompt Evaluation Step manual advance handler initialization order

### DIFF
--- a/frontend/src/modules/step-sequence/modules/PromptEvaluationStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/PromptEvaluationStep.tsx
@@ -214,6 +214,8 @@ export function PromptEvaluationStep({
   const context = useContext(StepSequenceContext);
   const effectiveOnUpdateConfig = context?.onUpdateConfig ?? onUpdateConfig;
   const isDesigner = context?.isEditMode ?? isEditMode;
+  const setManualAdvanceHandler = context?.setManualAdvanceHandler;
+  const setManualAdvanceDisabled = context?.setManualAdvanceDisabled;
 
   const typedConfig = useMemo(() => normalizeConfig(config), [config]);
   const { onChange, ...content } = typedConfig;
@@ -412,8 +414,6 @@ export function PromptEvaluationStep({
 
   const promptFieldId = `${definition.id}-prompt`;
   const developerFieldId = `${definition.id}-developer-message`;
-  const setManualAdvanceHandler = context?.setManualAdvanceHandler;
-  const setManualAdvanceDisabled = context?.setManualAdvanceDisabled;
 
   const configIds = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- récupère les gestionnaires de progression manuelle du contexte avant de les utiliser pour éviter l'écran blanc de l'étape d'évaluation de prompt

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d90425e2fc83229f01aae1d6122a94