### PR TITLE
Improve simulation chat menu responsiveness

### DIFF
--- a/frontend/src/components/GuidedFields.tsx
+++ b/frontend/src/components/GuidedFields.tsx
@@ -311,7 +311,26 @@ function GuidedFields({
                   </label>
                   <span className="text-xs text-[color:var(--brand-charcoal)]/80">1 à 4 mots par plat</span>
                 </div>
-                <div className="w-full overflow-hidden rounded-2xl border border-slate-200">
+                <div className="flex flex-col gap-3 md:hidden">
+                  {meals.map((meal) => (
+                    <div key={meal} className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+                      <p className="text-[0.7rem] font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+                        {meal}
+                      </p>
+                      <input
+                        type="text"
+                        value={current[meal] ?? ""}
+                        onChange={(event) => {
+                          onChange(field.id, { ...current, [meal]: event.target.value });
+                        }}
+                        maxLength={80}
+                        className="mt-2 w-full rounded-2xl border border-slate-200 px-4 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none"
+                        placeholder="Plat"
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="hidden w-full overflow-hidden rounded-2xl border border-slate-200 md:block">
                   <table className="min-w-full divide-y divide-slate-200 text-sm">
                     <tbody>
                       {meals.map((meal) => (
@@ -351,7 +370,49 @@ function GuidedFields({
                   </label>
                   <span className="text-xs text-[color:var(--brand-charcoal)]/80">1 à 4 mots par cellule</span>
                 </div>
-                <div className="w-full overflow-hidden rounded-2xl border border-slate-200">
+                <div className="flex flex-col gap-3 md:hidden">
+                  {meals.map((meal) => {
+                    const value: TableMenuFullMealValue = current[meal] ?? {
+                      plat: "",
+                      boisson: "",
+                      dessert: "",
+                    };
+                    return (
+                      <div key={meal} className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+                        <p className="text-[0.7rem] font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
+                          {meal}
+                        </p>
+                        <div className="mt-2 space-y-3 text-sm">
+                          {(["plat", "boisson", "dessert"] as const).map((column) => (
+                            <label
+                              key={column}
+                              className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70"
+                            >
+                              {column.charAt(0).toUpperCase() + column.slice(1)}
+                              <input
+                                type="text"
+                                value={value[column]}
+                                onChange={(event) => {
+                                  onChange(field.id, {
+                                    ...current,
+                                    [meal]: {
+                                      ...value,
+                                      [column]: event.target.value,
+                                    },
+                                  });
+                                }}
+                                maxLength={80}
+                                className="rounded-2xl border border-slate-200 px-4 py-2 text-sm focus:border-[color:var(--brand-red)] focus:outline-none"
+                                placeholder={column.charAt(0).toUpperCase() + column.slice(1)}
+                              />
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="hidden w-full overflow-hidden rounded-2xl border border-slate-200 md:block">
                   <table className="min-w-full divide-y divide-slate-200 text-sm">
                     <thead className="bg-slate-50 text-xs uppercase tracking-wide text-[color:var(--brand-charcoal)]">
                       <tr>

--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -727,6 +727,68 @@ export const ACTIVITY_CATALOG: Record<string, ActivityCatalogEntry> = {
       ],
     },
   },
+  "simulation-menu": {
+    componentKey: "step-sequence",
+    path: "/simulation-menu",
+    defaults: {
+      completionId: "simulation-menu",
+      enabled: true,
+      header: {
+        eyebrow: "Simulation menus",
+        title: "Compose un menu complet sans défilement",
+        subtitle:
+          "Teste la mise en forme du chat de simulation avec un tableau de menus afin de vérifier son rendu sur mobile.",
+        badge: "Étape unique",
+      },
+      layout: {
+        activityId: "simulation-menu",
+        headerClassName: "space-y-6",
+        contentClassName: "space-y-8",
+      },
+      card: {
+        title: "Simulation menu du jour",
+        description:
+          "Objectif : discuter avec le chef IA et valider un tableau de menus complet, sans débordement sur mobile.",
+        highlights: [
+          "Brief en contexte restauration",
+          "Tableau menu plat / boisson / dessert",
+          "Interface de simulation en une étape",
+        ],
+        cta: {
+          label: "Tester la simulation",
+          to: "/simulation-menu",
+        },
+      },
+      stepSequence: [
+        {
+          id: "simulation-menu:chat",
+          component: "simulation-chat",
+          config: {
+            title: "Simulation menu complet",
+            help:
+              "Échange avec le chef virtuel et complète le tableau pour valider chaque repas de la journée.",
+            roles: { ai: "Chef IA", user: "Participant" },
+            stages: [
+              {
+                id: "simulation-menu:stage-1",
+                prompt:
+                  "Le chef IA te propose un menu initial. Ajuste-le si nécessaire et renvoie la version finale dans le tableau ci-dessous.",
+                allowEmpty: false,
+                fields: [
+                  {
+                    id: "menu-jour",
+                    label: "Menu du jour",
+                    type: "table_menu_full",
+                    meals: ["Petit-déjeuner", "Déjeuner", "Dîner"],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
 };
 
 export interface ActivityCardOverrides

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -303,48 +303,84 @@ function renderHistoryValue(field: FieldSpec, value: unknown): JSX.Element | nul
     case "table_menu_day": {
       const table = (value as TableMenuDayValue) ?? {};
       return (
-        <table className="mt-3 min-w-full divide-y divide-white/20 text-xs">
-          <tbody>
+        <div className="mt-3 text-xs">
+          <div className="flex flex-col gap-3 md:hidden">
             {field.meals.map((meal) => (
-              <tr key={meal} className="divide-x divide-white/10">
-                <th className="bg-white/10 px-3 py-2 text-left font-semibold uppercase tracking-wide">
-                  {meal}
-                </th>
-                <td className="px-3 py-2">{table[meal] ?? "—"}</td>
-              </tr>
+              <div key={meal} className="rounded-2xl bg-white/5 p-3">
+                <p className="text-[0.6rem] font-semibold uppercase tracking-wide text-white/70">{meal}</p>
+                <p className="mt-2 whitespace-pre-wrap break-words text-sm text-white">{table[meal] ?? "—"}</p>
+              </div>
             ))}
-          </tbody>
-        </table>
+          </div>
+          <table className="hidden w-full divide-y divide-white/20 md:table">
+            <tbody>
+              {field.meals.map((meal) => (
+                <tr key={meal} className="divide-x divide-white/10">
+                  <th className="bg-white/10 px-3 py-2 text-left font-semibold uppercase tracking-wide align-top">
+                    {meal}
+                  </th>
+                  <td className="px-3 py-2 whitespace-pre-wrap break-words text-sm">{table[meal] ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       );
     }
     case "table_menu_full": {
       const table = (value as TableMenuFullValue) ?? {};
       return (
-        <table className="mt-3 min-w-full divide-y divide-white/20 text-xs">
-          <thead className="bg-white/10">
-            <tr>
-              <th className="px-3 py-2 text-left">Repas</th>
-              <th className="px-3 py-2 text-left">Plat</th>
-              <th className="px-3 py-2 text-left">Boisson</th>
-              <th className="px-3 py-2 text-left">Dessert</th>
-            </tr>
-          </thead>
-          <tbody>
+        <div className="mt-3 text-xs">
+          <div className="flex flex-col gap-3 md:hidden">
             {field.meals.map((meal) => {
               const row = table[meal] ?? { plat: "—", boisson: "—", dessert: "—" };
               return (
-                <tr key={meal} className="divide-x divide-white/10">
-                  <th className="bg-white/10 px-3 py-2 text-left font-semibold uppercase tracking-wide">
-                    {meal}
-                  </th>
-                  <td className="px-3 py-2">{row.plat || "—"}</td>
-                  <td className="px-3 py-2">{row.boisson || "—"}</td>
-                  <td className="px-3 py-2">{row.dessert || "—"}</td>
-                </tr>
+                <div key={meal} className="rounded-2xl bg-white/5 p-3">
+                  <p className="text-[0.6rem] font-semibold uppercase tracking-wide text-white/70">{meal}</p>
+                  <dl className="mt-2 space-y-2 text-sm text-white">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-white/60">Plat</dt>
+                      <dd className="mt-1 whitespace-pre-wrap break-words">{row.plat || "—"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-white/60">Boisson</dt>
+                      <dd className="mt-1 whitespace-pre-wrap break-words">{row.boisson || "—"}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-white/60">Dessert</dt>
+                      <dd className="mt-1 whitespace-pre-wrap break-words">{row.dessert || "—"}</dd>
+                    </div>
+                  </dl>
+                </div>
               );
             })}
-          </tbody>
-        </table>
+          </div>
+          <table className="hidden w-full divide-y divide-white/20 md:table">
+            <thead className="bg-white/10">
+              <tr>
+                <th className="px-3 py-2 text-left align-top">Repas</th>
+                <th className="px-3 py-2 text-left align-top">Plat</th>
+                <th className="px-3 py-2 text-left align-top">Boisson</th>
+                <th className="px-3 py-2 text-left align-top">Dessert</th>
+              </tr>
+            </thead>
+            <tbody>
+              {field.meals.map((meal) => {
+                const row = table[meal] ?? { plat: "—", boisson: "—", dessert: "—" };
+                return (
+                  <tr key={meal} className="divide-x divide-white/10">
+                    <th className="bg-white/10 px-3 py-2 text-left font-semibold uppercase tracking-wide align-top">
+                      {meal}
+                    </th>
+                    <td className="px-3 py-2 whitespace-pre-wrap break-words text-sm">{row.plat || "—"}</td>
+                    <td className="px-3 py-2 whitespace-pre-wrap break-words text-sm">{row.boisson || "—"}</td>
+                    <td className="px-3 py-2 whitespace-pre-wrap break-words text-sm">{row.dessert || "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       );
     }
     case "textarea_with_counter":


### PR DESCRIPTION
## Summary
- render table_menu_day and table_menu_full inputs as stacked cards on mobile to eliminate horizontal scrolling in the simulation chat activity while preserving desktop tables

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d903df6bac8322b6411d634656be9c