### PR TITLE
Add root npm scripts for frontend workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,6 @@ Le frontend React dispose d'un mode test permettant de contourner la page de con
 ## Tests frontend
 
 - `npm run build --prefix frontend` : garantit que Vite/Babel peut analyser le bundle (utile avant toute capture d'écran).
-- `npm test -- --run --prefix frontend` : lance Vitest en mode run. Certaines suites (`ClarityMapStep` / `VideoStep`) peuvent être instables ; documentez toute erreur connue dans vos comptes rendus.
+- `npm --prefix frontend test -- --run` : lance Vitest en mode run. Vous pouvez désormais utiliser `npm run test:frontend` depuis la racine du dépôt (scripts déclarés dans `package.json`). Pensez à exécuter `npm run install:frontend` si le binaire Vitest n'est pas encore installé. Certaines suites (`ClarityMapStep` / `VideoStep`) peuvent être instables ; documentez toute erreur connue dans vos comptes rendus.
 
 Respectez ces indications lors de la mise à jour du projet ou de la préparation de démonstrations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,12 @@
 {
-  "name": "FormationIA",
+  "name": "formationia",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "formationia",
+      "version": "0.0.0"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "formationia",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "install:frontend": "npm --prefix frontend install",
+    "build:frontend": "npm --prefix frontend run build",
+    "test:frontend": "npm --prefix frontend test -- --run"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root-level package.json exposing helper scripts for the frontend workflow
- update documentation to point to the new npm run commands and clarify dependency installation

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68d92ebb21248322a6d904ea32a8639d