### PR TITLE
Replace global activities with StepSequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Chaque page d’activité notifie désormais le backend via `POST /api/progress/
 - Les missions « Clarté d’abord » enregistrent aussi les réponses stade par stade (`POST /api/submit`) afin qu’un run puisse être repris ultérieurement.
 - `GET /api/progress` fournit l’état courant (utilisé sur l’écran `ActivitySelector` pour afficher un crochet vert).
 
-Lorsque l’activité est validée, le frontend déclenche automatiquement `POST /api/lti/score` (si une session LTI est active) pour envoyer un score « 1/1 » dans le carnet de notes de la plateforme. Chaque activité (« Parcours de la clarté », « Prompt Dojo », « Clarté d’abord », Atelier comparatif) renvoie ainsi son résultat au LMS pour alimenter le suivi global des apprenants.
+Lorsque l’activité est validée, le frontend déclenche automatiquement `POST /api/lti/score` (si une session LTI est active) pour envoyer un score « 1/1 » dans le carnet de notes de la plateforme. Le parcours StepSequence renvoie ainsi son résultat au LMS pour alimenter le suivi des apprenants.
 
 ## Lancer sans Docker
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -778,36 +778,15 @@ _PROGRESS_COOKIE_MAX_AGE = int(os.getenv("PROGRESS_COOKIE_MAX_AGE", str(365 * 24
 
 DEEP_LINK_ACTIVITIES: list[dict[str, Any]] = [
     {
-        "id": "atelier",
-        "title": "Atelier comparatif IA",
-        "description": "Comparer deux configurations de modèle et produire une synthèse finale.",
-        "route": "/atelier/etape-1",
-        "scoreMaximum": 1.0,
-    },
-    {
-        "id": "prompt-dojo",
-        "title": "Prompt Dojo — Mission débutant",
-        "description": "Affiner un prompt à travers une mission progressive et soumettre un score IA.",
-        "route": "/prompt-dojo",
-        "scoreMaximum": 1.0,
-    },
-    {
-        "id": "clarity",
-        "title": "Parcours de la clarté",
-        "description": "Tester la précision d’une consigne sur une grille 10×10 en temps réel.",
-        "route": "/parcours-clarte",
-        "scoreMaximum": 1.0,
-    },
-    {
-        "id": "clarte-dabord",
-        "title": "Clarté d’abord !",
-        "description": "Explorer trois manches guidées pour révéler la checklist idéale.",
-        "route": "/clarte-dabord",
+        "id": "stepsequence",
+        "title": "StepSequence",
+        "description": "Préparer, explorer et synthétiser un projet IA en trois étapes guidées.",
+        "route": "/stepsequence/etape-1",
         "scoreMaximum": 1.0,
     },
 ]
 _DEEP_LINK_ACTIVITY_MAP = {item["id"]: item for item in DEEP_LINK_ACTIVITIES}
-MAX_DEEP_LINK_SELECTION = 4
+MAX_DEEP_LINK_SELECTION = 1
 
 app.add_middleware(
     CORSMiddleware,

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -16,9 +16,9 @@ interface LayoutProps {
 }
 
 const STEPS = [
-  { number: 1, label: "Préparer", path: "/atelier/etape-1" },
-  { number: 2, label: "Explorer", path: "/atelier/etape-2" },
-  { number: 3, label: "Synthétiser", path: "/atelier/etape-3" },
+  { number: 1, label: "Préparer", path: "/stepsequence/etape-1" },
+  { number: 2, label: "Explorer", path: "/stepsequence/etape-2" },
+  { number: 3, label: "Synthétiser", path: "/stepsequence/etape-3" },
 ];
 
 function Layout({ currentStep }: LayoutProps): JSX.Element {

--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -11,11 +11,7 @@ import { useNavigate } from "react-router-dom";
 import ActivityLayout from "../components/ActivityLayout";
 import { admin, activities as activitiesClient } from "../api";
 import { useAdminAuth } from "../providers/AdminAuthProvider";
-import ClarityPath from "../pages/ClarityPath";
-import ClarteDabord from "../pages/ClarteDabord";
-import PromptDojo from "../pages/PromptDojo";
-import WorkshopExperience from "../pages/WorkshopExperience";
-import ExplorateurIA from "../pages/ExplorateurIA";
+import StepSequence from "../pages/WorkshopExperience";
 
 export interface ActivityHeaderConfig {
   eyebrow: string;
@@ -66,11 +62,7 @@ export interface ActivityProps {
 }
 
 export const COMPONENT_REGISTRY = {
-  "workshop-experience": WorkshopExperience,
-  "prompt-dojo": PromptDojo,
-  "clarity-path": ClarityPath,
-  "clarte-dabord": ClarteDabord,
-  "explorateur-ia": ExplorateurIA,
+  stepsequence: StepSequence,
 } as const satisfies Record<string, ComponentType<ActivityProps>>;
 
 export type ActivityComponentKey = keyof typeof COMPONENT_REGISTRY;
@@ -90,165 +82,36 @@ interface ActivityCatalogEntry {
 }
 
 export const ACTIVITY_CATALOG: Record<string, ActivityCatalogEntry> = {
-  atelier: {
-    componentKey: "workshop-experience",
-    path: "/atelier/*",
+  stepsequence: {
+    componentKey: "stepsequence",
+    path: "/stepsequence/*",
     defaults: {
-      completionId: "atelier",
+      completionId: "stepsequence",
       enabled: true,
       header: {
-        eyebrow: "Atelier comparatif IA",
-        title: "Cadrez, comparez, synthétisez vos essais IA",
+        eyebrow: "Parcours StepSequence",
+        title: "Construisez vos analyses IA en trois étapes guidées",
         subtitle:
-          "Suivez une progression claire pour préparer votre contexte, explorer deux profils IA en flux continu puis transformer les sorties en ressources réutilisables.",
-        badge: "Trois étapes guidées",
+          "Préparez votre contexte, comparez deux profils IA en flux continu puis transformez les résultats en synthèse réutilisable.",
+        badge: "Séquence pas à pas",
       },
       layout: {
-        activityId: "atelier",
+        activityId: "stepsequence",
         headerClassName: "space-y-8",
         contentClassName: "space-y-12",
       },
       card: {
-        title: "Atelier comparatif IA",
+        title: "StepSequence — Parcours guidé IA",
         description:
-          "Objectif : cadrer ta demande, comparer deux configurations IA et capitaliser sur les essais.",
+          "Objectif : cadrer la demande, tester deux configurations IA puis assembler une synthèse exploitable.",
         highlights: [
-          "Définir le contexte et les attentes",
-          "Tester modèle, verbosité et raisonnement",
-          "Assembler une synthèse réutilisable",
+          "Étape 1 : cadrer le contexte et les attentes",
+          "Étape 2 : comparer deux profils IA en temps réel",
+          "Étape 3 : structurer et exporter la synthèse finale",
         ],
         cta: {
-          label: "Lancer l’atelier",
-          to: "/atelier/etape-1",
-        },
-      },
-    },
-  },
-  "prompt-dojo": {
-    componentKey: "prompt-dojo",
-    path: "/prompt-dojo",
-    defaults: {
-      enabled: true,
-      header: {
-        eyebrow: "Prompt Dojo",
-        title: "Affûte ton prompt mission par mission",
-        subtitle:
-          "Choisis un défi parmi les missions et franchis les étapes pour décrocher ton badge en atteignant le score IA visé.",
-        badge: "Mode entraînement",
-      },
-      layout: {
-        contentAs: "div",
-        contentClassName: "gap-0",
-      },
-      card: {
-        title: "Prompt Dojo — Mission débutant",
-        description:
-          "Objectif : t’entraîner à affiner une consigne en suivant des défis progressifs.",
-        highlights: [
-          "Défis à difficulté graduelle",
-          "Retour immédiat sur la qualité du prompt",
-          "Construction d’une version finale personnalisée",
-        ],
-        cta: {
-          label: "Entrer dans le dojo",
-          to: "/prompt-dojo",
-        },
-      },
-    },
-  },
-  clarity: {
-    componentKey: "clarity-path",
-    path: "/parcours-clarte",
-    defaults: {
-      enabled: true,
-      header: {
-        eyebrow: "Parcours de la clarté",
-        title: "Guide le bonhomme avec une consigne limpide",
-        subtitle:
-          "Écris une instruction en langue naturelle. Le backend demande au modèle gpt-5-nano un plan complet, valide la trajectoire puis te montre l’exécution pas à pas.",
-        badge: "Mode jeu",
-      },
-      layout: {
-        innerClassName: "relative",
-        contentAs: "div",
-        contentClassName: "gap-10",
-      },
-      card: {
-        title: "Parcours de la clarté",
-        description:
-          "Objectif : expérimenter la précision des consignes sur un parcours 10×10.",
-        highlights: [
-          "Plan d’action IA généré avant l’animation",
-          "Visualisation pas à pas avec obstacles",
-          "Analyse des tentatives et du surcoût",
-        ],
-        cta: {
-          label: "Tester la clarté",
-          to: "/parcours-clarte",
-        },
-      },
-    },
-  },
-  "clarte-dabord": {
-    componentKey: "clarte-dabord",
-    path: "/clarte-dabord",
-    defaults: {
-      enabled: true,
-      header: {
-        eyebrow: "Clarté d'abord !",
-        title: "Identifie ce qu'il fallait dire dès la première consigne",
-        subtitle:
-          "Tu joues l'IA : l'usager précise son besoin manche après manche. Observe ce qui manquait au brief initial et retiens la checklist idéale.",
-        badge: "Trois manches guidées",
-      },
-      layout: {
-        contentAs: "div",
-        contentClassName: "gap-10",
-      },
-      card: {
-        title: "Clarté d’abord !",
-        description:
-          "Objectif : mesurer l’impact d’un brief incomplet et révéler la checklist idéale.",
-        highlights: [
-          "Deux missions thématiques en trois manches",
-          "Champs guidés avec validations pédagogiques",
-          "Révélation finale et export JSON du menu",
-        ],
-        cta: {
-          label: "Lancer Clarté d’abord !",
-          to: "/clarte-dabord",
-        },
-      },
-    },
-  },
-  "explorateur-ia": {
-    componentKey: "explorateur-ia",
-    path: "/explorateur-ia",
-    defaults: {
-      completionId: "explorateur-ia",
-      enabled: true,
-      header: {
-        eyebrow: "Activité 5",
-        title: "L’Explorateur IA",
-        subtitle:
-          "Parcours une mini-ville façon Game Boy pour valider quatre compétences IA sans jamais taper au clavier.",
-        badge: "Ville interactive",
-      },
-      layout: {
-        contentClassName: "space-y-12",
-      },
-      card: {
-        title: "L’Explorateur IA",
-        description:
-          "Objectif : compléter un parcours ludique mêlant quiz, drag-and-drop, décisions et dilemmes éthiques.",
-        highlights: [
-          "Déplacements façon jeu vidéo et interactions à la souris",
-          "Quatre mini-activités pédagogiques sans saisie de texte",
-          "Export JSON immédiat et impression PDF du bilan",
-        ],
-        cta: {
-          label: "Entrer dans la ville",
-          to: "/explorateur-ia",
+          label: "Démarrer StepSequence",
+          to: "/stepsequence/etape-1",
         },
       },
     },

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -24,11 +24,11 @@ import { useAdminAuth } from "../providers/AdminAuthProvider";
 const ADMIN_ROLES = ["admin", "superadmin", "administrator"];
 
 const DEFAULT_ACTIVITY_SELECTOR_HEADER: ActivitySelectorHeaderConfig = {
-  eyebrow: "Choisis ton activité",
-  title: "Quelle compétence veux-tu travailler avec l'IA ?",
+  eyebrow: "Accès direct",
+  title: "Lance StepSequence pour orchestrer ta collaboration IA",
   subtitle:
-    "Chaque activité se concentre sur une intention distincte : cadrer une demande, affiner un prompt, tester une consigne ou vérifier l'exhaustivité d'un brief.",
-  badge: "Objectifs pédagogiques",
+    "Prépare le contexte, compare deux profils IA puis assemble une synthèse exploitable : tout est guidé étape par étape.",
+  badge: "Parcours unique",
 };
 
 const sanitizeHeaderConfig = (

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -6,32 +6,32 @@ import { useLTI } from "../hooks/useLTI";
 
 const heroHighlights = [
   {
-    title: "Ateliers guidés",
+    title: "Séquence unique",
     description:
-      "Quatre parcours prêts à l'emploi pour cadrer une demande, tester des prompts ou clarifier une consigne d'évaluation.",
+      "StepSequence guide l'apprenant de la préparation du contexte à la synthèse finale en trois étapes coordonnées.",
   },
   {
     title: "Accompagnement humain",
     description:
-      "Chaque activité contient des repères pédagogiques et des rappels méthodologiques pour garder l'esprit critique face à l'IA.",
+      "Le parcours est ponctué de repères pédagogiques pour cultiver l'esprit critique face aux suggestions de l'IA.",
   },
 ];
 
 const featureCards = [
   {
-    title: "Clarté d'abord",
+    title: "Étape 1 — Préparer",
     description:
-      "Formalisez votre intention pédagogique en quelques étapes. L'interface suggère des formulations clés pour cadrer l'IA et éviter les dérives.",
+      "Cadrez la demande et identifiez les attentes clés : StepSequence vérifie la clarté du contexte partagé à l'IA.",
   },
   {
-    title: "Prompt Dojo",
+    title: "Étape 2 — Explorer",
     description:
-      "Comparez plusieurs prompts et mesurez leur impact. Les pistes d'amélioration sont affichées à chaque itération pour ancrer les bonnes pratiques.",
+      "Comparez deux profils IA en flux continu et observez leurs réponses côte à côte pour éclairer vos choix.",
   },
   {
-    title: "Parcours de la clarté",
+    title: "Étape 3 — Synthétiser",
     description:
-      "Un environnement ludique qui confronte l'étudiant à des cas ambigus et l'aide à cartographier ses choix argumentés.",
+      "Assemblez une synthèse réutilisable, exportable et argumentée pour capitaliser sur vos essais IA.",
   },
 ];
 
@@ -44,12 +44,12 @@ const integrationHighlights = [
   {
     title: "Deep Linking simplifié",
     description:
-      "Insérez une activité Formation IA dans n'importe quel cours Moodle en deux clics. Les paramètres sont transmis automatiquement à vos étudiants.",
+      "Insérez StepSequence dans n'importe quel cours Moodle en deux clics. Les paramètres sont transmis automatiquement à vos étudiants.",
   },
   {
     title: "Suivi des parcours",
     description:
-      "Remontez les traces d'apprentissage dans Moodle : achèvements, activités consultées et progression par atelier.",
+      "Remontez les traces d'apprentissage dans Moodle : achèvements, séquence consultée et progression détaillée.",
   },
 ];
 
@@ -62,12 +62,12 @@ const onboardingSteps = [
   {
     title: "Partager via Deep Link",
     description:
-      "Depuis un cours, utilisez l'insertion LTI pour sélectionner l'activité désirée et personnaliser son intitulé.",
+      "Depuis un cours, utilisez l'insertion LTI pour sélectionner StepSequence et personnaliser son intitulé.",
   },
   {
     title: "Accompagner la cohorte",
     description:
-      "Les apprenants accèdent instantanément aux parcours guidés et bénéficient des repères pédagogiques intégrés.",
+      "Les apprenants accèdent instantanément au parcours guidé et bénéficient des repères pédagogiques intégrés.",
   },
 ];
 
@@ -100,7 +100,7 @@ function LandingPage(): JSX.Element {
               to="/activites"
               className="rounded-full border border-white/60 bg-white/60 px-4 py-2 transition hover:bg-white"
             >
-              Parcours disponibles
+              StepSequence
             </Link>
             <a
               href="#integrations"
@@ -121,14 +121,14 @@ function LandingPage(): JSX.Element {
                 Plateforme pédagogique
               </span>
               <h1 className="text-4xl font-semibold leading-tight md:text-5xl">
-                L'atelier pour apprendre à collaborer avec l'IA, pensé pour la formation supérieure.
+                StepSequence : l'atelier pour apprendre à collaborer avec l'IA en formation supérieure.
               </h1>
               <p className="text-base leading-relaxed text-[color:var(--brand-charcoal)]">
-                Formation IA accompagne enseignants et apprenants dans la découverte responsable de l'intelligence artificielle générative. Chaque activité combine une progression scénarisée, des repères pédagogiques et des espaces de réflexion.
+                Formation IA accompagne enseignants et apprenants dans la découverte responsable de l'intelligence artificielle générative. Le parcours StepSequence combine narration, repères pédagogiques et espaces de réflexion pour ancrer les bonnes pratiques.
               </p>
               <div className="flex flex-col gap-3 sm:flex-row">
                 <Link to="/activites" className="cta-button cta-button--primary">
-                  Explorer les activités
+                  Découvrir StepSequence
                 </Link>
                 <Link to="/connexion" className="cta-button cta-button--light">
                   Se connecter ou activer via Moodle
@@ -190,13 +190,13 @@ function LandingPage(): JSX.Element {
           >
             <div className="space-y-3">
               <span className="brand-chip bg-[color:var(--brand-black)] text-white">
-                Parcours immersifs
+                Parcours StepSequence
               </span>
               <h2 className="text-3xl font-semibold leading-tight">
-                Des expériences prêtes à l'emploi pour apprivoiser l'IA en classe.
+                Un chemin unique pour apprivoiser l'IA en classe.
               </h2>
               <p className="text-sm leading-relaxed text-[color:var(--brand-charcoal)]">
-                Chaque activité propose une narration, des exemples annotés et des espaces d'analyse afin de faire émerger la stratégie numérique propre à votre établissement.
+                StepSequence offre une narration continue, des exemples annotés et des espaces d'analyse pour ancrer la stratégie numérique propre à votre établissement.
               </p>
             </div>
             <div className="grid gap-4 md:grid-cols-3">
@@ -212,7 +212,7 @@ function LandingPage(): JSX.Element {
                     {card.description}
                   </p>
                   <div className="mt-auto flex items-center gap-2 text-sm font-semibold text-[color:var(--brand-red)]">
-                    <span aria-hidden="true">→</span> Disponible dans le catalogue
+                    <span aria-hidden="true">→</span> Intégré à StepSequence
                   </div>
                 </article>
               ))}

--- a/frontend/src/pages/StepOne.tsx
+++ b/frontend/src/pages/StepOne.tsx
@@ -57,7 +57,7 @@ function StepOne({ sourceText, onSourceTextChange }: StepOneProps): JSX.Element 
             </div>
             <button
               type="button"
-              onClick={() => navigate("/atelier/etape-2")}
+              onClick={() => navigate("/stepsequence/etape-2")}
               className="cta-button cta-button--primary"
             >
               Passer à l'étape 2

--- a/frontend/src/pages/StepTwo.tsx
+++ b/frontend/src/pages/StepTwo.tsx
@@ -37,7 +37,7 @@ function StepTwo({
 
   useEffect(() => {
     if (!sourceText.trim()) {
-      navigate("/atelier/etape-1", { replace: true });
+      navigate("/stepsequence/etape-1", { replace: true });
     }
   }, [navigate, sourceText]);
 
@@ -135,7 +135,7 @@ function StepTwo({
           </div>
           <button
             type="button"
-            onClick={() => navigate("/atelier/etape-1")}
+            onClick={() => navigate("/stepsequence/etape-1")}
             className="cta-button cta-button--light"
           >
             Revenir à l’étape 1
@@ -267,7 +267,7 @@ function StepTwo({
       <div className="flex justify-end animate-section">
         <button
           type="button"
-          onClick={() => navigate("/atelier/etape-3")}
+          onClick={() => navigate("/stepsequence/etape-3")}
           className="cta-button cta-button--light disabled:cursor-not-allowed disabled:bg-slate-300"
           disabled={!canProceedToStepThree}
         >


### PR DESCRIPTION
## Summary
- limit the activity catalog and selector defaults to the StepSequence workflow and update the editor paths to /stepsequence
- rewrite the landing page content and CTA to promote StepSequence as the single guided journey
- restrict LTI deep linking to the StepSequence entry and align documentation with the new setup

## Testing
- npm run build
- PYTHONPATH=.. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9128f5b7083229976be619a7ec946