### PR TITLE
Clarify demo session launch step in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Le frontend React dispose d'un mode test permettant de contourner la page de con
 
 - Définissez `VITE_ADMIN_TEST_MODE=true` dans `.env.local` ou via la ligne de commande avant de lancer `npm run dev --prefix frontend`.
 - Depuis `/admin/connexion`, utilisez le bandeau « mode test » pour déclencher la session de démonstration. Le routeur préserve automatiquement la destination initialement demandée.
+- Après ouverture du bandeau, cliquez sur « Lancer la session de démonstration » pour accéder aux captures d'écran et à l'ensemble des interfaces protégées.
 - Les tests et captures d'écran peuvent être réalisés sans véritables identifiants ni appels réseau aux APIs d'authentification.
 
 ## Tests frontend


### PR DESCRIPTION
## Summary
- remind administrators to click "Lancer la session de démonstration" after opening the mode test banner to view protected content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97ec5b33483228b0e8f677bd69f43