### PR TITLE
Normalize Explorateur world module configuration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -915,15 +915,60 @@ def _normalize_explorateur_world_config(step: dict[str, Any]) -> None:
         terrain = config.get("terrain")
         normalized_config["terrain"] = deepcopy(terrain)
 
+        def _normalize_nested_step(payload: Mapping[str, Any]) -> dict[str, Any]:
+            normalized_step = deepcopy(payload)
+            config_payload = normalized_step.get("config")
+            module_type: str | None = None
+            if isinstance(config_payload, Mapping):
+                normalized_config_payload = deepcopy(config_payload)
+                raw_type = normalized_config_payload.get("type")
+                if isinstance(raw_type, str):
+                    trimmed_type = raw_type.strip()
+                    if trimmed_type:
+                        normalized_config_payload["type"] = trimmed_type
+                        module_type = trimmed_type
+                normalized_step["config"] = normalized_config_payload
+            elif config_payload is None:
+                normalized_step["config"] = None
+            else:
+                normalized_step["config"] = deepcopy(config_payload)
+
+            raw_component = normalized_step.get("component")
+            component_value = (
+                raw_component.strip() if isinstance(raw_component, str) else ""
+            )
+            if module_type and (component_value == "" or component_value == "custom"):
+                normalized_step["component"] = module_type
+            elif component_value:
+                normalized_step["component"] = component_value
+
+            return normalized_step
+
         raw_steps = config.get("steps")
-        if isinstance(raw_steps, list):
-            normalized_config["steps"] = deepcopy(raw_steps)
-        elif isinstance(raw_steps, tuple):
-            normalized_config["steps"] = [deepcopy(item) for item in raw_steps]
+        if isinstance(raw_steps, (list, tuple)):
+            normalized_config["steps"] = [
+                _normalize_nested_step(item)
+                for item in raw_steps
+                if isinstance(item, Mapping)
+            ]
 
         normalized_config["quarterDesignerSteps"] = deepcopy(
             config.get("quarterDesignerSteps")
         )
+
+        raw_designer_steps = config.get("quarterDesignerSteps")
+        if isinstance(raw_designer_steps, Mapping):
+            normalized_map: dict[str, list[dict[str, Any]]] = {}
+            for quarter_id, steps_payload in raw_designer_steps.items():
+                if not isinstance(steps_payload, (list, tuple)):
+                    continue
+                if isinstance(quarter_id, str):
+                    normalized_map[quarter_id] = [
+                        _normalize_nested_step(item)
+                        for item in steps_payload
+                        if isinstance(item, Mapping)
+                    ]
+            normalized_config["quarterDesignerSteps"] = normalized_map
 
         raw_quarters = config.get("quarters")
         if isinstance(raw_quarters, list):

--- a/backend/tests/test_admin_activities_config.py
+++ b/backend/tests/test_admin_activities_config.py
@@ -314,6 +314,22 @@ def test_explorateur_world_structure_is_normalized(tmp_path, monkeypatch) -> Non
                         "id": "world",
                         "config": {
                             "terrain": {"layout": "grid"},
+                            "steps": [
+                                {
+                                    "id": "clarte:quiz",
+                                    "component": "custom",
+                                    "config": {"type": "clarte-quiz"},
+                                }
+                            ],
+                            "quarterDesignerSteps": {
+                                "clarte": [
+                                    {
+                                        "id": "clarte:designer:basics",
+                                        "component": "custom",
+                                        "config": {"type": "explorateur-quarter-basics"},
+                                    }
+                                ]
+                            },
                             "customData": {"foo": "bar"},
                         },
                     }
@@ -335,9 +351,15 @@ def test_explorateur_world_structure_is_normalized(tmp_path, monkeypatch) -> Non
             assert step["component"] == "explorateur-world"
             config = step["config"]
             assert config["terrain"] == {"layout": "grid"}
-            assert config["steps"] == []
+            assert len(config["steps"]) == 1
+            assert config["steps"][0]["component"] == "clarte-quiz"
+            assert config["steps"][0]["config"]["type"] == "clarte-quiz"
             assert config["quarters"] == []
-            assert config["quarterDesignerSteps"] is None
+            assert isinstance(config["quarterDesignerSteps"], dict)
+            assert (
+                config["quarterDesignerSteps"]["clarte"][0]["component"]
+                == "explorateur-quarter-basics"
+            )
             assert config["customData"] == {"foo": "bar"}
 
             list_response = client.get("/api/admin/activities")
