### PR TITLE
Remove default AI comparison title

### DIFF
--- a/frontend/src/modules/step-sequence/modules/DualModelComparisonStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/DualModelComparisonStep.tsx
@@ -184,7 +184,7 @@ const DEFAULT_SUMMARY: NormalizedSummaryConfig = {
 };
 
 const DEFAULT_COPY: NormalizedCopyConfig = {
-  title: "Comparez deux configurations IA",
+  title: "",
   promptLabel: "Décrivez la consigne à soumettre",
   promptPlaceholder: "Décrivez le besoin ou la tâche attendue pour vos deux variantes.",
   launchCta: DEFAULT_LAUNCH_CTA,
@@ -763,9 +763,11 @@ export function DualModelComparisonStep({
                 {normalizedConfig.copy.badge}
               </span>
             )}
-            <h2 className="text-2xl leading-tight text-[color:var(--brand-black)]">
-              {normalizedConfig.copy.title}
-            </h2>
+            {normalizedConfig.copy.title && (
+              <h2 className="text-2xl leading-tight text-[color:var(--brand-black)]">
+                {normalizedConfig.copy.title}
+              </h2>
+            )}
             {normalizedConfig.copy.description && (
               <p className="text-sm text-[color:var(--brand-charcoal)]">
                 {normalizedConfig.copy.description}

--- a/frontend/src/modules/step-sequence/tools.ts
+++ b/frontend/src/modules/step-sequence/tools.ts
@@ -1061,7 +1061,7 @@ const DEFAULT_COMPARISON_SUMMARY: Required<DualModelComparisonCopyConfig["summar
   resetLabel: "Réinitialiser l’aperçu",
 };
 
-const DEFAULT_COMPARISON_TITLE = "Comparez deux configurations IA";
+const DEFAULT_COMPARISON_TITLE = "";
 const DEFAULT_COMPARISON_PROMPT_LABEL = "Décrivez la consigne à soumettre";
 const DEFAULT_COMPARISON_PROMPT_PLACEHOLDER =
   "Décrivez le besoin ou la tâche attendue pour vos deux variantes.";


### PR DESCRIPTION
## Summary
- remove the default heading from the AI comparison step configuration
- hide the comparison heading when no custom title is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d960e1f1dc8322a558084eb5c767b2