### PR TITLE
Élargir l'affichage du parcours de clarté

### DIFF
--- a/frontend/src/modules/clarity/components.tsx
+++ b/frontend/src/modules/clarity/components.tsx
@@ -130,8 +130,8 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
             </div>
           )}
         </div>
-        <div className="relative flex justify-center">
-          <div className="relative w-full max-w-[520px]">
+        <div className="relative flex justify-start">
+          <div className="relative w-full">
             <div className="relative aspect-square w-full">
               <div
                 ref={gridRef}
@@ -191,7 +191,7 @@ export function ClarityGrid({ player, target, blocked, visited }: ClarityGridPro
         </div>
         <div aria-hidden />
         <div
-          className="relative mx-auto text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
+          className="relative text-[11px] font-semibold text-[color:var(--brand-charcoal)]/70 md:text-xs"
           style={{
             width: gridRect.width > 0 ? gridRect.width : undefined,
             height: hasTileMeasurements ? tileHeight : undefined,

--- a/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceActivity.tsx
@@ -194,6 +194,10 @@ export function StepSequenceActivity({
         return <StepComponent {...componentProps} />;
       }
 
+      const containerClassName =
+        StepComponent.stepSequenceContainerClassName ??
+        "mx-auto flex w-full max-w-4xl flex-col gap-6";
+
       const canGoBack = stepIndex > 0;
       const isLastStep = stepIndex === stepCount - 1;
       const resolvedComponentKey = resolveStepComponentKey(step);
@@ -273,7 +277,7 @@ export function StepSequenceActivity({
         StepComponent.stepSequenceHideTitleInHeader !== true;
 
       return (
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <div className={containerClassName}>
           <header className="space-y-3 text-center">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
               {indicatorLabel}

--- a/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/clarity/ClarityMapStep.tsx
@@ -29,6 +29,8 @@ import type {
 import type {
   CompositeStepModuleDefinition,
   StepComponentProps,
+  StepComponentWithMetadata,
+  StepSequenceLayoutOverrides,
 } from "../../types";
 import { StepSequenceContext } from "../../types";
 
@@ -978,11 +980,9 @@ export function ClarityMapStep({
         </fieldset>
       )}
 
-      <div className="grid gap-6 lg:grid-cols-[3fr,2fr]">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,22rem)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,24rem)] 2xl:grid-cols-[minmax(0,1.6fr)_minmax(0,24rem)]">
         <div className="space-y-4">
-          <div className="rounded-3xl border border-white/40 bg-white/30 p-4 shadow-inner backdrop-blur">
-            <ClarityGrid player={playerPosition} target={target} blocked={blocked} visited={visited} />
-          </div>
+          <ClarityGrid player={playerPosition} target={target} blocked={blocked} visited={visited} />
           <div className="flex flex-wrap gap-3">
             <button
               type="button"
@@ -1052,3 +1052,13 @@ export function ClarityMapStep({
     </form>
   );
 }
+
+const CLARITY_MAP_LAYOUT_OVERRIDES: StepSequenceLayoutOverrides = Object.freeze({
+  innerClassName: "max-w-7xl",
+});
+
+const clarityMapStepWithMetadata = ClarityMapStep as StepComponentWithMetadata;
+clarityMapStepWithMetadata.stepSequenceLayoutOverrides =
+  CLARITY_MAP_LAYOUT_OVERRIDES;
+clarityMapStepWithMetadata.stepSequenceContainerClassName =
+  "mx-auto flex w-full max-w-6xl flex-col gap-6";

--- a/frontend/src/modules/step-sequence/types.ts
+++ b/frontend/src/modules/step-sequence/types.ts
@@ -85,6 +85,7 @@ export type StepComponentWithMetadata = ComponentType<StepComponentProps> & {
   stepSequenceWrapper?: StepSequenceWrapperPreference;
   stepSequenceLayoutOverrides?: StepSequenceLayoutOverrides;
   stepSequenceHideTitleInHeader?: boolean;
+  stepSequenceContainerClassName?: string;
 };
 
 export type StepRegistry = Record<string, StepComponentWithMetadata>;


### PR DESCRIPTION
## Summary
- allow StepSequence modules to override the default wrapper width through metadata
- expand the Clarity map layout and request wider activity bounds so the grid fills more horizontal space
- register Clarity-specific layout overrides to keep the plan sidebar compact while the map stretches

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d9c71645a483228994b72cf967ed99