@@ -345,6 +367,9 @@ def test_explorateur_world_structure_is_normalized(tmp_path, monkeypatch) -> Non
             list_payload = list_response.json()
             stored_step = list_payload["activities"][0]["stepSequence"][0]
             assert stored_step["config"] == config
+            assert stored_step["config"]["steps"][0]["component"] == "clarte-quiz"
+            quarter_steps = stored_step["config"]["quarterDesignerSteps"]["clarte"]
+            assert quarter_steps[0]["component"] == "explorateur-quarter-basics"
 
             activity_path = main._activity_file_path("explorateur")
             assert activity_path.exists()

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -295,6 +295,36 @@ def test_create_explorateur_world_step_defaults_structure() -> None:
     assert config["steps"] == []
 
 
+def test_create_explorateur_world_step_normalizes_custom_modules() -> None:
+    step = create_explorateur_world_step(
+        step_id="explorateur",
+        config={
+            "steps": [
+                {
+                    "id": "clarte:quiz",
+                    "component": "custom",
+                    "config": {"type": "clarte-quiz", "question": "?"},
+                }
+            ],
+            "quarterDesignerSteps": {
+                "clarte": [
+                    {
+                        "id": "clarte:designer:basics",
+                        "component": "custom",
+                        "config": {"type": "explorateur-quarter-basics"},
+                    }
+                ]
+            },
+        },
+    )
+
+    config = step["config"]
+    assert config["steps"][0]["component"] == "clarte-quiz"
+    assert config["steps"][0]["config"]["type"] == "clarte-quiz"
+    designer_step = config["quarterDesignerSteps"]["clarte"][0]
+    assert designer_step["component"] == "explorateur-quarter-basics"
+
+
 def test_create_composite_step_wraps_modules() -> None:
     step = create_composite_step(
         step_id="composite",

--- a/frontend/src/pages/explorateurIA/configUtils.ts
+++ b/frontend/src/pages/explorateurIA/configUtils.ts
@@ -89,19 +89,37 @@ export function sanitizeSteps(
     if (typeof candidate.id !== "string" || candidate.id.trim().length === 0) {
       continue;
     }
-    if (
-      typeof candidate.component !== "string" ||
-      candidate.component.trim().length === 0
-    ) {
+    const clonedConfig =
+      candidate.config == null
+        ? candidate.config
+        : cloneStepConfig(candidate.config);
+
+    let inferredType: string | null = null;
+    if (clonedConfig && typeof clonedConfig === "object") {
+      const maybeType = (clonedConfig as { type?: unknown }).type;
+      if (typeof maybeType === "string" && maybeType.trim().length > 0) {
+        inferredType = maybeType.trim();
+        (clonedConfig as { type: string }).type = inferredType;
+      }
+    }
+
+    const rawComponent =
+      typeof candidate.component === "string"
+        ? candidate.component.trim()
+        : "";
+    const component =
+      rawComponent && rawComponent !== "custom"
+        ? rawComponent
+        : inferredType ?? rawComponent;
+
+    if (!component) {
       continue;
     }
+
     steps.push({
       id: candidate.id,
-      component: candidate.component,
-      config:
-        candidate.config == null
-          ? candidate.config
-          : cloneStepConfig(candidate.config),
+      component,
+      config: clonedConfig,
       composite: null,
     });
   }

--- a/frontend/src/pages/explorateurIA/designerUtils.ts
+++ b/frontend/src/pages/explorateurIA/designerUtils.ts
@@ -107,6 +107,20 @@ export function createNewQuarterTemplate(
   } satisfies ExplorateurIAQuarterConfig;
 }
 
+function resolveStepComponent(step: StepDefinition): string | null {
+  if (typeof step.component === "string" && step.component.trim().length > 0) {
+    return step.component.trim();
+  }
+  const rawConfig = step.config;
+  if (rawConfig && typeof rawConfig === "object") {
+    const maybeType = (rawConfig as { type?: unknown }).type;
+    if (typeof maybeType === "string" && maybeType.trim().length > 0) {
+      return maybeType.trim();
+    }
+  }
+  return null;
+}
+
 export function ensureDesignerStepId(
   quarterId: QuarterId,
   step: StepDefinition,
@@ -116,10 +130,7 @@ export function ensureDesignerStepId(
     typeof step.id === "string" && step.id.trim().length > 0
       ? ensureStepHasQuarterPrefix(step.id, quarterId)
       : `${quarterId}:designer:${index + 1}`;
-  const component =
-    typeof step.component === "string" && step.component.trim().length > 0
-      ? step.component
-      : "custom";
+  const component = resolveStepComponent(step) ?? "rich-content";
   if (step.composite != null) {
     return {
       id,
@@ -173,7 +184,7 @@ export function createBasicsDesignerStep(
   const baseId = quarter.id;
   return {
     id: `${baseId}:designer:basics`,
-    component: "custom",
+    component: "explorateur-quarter-basics",
     config: {
       type: "explorateur-quarter-basics",
       quarterId: baseId,
@@ -191,7 +202,7 @@ export function createInventoryDesignerStep(
   const baseId = quarter.id;
   return {
     id: `${baseId}:designer:inventory`,
-    component: "custom",
+    component: "explorateur-quarter-inventory",
     config: {
       type: "explorateur-quarter-inventory",
       quarterId: baseId,
@@ -334,10 +345,7 @@ export function ensureQuarterSequenceStep(
   quarterId: QuarterId
 ): StepDefinition {
   const id = ensureStepHasQuarterPrefix(step.id, quarterId);
-  const component =
-    typeof step.component === "string" && step.component.trim().length > 0
-      ? step.component
-      : "custom";
+  const component = resolveStepComponent(step) ?? "rich-content";
 
   if (step.composite != null) {
     return {

--- a/frontend/src/pages/explorateurIA/modules/registry.tsx
+++ b/frontend/src/pages/explorateurIA/modules/registry.tsx
@@ -4,6 +4,7 @@ import type { ComponentType } from "react";
 import {
   registerStepComponent,
   type StepComponentProps,
+  type StepComponentWithMetadata,
 } from "../../../modules/step-sequence";
 
 export interface ExplorateurIAModuleConfig {
@@ -26,6 +27,23 @@ export function registerExplorateurIAModule(
   component: ExplorateurIAModuleComponent
 ): void {
   MODULE_REGISTRY.set(type, component);
+
+  const StepComponent = ((props: StepComponentProps) => {
+    const handleUpdate = (next: ExplorateurIAModuleConfig) => {
+      const payload =
+        next && typeof next === "object"
+          ? { ...next, type: (next as { type?: string }).type ?? type }
+          : { type };
+      props.onUpdateConfig?.(payload);
+    };
+
+    return component({
+      ...(props as ExplorateurIAModuleProps),
+      onUpdateConfig: handleUpdate,
+    });
+  }) as StepComponentWithMetadata;
+
+  registerStepComponent(type, StepComponent);
 }
 
 function getExplorateurIAModule(

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -89,7 +89,7 @@ const CLARTE_STEPS: StepDefinition[] = [
   },
   {
     id: "clarte:quiz",
-    component: "custom",
+    component: "clarte-quiz",
     config: DEFAULT_CLARTE_QUIZ_CONFIG,
   },
 ];
@@ -115,7 +115,7 @@ const CREATION_STEPS: StepDefinition[] = [
   },
   {
     id: "creation:builder",
-    component: "custom",
+    component: "creation-builder",
     config: DEFAULT_CREATION_BUILDER_CONFIG,
   },
   {
@@ -155,7 +155,7 @@ const DECISION_STEPS: StepDefinition[] = [
   },
   {
     id: "decision:path",
-    component: "custom",
+    component: "decision-path",
     config: DEFAULT_DECISION_PATH_CONFIG,
   },
 ];
@@ -171,7 +171,7 @@ const ETHIQUE_STEPS: StepDefinition[] = [
   },
   {
     id: "ethique:dilemmas",
-    component: "custom",
+    component: "ethics-dilemmas",
     config: DEFAULT_ETHICS_DILEMMAS_CONFIG,
   },
   {


### PR DESCRIPTION
## Summary
- normalize nested Explorateur world steps on the backend so saved configurations no longer depend on the legacy `custom` component
- align the frontend Explorateur world defaults, designer utilities and module registry with dedicated step-sequence components
- extend backend tests to cover the new normalization behavior

## Testing
- pytest backend/tests/test_step_sequence_components.py::test_create_explorateur_world_step_normalizes_custom_modules
- pytest backend/tests/test_admin_activities_config.py::test_explorateur_world_structure_is_normalized
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d9616b07e8832286bf8cb6610cd0cd