### PR TITLE
Ensure clarity map composites no longer block progression

### DIFF
--- a/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/CompositeStep.tsx
@@ -86,11 +86,13 @@ export function CompositeStep({
   onUpdateConfig,
 }: StepComponentProps): JSX.Element | null {
   const parentContext = useContext(StepSequenceContext);
-  const supportsGlobalContinue = Boolean(
+  const hasManualAdvanceBridge = Boolean(
     parentContext?.setManualAdvanceHandler &&
       parentContext?.setManualAdvanceDisabled &&
       parentContext?.getManualAdvanceState
   );
+  const supportsGlobalContinue =
+    hasManualAdvanceBridge && Boolean(parentContext?.activityContext);
 
   const compositeConfig = useMemo(() => {
     if (isCompositeConfig(config)) {

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -396,9 +396,28 @@ export function ClarityMapStep({
 }: StepComponentProps): JSX.Element {
   const sequenceContext = useContext(StepSequenceContext);
   const activeStepId = sequenceContext?.steps?.[sequenceContext.stepIndex]?.id;
-  const shouldAutoPublish = Boolean(sequenceContext) && activeStepId !== definition.id;
   const sequencePayloads = sequenceContext?.payloads ?? null;
   const compositeModules = sequenceContext?.compositeModules ?? null;
+
+  const isInsideComposite = useMemo(() => {
+    if (!compositeModules) {
+      return false;
+    }
+
+    for (const modules of Object.values(compositeModules)) {
+      if (!Array.isArray(modules)) {
+        continue;
+      }
+      if (modules.some((module) => module.id === definition.id)) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [compositeModules, definition.id]);
+
+  const shouldAutoPublish =
+    Boolean(sequenceContext) && (activeStepId !== definition.id || isInsideComposite);
 
   const detectedPromptStepId = useMemo(() => {
     if (!compositeModules) {

--- a/frontend/tests/step-sequence/ClarityMapStep.test.tsx
+++ b/frontend/tests/step-sequence/ClarityMapStep.test.tsx
@@ -166,6 +166,48 @@ describe("ClarityMapStep", () => {
     });
   });
 
+  it("publishes automatically inside a composite even when sharing the active step id", async () => {
+    const onAdvance = vi.fn();
+    const sharedId = "shared-step";
+    const props: StepComponentProps = {
+      definition: { id: sharedId, component: "clarity-map" },
+      config: { obstacleCount: 0, allowInstructionInput: true },
+      payload: undefined,
+      isActive: true,
+      isEditMode: false,
+      onAdvance,
+      onUpdateConfig: vi.fn(),
+    };
+
+    const compositeContext = {
+      stepIndex: 0,
+      stepCount: 1,
+      steps: [
+        { id: sharedId, component: "composite", composite: { modules: [] } },
+      ],
+      payloads: {},
+      isEditMode: false,
+      onAdvance: vi.fn(),
+      onUpdateConfig: vi.fn(),
+      goToStep: vi.fn(),
+      compositeModules: {
+        [sharedId]: [
+          { id: sharedId, component: "clarity-map", slot: "main", config: null },
+        ],
+      },
+    };
+
+    render(
+      <StepSequenceContext.Provider value={compositeContext}>
+        <ClarityMapStep {...props} />
+      </StepSequenceContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(onAdvance).toHaveBeenCalled();
+    });
+  });
+
   it("affiche la commande reçue depuis le module prompt configuré", () => {
     const mapPayload: ClarityMapStepPayload = {
       runId: "run-shared",


### PR DESCRIPTION
## Summary
- ensure the Clarity map module auto-publishes when nested in a composite even if it reuses the parent step id
- avoid hiding the composite fallback Continue button when no global manual-advance UI is available
- add a regression test covering composite auto-publication with a shared step id

## Testing
- npm --prefix frontend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d9034f596c8322869c832f836fd8e0