### PR TITLE
Allow clearing StepSequence clarity labels

### DIFF
--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -32,6 +32,11 @@ import type {
 } from "../../types";
 import { StepSequenceContext } from "../../types";
 
+const DEFAULT_INSTRUCTION_LABEL = "Commande transmise";
+const DEFAULT_INSTRUCTION_PLACEHOLDER = "La consigne reçue s'affichera ici…";
+const DEFAULT_PLAN_PLACEHOLDER_MESSAGE =
+  "Le plan validé apparaîtra ici dès que le backend aura converti ta consigne.";
+
 import type { ClarityPromptStepPayload } from "./ClarityPromptStep";
 
 export interface ClarityMapStepPayload {
@@ -246,10 +251,10 @@ function sanitizeConfig(config: unknown): NormalizedClarityMapConfig {
       initialTarget: null,
       promptStepId: "",
       allowInstructionInput: true,
-      instructionLabel: "Commande transmise",
-      instructionPlaceholder: "La consigne reçue s'affichera ici…",
+      instructionLabel: DEFAULT_INSTRUCTION_LABEL,
+      instructionPlaceholder: DEFAULT_INSTRUCTION_PLACEHOLDER,
       showPlanPlaceholder: true,
-      planPlaceholderMessage: "Le plan validé apparaîtra ici dès que le backend aura converti ta consigne.",
+      planPlaceholderMessage: DEFAULT_PLAN_PLACEHOLDER_MESSAGE,
       hideInstructionPanel: false,
     };
   }
@@ -264,18 +269,18 @@ function sanitizeConfig(config: unknown): NormalizedClarityMapConfig {
   const promptStepId = typeof raw.promptStepId === "string" ? raw.promptStepId.trim() : "";
   const allowInstructionInput = raw.allowInstructionInput !== false;
   const instructionLabel =
-    typeof raw.instructionLabel === "string" && raw.instructionLabel.trim()
-      ? raw.instructionLabel.trim()
-      : "Commande transmise";
+    typeof raw.instructionLabel === "string"
+      ? raw.instructionLabel.trim() || ""
+      : DEFAULT_INSTRUCTION_LABEL;
   const instructionPlaceholder =
-    typeof raw.instructionPlaceholder === "string" && raw.instructionPlaceholder.trim()
-      ? raw.instructionPlaceholder.trim()
-      : "La consigne reçue s'affichera ici…";
+    typeof raw.instructionPlaceholder === "string"
+      ? raw.instructionPlaceholder.trim() || ""
+      : DEFAULT_INSTRUCTION_PLACEHOLDER;
   const showPlanPlaceholder = raw.showPlanPlaceholder !== false;
   const planPlaceholderMessage =
-    typeof raw.planPlaceholderMessage === "string" && raw.planPlaceholderMessage.trim()
-      ? raw.planPlaceholderMessage.trim()
-      : "Le plan validé apparaîtra ici dès que le backend aura converti ta consigne.";
+    typeof raw.planPlaceholderMessage === "string"
+      ? raw.planPlaceholderMessage.trim() || ""
+      : DEFAULT_PLAN_PLACEHOLDER_MESSAGE;
   const hideInstructionPanel = raw.hideInstructionPanel === true;
 
   return {

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityPromptStep.tsx
@@ -12,6 +12,13 @@ import {
 import type { StepComponentProps } from "../../types";
 import { StepSequenceContext } from "../../types";
 
+const DEFAULT_PROMPT_LABEL = "Consigne à transmettre";
+const DEFAULT_PROMPT_PLACEHOLDER = "Décris l'action à effectuer…";
+const DEFAULT_AUTO_PUBLISH_HELPER_TEXT =
+  'Clique sur "Lancer la consigne" pour envoyer le prompt au module carte.';
+const DEFAULT_MANUAL_PUBLISH_HELPER_TEXT =
+  'Clique sur "Continuer" pour transmettre la consigne au module suivant.';
+
 export interface ClarityPromptStepPayload {
   instruction: string;
   triggerId?: string;
@@ -52,28 +59,28 @@ interface NormalizedPromptConfig {
 function sanitizeConfig(config: unknown): NormalizedPromptConfig {
   if (!config || typeof config !== "object") {
     return {
-      promptLabel: "Consigne à transmettre",
-      promptPlaceholder: "Décris l'action à effectuer…",
+      promptLabel: DEFAULT_PROMPT_LABEL,
+      promptPlaceholder: DEFAULT_PROMPT_PLACEHOLDER,
       model: "gpt-5-mini",
       verbosity: "medium",
       thinking: "medium",
       developerPrompt: "",
       settingsMode: "hidden",
       helperTextEnabled: true,
-      autoPublishHelperText: "Clique sur \"Lancer la consigne\" pour envoyer le prompt au module carte.",
-      manualPublishHelperText: "Clique sur \"Continuer\" pour transmettre la consigne au module suivant.",
+      autoPublishHelperText: DEFAULT_AUTO_PUBLISH_HELPER_TEXT,
+      manualPublishHelperText: DEFAULT_MANUAL_PUBLISH_HELPER_TEXT,
     };
   }
 
   const raw = config as ClarityPromptStepConfig;
   const promptLabel =
-    typeof raw.promptLabel === "string" && raw.promptLabel.trim()
-      ? raw.promptLabel.trim()
-      : "Consigne à transmettre";
+    typeof raw.promptLabel === "string"
+      ? raw.promptLabel.trim() || ""
+      : DEFAULT_PROMPT_LABEL;
   const promptPlaceholder =
-    typeof raw.promptPlaceholder === "string" && raw.promptPlaceholder.trim()
-      ? raw.promptPlaceholder.trim()
-      : "Décris l'action à effectuer…";
+    typeof raw.promptPlaceholder === "string"
+      ? raw.promptPlaceholder.trim() || ""
+      : DEFAULT_PROMPT_PLACEHOLDER;
 
   const model = typeof raw.model === "string" && raw.model.trim() ? raw.model.trim() : "gpt-5-mini";
 
@@ -93,13 +100,13 @@ function sanitizeConfig(config: unknown): NormalizedPromptConfig {
       : "hidden";
   const helperTextEnabled = raw.helperTextEnabled !== false;
   const autoPublishHelperText =
-    typeof raw.autoPublishHelperText === "string" && raw.autoPublishHelperText.trim()
+    typeof raw.autoPublishHelperText === "string"
       ? raw.autoPublishHelperText.trim()
-      : "Clique sur \"Lancer la consigne\" pour envoyer le prompt au module carte.";
+      : DEFAULT_AUTO_PUBLISH_HELPER_TEXT;
   const manualPublishHelperText =
-    typeof raw.manualPublishHelperText === "string" && raw.manualPublishHelperText.trim()
+    typeof raw.manualPublishHelperText === "string"
       ? raw.manualPublishHelperText.trim()
-      : "Clique sur \"Continuer\" pour transmettre la consigne au module suivant.";
+      : DEFAULT_MANUAL_PUBLISH_HELPER_TEXT;
 
   return {
     promptLabel,


### PR DESCRIPTION
## Summary
- keep Clarity prompt and map configuration sanitizers from restoring default labels when the author clears a field
- centralize default text constants for those steps so the UI still has fallbacks when configs are missing

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d95bbee76c83228faac0948e2a618f