### PR TITLE
Fix layout override merging for nested activities

### DIFF
--- a/frontend/src/config/activities.tsx
+++ b/frontend/src/config/activities.tsx
@@ -768,7 +768,28 @@ export function buildActivityElement(
 
     const handleSetOverrides = useCallback(
       (next: Partial<ActivityLayoutConfig>) => {
-        setOverrides(next);
+        setOverrides((prev) => {
+          if (!next || Object.keys(next).length === 0) {
+            return prev;
+          }
+
+          let didChange = false;
+          const updated: Partial<ActivityLayoutConfig> = { ...prev };
+          for (const key of Object.keys(next) as Array<keyof ActivityLayoutConfig>) {
+            const value = next[key];
+            if (value === undefined || value === null) {
+              if (key in updated) {
+                delete updated[key];
+                didChange = true;
+              }
+            } else if (updated[key] !== value) {
+              updated[key] = value;
+              didChange = true;
+            }
+          }
+
+          return didChange ? updated : prev;
+        });
       },
       []
     );


### PR DESCRIPTION
## Summary
- merge activity layout overrides instead of replacing them outright
- ensure null/undefined clears an override and avoid redundant state updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d91267f28c8322b60e8acb270252c5