### PR TITLE
Allow simulation chat stages to keep blank-labelled fields

### DIFF
--- a/frontend/src/modules/step-sequence/modules/FormStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/FormStep.tsx
@@ -376,7 +376,7 @@ export function validateFieldSpec(spec: unknown): spec is FieldSpec {
   if (typeof base.id !== "string" || base.id.trim().length === 0) {
     return false;
   }
-  if (typeof base.label !== "string" || base.label.trim().length === 0) {
+  if (typeof base.label !== "string") {
     return false;
   }
 

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -204,11 +204,11 @@ function normalizeSimulationChatConfig(config: unknown): SimulationChatConfig {
   };
 
   const title =
-    typeof base.title === "string" && base.title.trim().length > 0
+    typeof base.title === "string"
       ? base.title
       : DEFAULT_TITLE;
   const help =
-    typeof base.help === "string" && base.help.trim().length > 0
+    typeof base.help === "string"
       ? base.help
       : DEFAULT_HELP;
 

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -115,33 +115,22 @@ function cloneFieldSpec(field: FieldSpec): FieldSpec {
   }
 }
 
-const TEMPORARY_FIELD_LABEL = "__simulation_chat_field_label__";
-
 function normalizeFieldSpecForStage(spec: unknown): FieldSpec | null {
   if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
     return null;
   }
 
   const original = spec as Record<string, unknown>;
-  const rawLabel = typeof original.label === "string" ? original.label : "";
-  const labelForValidation =
-    rawLabel.trim().length > 0 ? rawLabel : TEMPORARY_FIELD_LABEL;
-
   const candidate = {
     ...original,
-    label: labelForValidation,
+    label: typeof original.label === "string" ? original.label : "",
   };
 
   if (!validateFieldSpec(candidate)) {
     return null;
   }
 
-  const normalized = {
-    ...candidate,
-    label: rawLabel,
-  } as FieldSpec;
-
-  return cloneFieldSpec(normalized);
+  return cloneFieldSpec(candidate as FieldSpec);
 }
 
 function isStageAnswerLike(value: unknown): value is StageAnswer {

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -224,13 +224,9 @@ function normalizeSimulationChatConfig(config: unknown): SimulationChatConfig {
       : DEFAULT_HELP;
 
   const aiRole =
-    typeof base.roles?.ai === "string" && base.roles.ai.trim().length > 0
-      ? base.roles.ai
-      : DEFAULT_ROLE_AI;
+    typeof base.roles?.ai === "string" ? base.roles.ai : DEFAULT_ROLE_AI;
   const userRole =
-    typeof base.roles?.user === "string" && base.roles.user.trim().length > 0
-      ? base.roles.user
-      : DEFAULT_ROLE_USER;
+    typeof base.roles?.user === "string" ? base.roles.user : DEFAULT_ROLE_USER;
 
   const missionId =
     typeof base.missionId === "string" && base.missionId.trim().length > 0

--- a/frontend/tests/step-sequence/FormStep.test.tsx
+++ b/frontend/tests/step-sequence/FormStep.test.tsx
@@ -279,6 +279,13 @@ describe("validateFieldSpec", () => {
     expect(validateFieldSpec(spec)).toBe(true);
   });
 
+  it("accepts specs whose labels are temporarily blank", () => {
+    const spec = createDefaultFieldSpec("textarea_with_counter");
+    spec.label = "";
+
+    expect(validateFieldSpec(spec)).toBe(true);
+  });
+
   it("rejects malformed specs", () => {
     const invalid = { id: "", label: "", type: "unknown" } as unknown;
     expect(validateFieldSpec(invalid)).toBe(false);

--- a/frontend/tests/step-sequence/SimulationChatStep.test.tsx
+++ b/frontend/tests/step-sequence/SimulationChatStep.test.tsx
@@ -90,4 +90,19 @@ describe("SimulationChatStep", () => {
     expect(remainingInputs).toHaveLength(1);
     expect(remainingInputs[0]).toHaveValue("");
   });
+
+  it("preserves the AI role label while editing", async () => {
+    const config: SimulationChatConfig = {
+      ...baseConfig,
+      roles: { ai: "Intelligence", user: "Participant" },
+      stages: [],
+    };
+
+    renderSimulationChatStep(config);
+
+    const [input] = await screen.findAllByLabelText("Libellé du rôle IA");
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(input).toHaveValue("");
+  });
 });

--- a/frontend/tests/step-sequence/SimulationChatStep.test.tsx
+++ b/frontend/tests/step-sequence/SimulationChatStep.test.tsx
@@ -105,4 +105,25 @@ describe("SimulationChatStep", () => {
 
     expect(input).toHaveValue("");
   });
+
+  it("allows clearing the title and help without restoring defaults", async () => {
+    const config: SimulationChatConfig = {
+      ...baseConfig,
+      stages: [],
+    };
+
+    renderSimulationChatStep(config);
+
+    const [submitLabelInput] = await screen.findAllByLabelText("Libellé du bouton");
+    const settingsPanel = submitLabelInput.closest("aside");
+    expect(settingsPanel).not.toBeNull();
+
+    const titleInput = within(settingsPanel as HTMLElement).getByLabelText("Titre");
+    fireEvent.change(titleInput, { target: { value: "" } });
+    expect(titleInput).toHaveValue("");
+
+    const helpTextarea = within(settingsPanel as HTMLElement).getByLabelText("Aide contextuelle");
+    fireEvent.change(helpTextarea, { target: { value: "" } });
+    expect(helpTextarea).toHaveValue("");
+  });
 });


### PR DESCRIPTION
## Summary
- adjust simulation chat stage normalization so field specs with temporary empty labels are preserved while keeping structural validation
- add regression tests covering blank label normalization and edit-mode preservation of the field editor

## Testing
- npm --prefix frontend test -- SimulationChatStep

------
https://chatgpt.com/codex/tasks/task_e_68d9746d8f4883228366dc23417eda00