### PR TITLE
fix: clean up clarity map labeling

### DIFF
--- a/frontend/src/modules/clarity/atlas.tsx
+++ b/frontend/src/modules/clarity/atlas.tsx
@@ -1,0 +1,131 @@
+import { useMemo, type CSSProperties } from "react";
+
+import mapPackAtlas from "../../assets/kenney_map-pack/Spritesheet/mapPack_spritesheet.png";
+import mapPackAtlasDescription from "../../assets/kenney_map-pack/Spritesheet/mapPack_enriched.xml?raw";
+
+export type TileCoord = [number, number] | [number, number, number, number];
+
+interface AtlasEntry {
+  name: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+}
+
+const DEFAULT_TILE_SIZE = 64;
+
+function parseAtlasDescription(xml: string): Map<string, AtlasEntry> {
+  const entries = new Map<string, AtlasEntry>();
+  const subTextureRegex = /<SubTexture\s+([^>]+?)\s*\/>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = subTextureRegex.exec(xml)) !== null) {
+    const attributeSource = match[1];
+    const attributeRegex = /(\w+)="([^"]*)"/g;
+    const attributes: Record<string, string> = {};
+
+    let attributeMatch: RegExpExecArray | null;
+    while ((attributeMatch = attributeRegex.exec(attributeSource)) !== null) {
+      attributes[attributeMatch[1]] = attributeMatch[2];
+    }
+
+    const name = attributes.name;
+    if (!name) {
+      continue;
+    }
+
+    const x = Number.parseInt(attributes.x ?? "", 10);
+    const y = Number.parseInt(attributes.y ?? "", 10);
+    const width = Number.parseInt(attributes.width ?? "", 10);
+    const height = Number.parseInt(attributes.height ?? "", 10);
+
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      continue;
+    }
+
+    entries.set(name, {
+      name,
+      x,
+      y,
+      width: Number.isFinite(width) ? width : DEFAULT_TILE_SIZE,
+      height: Number.isFinite(height) ? height : DEFAULT_TILE_SIZE,
+    });
+  }
+
+  return entries;
+}
+
+const ATLAS_ENTRIES = parseAtlasDescription(mapPackAtlasDescription);
+
+export function atlas(name: string): TileCoord {
+  const entry = ATLAS_ENTRIES.get(name);
+  if (!entry) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`[clarity] Tuile manquante dans l'atlas: ${name}`);
+    }
+    return [0, 0, DEFAULT_TILE_SIZE, DEFAULT_TILE_SIZE];
+  }
+  return [
+    entry.x,
+    entry.y,
+    entry.width ?? DEFAULT_TILE_SIZE,
+    entry.height ?? DEFAULT_TILE_SIZE,
+  ];
+}
+
+export interface SpriteFromAtlasProps {
+  coord: TileCoord;
+  scale: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function SpriteFromAtlas({
+  coord,
+  scale,
+  className,
+  style,
+}: SpriteFromAtlasProps): JSX.Element | null {
+  const [x, y, rawWidth, rawHeight] = coord;
+  const width = rawWidth ?? DEFAULT_TILE_SIZE;
+  const height = rawHeight ?? DEFAULT_TILE_SIZE;
+
+  if (scale <= 0 || width <= 0 || height <= 0) {
+    return null;
+  }
+
+  const zoomX = scale / width;
+  const zoomY = scale / height;
+
+  return (
+    <div
+      className={className}
+      style={{
+        width: scale,
+        height: scale,
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          width,
+          height,
+          backgroundImage: `url(${mapPackAtlas})`,
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: `${-x}px ${-y}px`,
+          imageRendering: "pixelated",
+          transform: `scale(${zoomX}, ${zoomY})`,
+          transformOrigin: "top left",
+        }}
+      />
+    </div>
+  );
+}
+
+export function useAtlasCoord(name: string): TileCoord {
+  return useMemo(() => atlas(name), [name]);
+}
+
+export { DEFAULT_TILE_SIZE };

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -88,21 +88,36 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
     <div className="relative mx-auto w-full max-w-[520px]">
       <div className="grid grid-cols-[auto,1fr] grid-rows-[1fr,auto] items-start gap-x-2 gap-y-2 sm:gap-x-3 sm:gap-y-3 md:gap-x-4 md:gap-y-4">
         <div
-          className="grid grid-rows-10 justify-items-end text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
+          className="relative w-6 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 sm:w-7 md:w-8 md:text-xs"
           style={{
             height: gridExtent > 0 ? gridExtent : undefined,
-            gridTemplateRows:
-              tileSize > 0 ? `repeat(${GRID_SIZE}, ${tileSize}px)` : undefined,
           }}
         >
-          {axis.map((value) => (
-            <span
-              key={`row-${value}`}
-              className="grid h-full w-full items-center justify-items-end text-right leading-none"
-            >
-              {value}
-            </span>
-          ))}
+          {tileSize > 0 ? (
+            axis.map((value) => (
+              <span
+                key={`row-${value}`}
+                className="pointer-events-none absolute right-0 flex w-full items-center justify-end leading-none"
+                style={{
+                  top: value * tileSize,
+                  height: tileSize,
+                }}
+              >
+                {value}
+              </span>
+            ))
+          ) : (
+            <div className="grid h-full w-full grid-rows-10 justify-items-end">
+              {axis.map((value) => (
+                <span
+                  key={`row-${value}`}
+                  className="flex h-full w-full items-center justify-end leading-none"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <div className="relative flex justify-center">
           <div

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -93,31 +93,21 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
             height: gridExtent > 0 ? gridExtent : undefined,
           }}
         >
-          {tileSize > 0 ? (
-            axis.map((value) => (
+          <div
+            className="grid h-full w-full justify-items-end"
+            style={{
+              gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+            }}
+          >
+            {axis.map((value) => (
               <span
                 key={`row-${value}`}
-                className="pointer-events-none absolute right-0 flex w-full items-center justify-end leading-none"
-                style={{
-                  top: value * tileSize,
-                  height: tileSize,
-                }}
+                className="flex h-full w-full items-center justify-end leading-none"
               >
                 {value}
               </span>
-            ))
-          ) : (
-            <div className="grid h-full w-full grid-rows-10 justify-items-end">
-              {axis.map((value) => (
-                <span
-                  key={`row-${value}`}
-                  className="flex h-full w-full items-center justify-end leading-none"
-                >
-                  {value}
-                </span>
-              ))}
-            </div>
-          )}
+            ))}
+          </div>
         </div>
         <div className="relative flex justify-center">
           <div
@@ -184,11 +174,10 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         </div>
         <div aria-hidden />
         <div
-          className="mx-auto grid grid-cols-10 justify-items-center text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
+          className="mx-auto grid justify-items-center text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{
             width: gridExtent > 0 ? gridExtent : undefined,
-            gridTemplateColumns:
-              tileSize > 0 ? `repeat(${GRID_SIZE}, ${tileSize}px)` : undefined,
+            gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
           }}
         >
           {axis.map((value) => (

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -96,7 +96,10 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           }}
         >
           {axis.map((value) => (
-            <span key={`row-${value}`} className="flex h-full w-full items-center justify-end">
+            <span
+              key={`row-${value}`}
+              className="grid h-full w-full items-center justify-items-end text-right leading-none"
+            >
               {value}
             </span>
           ))}

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -89,16 +89,16 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{ height: gridExtent }}
         >
-          <div className="flex h-full w-full flex-col items-end">
+          <div
+            className="grid h-full w-full justify-items-end"
+            style={{
+              gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+            }}
+          >
             {axis.map((value) => (
               <span
                 key={`row-${value}`}
-                className="flex w-full items-center justify-end"
-                style={{
-                  height: tileSize,
-                  lineHeight: `${tileSize}px`,
-                  flex: tileSize > 0 ? `0 0 ${tileSize}px` : undefined,
-                }}
+                className="flex h-full w-full items-center justify-end"
               >
                 {value}
               </span>
@@ -167,17 +167,16 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         className="mt-2 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
         style={{ width: gridExtent }}
       >
-        <div className="grid grid-cols-10">
+        <div
+          className="grid"
+          style={{
+            gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+          }}
+        >
           {axis.map((value) => (
             <span
               key={`col-${value}`}
-              className="flex items-center justify-center"
-              style={{
-                height: tileSize,
-                lineHeight: `${tileSize}px`,
-                width: tileSize,
-                minWidth: tileSize,
-              }}
+              className="flex h-full w-full items-center justify-center"
             >
               {value}
             </span>

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -99,21 +99,38 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{ height: gridExtent }}
         >
-          <div
-            className="grid h-full w-full justify-items-end"
-            style={{
-              gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-            }}
-          >
-            {axis.map((value) => (
-              <span
-                key={`row-${value}`}
-                className="flex h-full w-full items-center justify-end"
-              >
-                {value}
-              </span>
-            ))}
-          </div>
+          {tileSize > 0 ? (
+            <div className="relative h-full w-full">
+              {axis.map((value) => (
+                <span
+                  key={`row-${value}`}
+                  className="absolute flex w-full items-center justify-end"
+                  style={{
+                    top: `${value * tileSize}px`,
+                    height: `${tileSize}px`,
+                  }}
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div
+              className="grid h-full w-full justify-items-end"
+              style={{
+                gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+              }}
+            >
+              {axis.map((value) => (
+                <span
+                  key={`row-${value}`}
+                  className="flex h-full w-full items-center justify-end"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <div className="relative">
           <div className="relative aspect-square h-[clamp(180px,calc(100vw-120px),400px)] rounded-3xl border border-white/60 bg-gradient-to-br from-sky-100/70 via-white/80 to-slate-100/70 p-2 shadow-inner">
@@ -175,23 +192,40 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
       </div>
       <div
         className="mt-2 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
-        style={{ width: gridExtent }}
+        style={{ width: gridExtent, height: tileSize > 0 ? tileSize : undefined }}
       >
-        <div
-          className="grid"
-          style={{
-            gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-          }}
-        >
-          {axis.map((value) => (
-            <span
-              key={`col-${value}`}
-              className="flex h-full w-full items-center justify-center"
-            >
-              {value}
-            </span>
-          ))}
-        </div>
+        {tileSize > 0 ? (
+          <div className="relative h-full w-full">
+            {axis.map((value) => (
+              <span
+                key={`col-${value}`}
+                className="absolute flex h-full items-center justify-center"
+                style={{
+                  left: `${value * tileSize}px`,
+                  width: `${tileSize}px`,
+                }}
+              >
+                {value}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div
+            className="grid"
+            style={{
+              gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+            }}
+          >
+            {axis.map((value) => (
+              <span
+                key={`col-${value}`}
+                className="flex h-full w-full items-center justify-center"
+              >
+                {value}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -99,21 +99,35 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{ height: gridExtent }}
         >
-          <div
-            className="grid h-full w-full justify-items-end"
-            style={{
-              gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-            }}
-          >
-            {axis.map((value) => (
-              <span
-                key={`row-${value}`}
-                className="flex h-full w-full items-center justify-end"
-              >
-                {value}
-              </span>
-            ))}
-          </div>
+          {tileSize > 0 ? (
+            <div className="pointer-events-none relative h-full w-full">
+              {axis.map((value) => (
+                <span
+                  key={`row-${value}`}
+                  className="absolute right-0 flex -translate-y-1/2 items-center justify-end"
+                  style={{ top: value * tileSize + tileSize / 2 }}
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div
+              className="grid h-full w-full justify-items-end"
+              style={{
+                gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+              }}
+            >
+              {axis.map((value) => (
+                <span
+                  key={`row-${value}`}
+                  className="flex h-full w-full items-center justify-end"
+                >
+                  {value}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <div className="relative">
           <div className="relative aspect-square h-[clamp(180px,calc(100vw-120px),400px)] rounded-3xl border border-white/60 bg-gradient-to-br from-sky-100/70 via-white/80 to-slate-100/70 p-2 shadow-inner">
@@ -177,21 +191,35 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         className="mt-2 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
         style={{ width: gridExtent, height: tileSize > 0 ? tileSize : undefined }}
       >
-        <div
-          className="grid h-full w-full"
-          style={{
-            gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-          }}
-        >
-          {axis.map((value) => (
-            <span
-              key={`col-${value}`}
-              className="flex h-full w-full items-center justify-center"
-            >
-              {value}
-            </span>
-          ))}
-        </div>
+        {tileSize > 0 ? (
+          <div className="pointer-events-none relative h-full w-full">
+            {axis.map((value) => (
+              <span
+                key={`col-${value}`}
+                className="absolute left-0 top-1/2 flex -translate-y-1/2 -translate-x-1/2 items-center justify-center"
+                style={{ left: value * tileSize + tileSize / 2 }}
+              >
+                {value}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div
+            className="grid h-full w-full"
+            style={{
+              gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+            }}
+          >
+            {axis.map((value) => (
+              <span
+                key={`col-${value}`}
+                className="flex h-full w-full items-center justify-center"
+              >
+                {value}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -57,25 +57,35 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
       return;
     }
 
-    const updateTileSize = () => {
-      const width = element.clientWidth;
+    const measureExtent = () => {
+      const { width } = element.getBoundingClientRect();
       if (width <= 0) {
         return;
       }
       setGridExtent(width);
     };
 
-    updateTileSize();
+    measureExtent();
 
     if (typeof ResizeObserver === "undefined") {
-      const handleResize = () => updateTileSize();
+      const handleResize = () => measureExtent();
       window.addEventListener("resize", handleResize);
       return () => {
         window.removeEventListener("resize", handleResize);
       };
     }
 
-    const observer = new ResizeObserver(() => updateTileSize());
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      const { width } = entry.contentRect;
+      if (width <= 0) {
+        return;
+      }
+      setGridExtent(width);
+    });
     observer.observe(element);
     return () => {
       observer.disconnect();

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -99,38 +99,21 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{ height: gridExtent }}
         >
-          {tileSize > 0 ? (
-            <div className="relative h-full w-full">
-              {axis.map((value) => (
-                <span
-                  key={`row-${value}`}
-                  className="absolute flex w-full items-center justify-end"
-                  style={{
-                    top: `${value * tileSize}px`,
-                    height: `${tileSize}px`,
-                  }}
-                >
-                  {value}
-                </span>
-              ))}
-            </div>
-          ) : (
-            <div
-              className="grid h-full w-full justify-items-end"
-              style={{
-                gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-              }}
-            >
-              {axis.map((value) => (
-                <span
-                  key={`row-${value}`}
-                  className="flex h-full w-full items-center justify-end"
-                >
-                  {value}
-                </span>
-              ))}
-            </div>
-          )}
+          <div
+            className="grid h-full w-full justify-items-end"
+            style={{
+              gridTemplateRows: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+            }}
+          >
+            {axis.map((value) => (
+              <span
+                key={`row-${value}`}
+                className="flex h-full w-full items-center justify-end"
+              >
+                {value}
+              </span>
+            ))}
+          </div>
         </div>
         <div className="relative">
           <div className="relative aspect-square h-[clamp(180px,calc(100vw-120px),400px)] rounded-3xl border border-white/60 bg-gradient-to-br from-sky-100/70 via-white/80 to-slate-100/70 p-2 shadow-inner">
@@ -194,38 +177,21 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         className="mt-2 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
         style={{ width: gridExtent, height: tileSize > 0 ? tileSize : undefined }}
       >
-        {tileSize > 0 ? (
-          <div className="relative h-full w-full">
-            {axis.map((value) => (
-              <span
-                key={`col-${value}`}
-                className="absolute flex h-full items-center justify-center"
-                style={{
-                  left: `${value * tileSize}px`,
-                  width: `${tileSize}px`,
-                }}
-              >
-                {value}
-              </span>
-            ))}
-          </div>
-        ) : (
-          <div
-            className="grid"
-            style={{
-              gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
-            }}
-          >
-            {axis.map((value) => (
-              <span
-                key={`col-${value}`}
-                className="flex h-full w-full items-center justify-center"
-              >
-                {value}
-              </span>
-            ))}
-          </div>
-        )}
+        <div
+          className="grid h-full w-full"
+          style={{
+            gridTemplateColumns: `repeat(${GRID_SIZE}, minmax(0, 1fr))`,
+          }}
+        >
+          {axis.map((value) => (
+            <span
+              key={`col-${value}`}
+              className="flex h-full w-full items-center justify-center"
+            >
+              {value}
+            </span>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -91,6 +91,8 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="grid grid-rows-10 justify-items-end text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{
             height: gridExtent > 0 ? gridExtent : undefined,
+            gridTemplateRows:
+              tileSize > 0 ? `repeat(${GRID_SIZE}, ${tileSize}px)` : undefined,
           }}
         >
           {axis.map((value) => (
@@ -167,6 +169,8 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           className="mx-auto grid grid-cols-10 justify-items-center text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{
             width: gridExtent > 0 ? gridExtent : undefined,
+            gridTemplateColumns:
+              tileSize > 0 ? `repeat(${GRID_SIZE}, ${tileSize}px)` : undefined,
           }}
         >
           {axis.map((value) => (

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -88,7 +88,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
   }, []);
 
   return (
-    <div className="relative mx-auto w-full max-w-[560px]">
+    <div className="relative w-full">
       <div className="grid grid-cols-[auto,1fr] grid-rows-[1fr,auto] items-start gap-x-2 gap-y-2 sm:gap-x-3 sm:gap-y-3 md:gap-x-4 md:gap-y-4">
         <div
           className="relative w-6 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 sm:w-7 md:w-8 md:text-xs"
@@ -97,16 +97,16 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           }}
         >
           {hasTileMeasurements ? (
-            <div className="pointer-events-none absolute inset-0">
+            <div
+              className="pointer-events-none absolute inset-0 grid justify-items-end"
+              style={{
+                gridTemplateRows: `repeat(${GRID_SIZE}, ${tileHeight}px)`,
+              }}
+            >
               {axis.map((value) => (
                 <span
                   key={`row-${value}`}
-                  className="absolute flex w-full justify-end text-right"
-                  style={{
-                    top: tileHeight * value + tileHeight / 2,
-                    transform: "translateY(-50%)",
-                    lineHeight: 1,
-                  }}
+                  className="flex h-full w-full items-center justify-end leading-none"
                 >
                   {value}
                 </span>
@@ -131,21 +131,16 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           )}
         </div>
         <div className="relative flex justify-center">
-          <div
-            className="relative w-full max-w-[460px] rounded-3xl border border-white/60 bg-gradient-to-br from-sky-100/70 via-white/80 to-slate-100/70 p-2 shadow-inner"
-            style={{
-              width: "clamp(200px, calc(100vw - 96px), 460px)",
-              height: "clamp(200px, calc(100vw - 96px), 460px)",
-            }}
-          >
-            <div
-              ref={gridRef}
-              className="relative grid h-full w-full grid-cols-10 grid-rows-10 overflow-hidden rounded-2xl bg-slate-50/40"
-            >
-              {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, index) => {
-                const x = index % GRID_SIZE;
-                const y = Math.floor(index / GRID_SIZE);
-                const key = `${x}-${y}`;
+          <div className="relative w-full max-w-[520px]">
+            <div className="relative aspect-square w-full">
+              <div
+                ref={gridRef}
+                className="relative grid h-full w-full grid-cols-10 grid-rows-10 overflow-hidden rounded-2xl border border-white/60 bg-slate-50/40 shadow-inner"
+              >
+                {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, index) => {
+                  const x = index % GRID_SIZE;
+                  const y = Math.floor(index / GRID_SIZE);
+                  const key = `${x}-${y}`;
                 const isStart = x === START_POSITION.x && y === START_POSITION.y;
                 const isVisited = visited.has(key) && !isStart;
                 const isTarget = x === target.x && y === target.y;
@@ -186,10 +181,11 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
                   </div>
                 );
               })}
-              <div
-                className="clarity-grid-overlay"
-                style={tileSize > 0 ? { backgroundSize: `${tileSize}px ${tileSize}px` } : undefined}
-              />
+                <div
+                  className="clarity-grid-overlay"
+                  style={tileSize > 0 ? { backgroundSize: `${tileSize}px ${tileSize}px` } : undefined}
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -202,17 +198,16 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
           }}
         >
           {hasTileMeasurements ? (
-            <div className="pointer-events-none relative h-full w-full">
+            <div
+              className="pointer-events-none absolute inset-0 grid justify-items-center"
+              style={{
+                gridTemplateColumns: `repeat(${GRID_SIZE}, ${tileWidth}px)`,
+              }}
+            >
               {axis.map((value) => (
                 <span
                   key={`col-${value}`}
-                  className="absolute flex h-full items-center justify-center"
-                  style={{
-                    left: tileWidth * value + tileWidth / 2,
-                    transform: "translateX(-50%)",
-                    width: tileWidth,
-                    lineHeight: 1,
-                  }}
+                  className="flex h-full w-full items-center justify-center leading-none"
                 >
                   {value}
                 </span>

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -48,8 +48,8 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
   const blockedSet = useMemo(() => new Set(blocked.map((cell) => `${cell.x}-${cell.y}`)), [blocked]);
   const axis = useMemo(() => Array.from({ length: GRID_SIZE }, (_, index) => index), []);
   const gridRef = useRef<HTMLDivElement | null>(null);
-  const [tileSize, setTileSize] = useState(32);
-  const axisExtent = tileSize > 0 ? tileSize * GRID_SIZE : 0;
+  const [gridExtent, setGridExtent] = useState(0);
+  const tileSize = gridExtent > 0 ? gridExtent / GRID_SIZE : 0;
 
   useEffect(() => {
     const element = gridRef.current;
@@ -62,8 +62,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
       if (width <= 0) {
         return;
       }
-      const nextSize = width / GRID_SIZE;
-      setTileSize(nextSize > 0 ? nextSize : 0);
+      setGridExtent(width);
     };
 
     updateTileSize();
@@ -88,14 +87,18 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
       <div className="flex items-start gap-2 sm:gap-3 md:gap-4">
         <div
           className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
-          style={{ height: axisExtent }}
+          style={{ height: gridExtent }}
         >
-          <div className="grid h-full grid-rows-10 content-start justify-items-end gap-0">
+          <div className="flex h-full w-full flex-col items-end">
             {axis.map((value) => (
               <span
                 key={`row-${value}`}
                 className="flex w-full items-center justify-end"
-                style={{ height: tileSize, lineHeight: `${tileSize}px` }}
+                style={{
+                  height: tileSize,
+                  lineHeight: `${tileSize}px`,
+                  flex: tileSize > 0 ? `0 0 ${tileSize}px` : undefined,
+                }}
               >
                 {value}
               </span>
@@ -152,21 +155,29 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
                   </div>
                 );
               })}
+              <div
+                className="clarity-grid-overlay"
+                style={tileSize > 0 ? { backgroundSize: `${tileSize}px ${tileSize}px` } : undefined}
+              />
             </div>
-            <div className="clarity-grid-overlay" />
           </div>
         </div>
       </div>
       <div
         className="mt-2 text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
-        style={{ width: axisExtent }}
+        style={{ width: gridExtent }}
       >
         <div className="grid grid-cols-10">
           {axis.map((value) => (
             <span
               key={`col-${value}`}
               className="flex items-center justify-center"
-              style={{ height: tileSize, lineHeight: `${tileSize}px` }}
+              style={{
+                height: tileSize,
+                lineHeight: `${tileSize}px`,
+                width: tileSize,
+                minWidth: tileSize,
+              }}
             >
               {value}
             </span>

--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -164,7 +164,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         </div>
         <div aria-hidden />
         <div
-          className="grid grid-cols-10 justify-items-center text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
+          className="mx-auto grid grid-cols-10 justify-items-center text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{
             width: gridExtent > 0 ? gridExtent : undefined,
           }}


### PR DESCRIPTION
## Summary
- add an atlas helper to reuse the Explorateur tileset within the clarity module
- rebuild the Clarity map grid with atlas sprites for ground, blocked cells, goal, and player while aligning numeric axes with tile sizing
- remove start/goal text overlays and keep the starting cell rendered with standard grass

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d96c9154f88322a284a2434cbc9edb