### PR TITLE
Limit Explorateur World config to inventory overrides

### DIFF
--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -30,7 +30,6 @@ import {
   cloneStepConfig,
   cloneStepDefinition,
   ensureStepHasQuarterPrefix,
-  sanitizeSteps,
 } from "./explorateurIA/configUtils";
 import {
   cloneQuarter,
@@ -2532,21 +2531,15 @@ export function sanitizeExplorateurIAConfig(
     quarterDesignerSteps?: unknown;
   };
   const terrain = sanitizeTerrainConfig(base.terrain);
-  const steps = sanitizeSteps(base.steps);
   const quarters = sanitizeQuarterConfigs(
     base.quarters,
     DEFAULT_EXPLORATEUR_QUARTERS
   );
   const derived = deriveQuarterData(quarters);
-  const expandedQuarterSteps = expandQuarterSteps(
-    steps.length > 0 ? steps : getDefaultExplorateurSteps(),
-    WORLD1_QUARTER_STEPS,
-    derived.quarterOrder
-  );
-  const { designerSteps, quarterSteps } = sanitizeQuarterDesignerSteps(
-    base.quarterDesignerSteps,
+  const quarterSteps = cloneQuarterStepMap(WORLD1_QUARTER_STEPS);
+  const designerSteps = createDefaultQuarterDesignerStepMap(
     quarters,
-    expandedQuarterSteps
+    quarterSteps
   );
   return {
     terrain,

--- a/frontend/tests/pages/ExplorateurIA.config.test.ts
+++ b/frontend/tests/pages/ExplorateurIA.config.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createDefaultExplorateurIAConfig,
+  sanitizeExplorateurIAConfig,
+} from "../../src/pages/ExplorateurIA";
+import { DEFAULT_EXPLORATEUR_QUARTERS } from "../../src/pages/explorateurIA/config";
+
+describe("sanitizeExplorateurIAConfig", () => {
+  it("retire les étapes personnalisées pour ne conserver que la séquence par défaut", () => {
+    const defaultConfig = createDefaultExplorateurIAConfig();
+    const dirtyConfig = {
+      ...defaultConfig,
+      steps: [
+        {
+          id: "custom:step",
+          component: "rich-content",
+          config: { title: "Titre personnalisé" },
+        },
+      ],
+      quarterDesignerSteps: {
+        clarte: [
+          {
+            id: "clarte:custom",
+            component: "rich-content",
+            config: { title: "Contenu inattendu" },
+          },
+        ],
+      },
+    };
+
+    const sanitized = sanitizeExplorateurIAConfig(dirtyConfig);
+
+    expect(sanitized.steps).toEqual(defaultConfig.steps);
+    expect(sanitized.quarterDesignerSteps).toEqual(
+      defaultConfig.quarterDesignerSteps
+    );
+  });
+
+  it("préserve uniquement les inventaires lors de la sanitation des quartiers", () => {
+    const defaultConfig = createDefaultExplorateurIAConfig();
+    const dirtyConfig = {
+      ...defaultConfig,
+      quarters: defaultConfig.quarters.map((quarter) =>
+        quarter.id === "clarte"
+          ? {
+              ...quarter,
+              label: "Label modifié",
+              color: "#000000",
+              inventory: {
+                ...quarter.inventory!,
+                title: "Boussole revisitée",
+              },
+            }
+          : quarter
+      ),
+    };
+
+    const sanitized = sanitizeExplorateurIAConfig(dirtyConfig);
+    const defaultClarte = DEFAULT_EXPLORATEUR_QUARTERS.find(
+      (quarter) => quarter.id === "clarte"
+    );
+    const sanitizedClarte = sanitized.quarters.find(
+      (quarter) => quarter.id === "clarte"
+    );
+
+    expect(defaultClarte).toBeDefined();
+    expect(sanitizedClarte).toBeDefined();
+    expect(sanitizedClarte?.label).toBe(defaultClarte?.label);
+    expect(sanitizedClarte?.color).toBe(defaultClarte?.color);
+    expect(sanitizedClarte?.inventory?.title).toBe("Boussole revisitée");
+  });
+});


### PR DESCRIPTION
## Summary
- reset Explorateur World sanitization to drop custom step definitions and always rebuild the default sequence
- limit quarter sanitization to preserving inventory overrides while restoring default metadata
- add unit tests covering the sanitization behaviour

## Testing
- npm --prefix frontend test -- --run ExplorateurIA.config.test.ts *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d98108ea508322af738e66a4f1d9cc