### PR TITLE
feat: add live simulation chat streaming mode

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,6 +69,26 @@ MAX_STEPS_PER_ACTION = 20
 DEFAULT_PLAN_MODEL = "gpt-5-mini"
 DEFAULT_PLAN_VERBOSITY = "medium"
 DEFAULT_PLAN_THINKING = "medium"
+DEFAULT_SIMULATION_CHAT_MODEL = "gpt-5-mini"
+
+SIMULATION_CHAT_RESPONSE_SCHEMA = {
+    "name": "simulation_chat_response",
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "reply": {
+                "type": "string",
+                "description": "Texte renvoyé à l’apprenant.",
+            },
+            "shouldEnd": {
+                "type": "boolean",
+                "description": "Indique si la discussion doit se terminer.",
+            },
+        },
+        "required": ["reply", "shouldEnd"],
+    },
+}
 
 DEFAULT_ACTIVITY_GENERATION_SYSTEM_MESSAGE = " ".join(
     [
@@ -1311,6 +1331,63 @@ def _extract_plan_from_response(response: Any) -> PlanModel | None:
     return None
 
 
+def _extract_simulation_chat_response(response: Any) -> SimulationChatResponsePayload | None:
+    if response is None:
+        return None
+
+    direct_parsed = getattr(response, "parsed", None)
+    if direct_parsed:
+        try:
+            if isinstance(direct_parsed, SimulationChatResponsePayload):
+                return direct_parsed
+            if isinstance(direct_parsed, dict):
+                return SimulationChatResponsePayload.model_validate(direct_parsed)
+        except ValidationError:
+            return None
+
+    output_items = getattr(response, "output", None)
+    if output_items is None and isinstance(response, dict):
+        output_items = response.get("output")
+    if not output_items:
+        return None
+
+    for item in output_items:
+        content = getattr(item, "content", None)
+        if content is None and isinstance(item, dict):
+            content = item.get("content")
+        if not content:
+            continue
+        for part in content:
+            parsed = getattr(part, "parsed", None)
+            if parsed:
+                try:
+                    if isinstance(parsed, SimulationChatResponsePayload):
+                        return parsed
+                    if isinstance(parsed, dict):
+                        return SimulationChatResponsePayload.model_validate(parsed)
+                except ValidationError:
+                    continue
+            if isinstance(part, dict) and "parsed" in part:
+                try:
+                    return SimulationChatResponsePayload.model_validate(part["parsed"])
+                except ValidationError:
+                    continue
+            text = getattr(part, "text", None)
+            if text is None and isinstance(part, dict):
+                text = part.get("text")
+            if not text:
+                continue
+            try:
+                parsed_text = json.loads(text)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            try:
+                return SimulationChatResponsePayload.model_validate(parsed_text)
+            except ValidationError:
+                continue
+    return None
+
+
 def _request_plan_from_llm(client: ResponsesClient, payload: PlanRequest) -> PlanModel:
     last_error: PlanGenerationError | None = None
     for attempt in range(2):
@@ -1449,6 +1526,17 @@ def _sse_headers() -> dict[str, str]:
         "X-Accel-Buffering": "no",
         "Connection": "keep-alive",
     }
+
+
+def _yield_text_chunks(text: str, chunk_size: int = 160) -> Generator[str, None, None]:
+    if not text:
+        return
+    length = len(text)
+    start = 0
+    while start < length:
+        end = min(length, start + chunk_size)
+        yield text[start:end]
+        start = end
 
 
 def _extract_text_from_response(response) -> str:
@@ -1915,6 +2003,26 @@ class SubmissionRequest(BaseModel):
     stage_index: int = Field(..., alias="stageIndex", ge=0, le=29)
     payload: Any
     run_id: str | None = Field(default=None, alias="runId")
+
+
+class SimulationChatMessage(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    role: Literal["user", "ai", "assistant"]
+    content: str = Field(..., min_length=1, max_length=6000)
+
+
+class SimulationChatRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, str_strip_whitespace=True)
+
+    system_message: str = Field(..., alias="systemMessage", min_length=1, max_length=6000)
+    messages: list[SimulationChatMessage] = Field(default_factory=list)
+    model: str | None = None
+
+
+class SimulationChatResponsePayload(BaseModel):
+    reply: str = Field(..., min_length=1, max_length=8000)
+    should_end: bool = Field(..., alias="shouldEnd")
 
 
 class ActivityProgressRequest(BaseModel):
@@ -4020,6 +4128,76 @@ def _handle_prompt_evaluation(payload: PromptEvaluationRequest) -> PromptEvaluat
     return PromptEvaluationResponseModel(evaluation=evaluation, raw=raw)
 
 
+def _handle_simulation_chat(payload: SimulationChatRequest) -> StreamingResponse:
+    client = _ensure_client()
+    model_name = payload.model or DEFAULT_SIMULATION_CHAT_MODEL
+    model = _validate_model(model_name)
+
+    system_message = payload.system_message.strip()
+    if not system_message:
+        raise HTTPException(status_code=400, detail="systemMessage ne peut pas être vide.")
+
+    prepared_messages: list[dict[str, str]] = []
+    for message in payload.messages:
+        normalized_role = (message.role or "").lower()
+        role = "assistant" if normalized_role in {"ai", "assistant"} else "user"
+        content = message.content.strip()
+        if not content:
+            continue
+        prepared_messages.append({"role": role, "content": content})
+
+    if not prepared_messages:
+        raise HTTPException(status_code=400, detail="Le message utilisateur est requis.")
+    if prepared_messages[-1]["role"] != "user":
+        raise HTTPException(
+            status_code=400,
+            detail="Le dernier message doit provenir de l'utilisateur.",
+        )
+
+    def stream_response() -> Generator[str, None, None]:
+        yield _sse_comment("simulation-chat")
+        try:
+            with client.responses.stream(
+                model=model,
+                input=[{"role": "system", "content": system_message}, *prepared_messages],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": SIMULATION_CHAT_RESPONSE_SCHEMA,
+                },
+            ) as stream:
+                for event in stream:
+                    if event.type == "response.error":
+                        error_message = "Erreur du service de génération"
+                        details = getattr(event, "error", None)
+                        if isinstance(details, dict):
+                            error_message = details.get("message", error_message)
+                        raise HTTPException(status_code=500, detail=error_message)
+                final_response = stream.get_final_response()
+        except HTTPException as exc:
+            yield _sse_event("error", {"message": exc.detail})
+            return
+        except Exception as exc:  # pragma: no cover - defensive catch
+            yield _sse_event("error", {"message": str(exc)})
+            return
+
+        parsed = _extract_simulation_chat_response(final_response)
+        if parsed is None:
+            yield _sse_event("error", {"message": "Réponse du modèle invalide."})
+            return
+
+        reply_text = parsed.reply.strip()
+        if reply_text:
+            for chunk in _yield_text_chunks(reply_text):
+                yield _sse_event("delta", {"text": chunk})
+        yield _sse_event("done", {"shouldEnd": parsed.should_end})
+
+    return StreamingResponse(
+        stream_response(),
+        media_type="text/event-stream",
+        headers=_sse_headers(),
+    )
+
+
 @app.post("/api/summary")
 def fetch_summary(payload: SummaryRequest, _: None = Depends(_require_api_key)) -> StreamingResponse:
     return _handle_summary(payload)
@@ -4028,6 +4206,13 @@ def fetch_summary(payload: SummaryRequest, _: None = Depends(_require_api_key)) 
 @app.post("/summary")
 def fetch_summary_legacy(payload: SummaryRequest, _: None = Depends(_require_api_key)) -> StreamingResponse:
     return _handle_summary(payload)
+
+
+@app.post("/api/simulation-chat")
+def stream_simulation_chat(
+    payload: SimulationChatRequest, _: None = Depends(_require_api_key)
+) -> StreamingResponse:
+    return _handle_simulation_chat(payload)
 
 
 @app.post("/api/prompt-evaluation", response_model=PromptEvaluationResponseModel)

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -613,6 +613,9 @@ def create_simulation_chat_step(
     stages: Sequence[Mapping[str, Any]] | None = None,
     mode: str | None = None,
     system_message: str | None = None,
+    model: str | None = None,
+    verbosity: str | None = None,
+    thinking: str | None = None,
 ) -> StepDefinition:
     """Crée une étape « simulation-chat » dédiée aux jeux de rôle guidés.
 
@@ -669,6 +672,24 @@ def create_simulation_chat_step(
         if stripped_message:
             normalized_system_message = stripped_message
 
+    normalized_model = None
+    if isinstance(model, str):
+        stripped_model = model.strip()
+        if stripped_model:
+            normalized_model = stripped_model
+
+    normalized_verbosity = None
+    if isinstance(verbosity, str):
+        normalized = verbosity.strip().lower()
+        if normalized in {"low", "medium", "high"}:
+            normalized_verbosity = normalized
+
+    normalized_thinking = None
+    if isinstance(thinking, str):
+        normalized = thinking.strip().lower()
+        if normalized in {"minimal", "medium", "high"}:
+            normalized_thinking = normalized
+
     config = {
         "title": str(title),
         "help": str(help_text),
@@ -677,6 +698,9 @@ def create_simulation_chat_step(
         "stages": normalized_stages,
         "mode": normalized_mode,
         "systemMessage": normalized_system_message,
+        "model": normalized_model,
+        "verbosity": normalized_verbosity,
+        "thinking": normalized_thinking,
     }
     return {
         "id": str(step_id),

--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -611,6 +611,8 @@ def create_simulation_chat_step(
     mission_id: str | None = None,
     roles: Mapping[str, Any] | None = None,
     stages: Sequence[Mapping[str, Any]] | None = None,
+    mode: str | None = None,
+    system_message: str | None = None,
 ) -> StepDefinition:
     """Crée une étape « simulation-chat » dédiée aux jeux de rôle guidés.
 
@@ -629,6 +631,10 @@ def create_simulation_chat_step(
     stages:
         Liste ordonnée d'étapes internes, chacune contenant un prompt et une
         configuration de champs pour la réponse de l'utilisateur.
+    mode:
+        Mode de fonctionnement de la simulation ("scripted" ou "live").
+    system_message:
+        Message système optionnel utilisé pour initialiser le modèle en mode « live ».
 
     Returns
     -------
@@ -656,12 +662,21 @@ def create_simulation_chat_step(
                 }
             )
 
+    normalized_mode = "live" if isinstance(mode, str) and mode.strip().lower() == "live" else "scripted"
+    normalized_system_message = None
+    if isinstance(system_message, str):
+        stripped_message = system_message.strip()
+        if stripped_message:
+            normalized_system_message = stripped_message
+
     config = {
         "title": str(title),
         "help": str(help_text),
         "missionId": mission_id,
         "roles": normalized_roles,
         "stages": normalized_stages,
+        "mode": normalized_mode,
+        "systemMessage": normalized_system_message,
     }
     return {
         "id": str(step_id),

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -163,6 +163,9 @@ def test_create_simulation_chat_step_sets_roles_and_stages() -> None:
         "stages",
         "mode",
         "systemMessage",
+        "model",
+        "verbosity",
+        "thinking",
     }
     assert config["roles"] == {"ai": "Coach", "user": "Participant"}
     assert len(config["stages"]) == 1
@@ -176,6 +179,9 @@ def test_create_simulation_chat_step_sets_roles_and_stages() -> None:
     }
     assert config["mode"] == "scripted"
     assert config["systemMessage"] is None
+    assert config["model"] is None
+    assert config["verbosity"] is None
+    assert config["thinking"] is None
 
 
 def test_create_simulation_chat_step_accepts_live_mode() -> None:
@@ -191,6 +197,9 @@ def test_create_simulation_chat_step_accepts_live_mode() -> None:
     config = step["config"]
     assert config["mode"] == "live"
     assert config["systemMessage"] == "Conduis la discussion."
+    assert config["model"] is None
+    assert config["verbosity"] is None
+    assert config["thinking"] is None
 
 
 def test_create_info_cards_step_includes_columns_and_cards() -> None:

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -155,7 +155,15 @@ def test_create_simulation_chat_step_sets_roles_and_stages() -> None:
     )
 
     config = step["config"]
-    assert set(config) == {"title", "help", "missionId", "roles", "stages"}
+    assert set(config) == {
+        "title",
+        "help",
+        "missionId",
+        "roles",
+        "stages",
+        "mode",
+        "systemMessage",
+    }
     assert config["roles"] == {"ai": "Coach", "user": "Participant"}
     assert len(config["stages"]) == 1
     assert config["stages"][0]["prompt"] == "Question"
@@ -166,6 +174,23 @@ def test_create_simulation_chat_step_sets_roles_and_stages() -> None:
         "allowEmpty",
         "submitLabel",
     }
+    assert config["mode"] == "scripted"
+    assert config["systemMessage"] is None
+
+
+def test_create_simulation_chat_step_accepts_live_mode() -> None:
+    step = create_simulation_chat_step(
+        step_id="simulation",
+        title="Simulation",
+        help_text="Aide",
+        mode="live",
+        system_message="  Conduis la discussion.  ",
+        stages=[],
+    )
+
+    config = step["config"]
+    assert config["mode"] == "live"
+    assert config["systemMessage"] == "Conduis la discussion."
 
 
 def test_create_info_cards_step_includes_columns_and_cards() -> None:

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -920,6 +920,9 @@ export function SimulationChatStep({
                 return next;
               });
               setConversationFinished(shouldEnd);
+              if (supportsManualAdvance) {
+                setManualAdvanceDisabled?.(!shouldEnd);
+              }
               if (shouldEnd) {
                 setLiveError(null);
                 if (!supportsManualAdvance) {
@@ -969,6 +972,7 @@ export function SimulationChatStep({
       liveInput,
       runId,
       supportsManualAdvance,
+      setManualAdvanceDisabled,
     ]
   );
 

--- a/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/SimulationChatStep.tsx
@@ -978,32 +978,26 @@ export function SimulationChatStep({
       runId: runId ?? null,
       conversation: {
         messages: conversationRef.current.map(({ isStreaming: _omit, ...rest }) => rest),
-        finished: true,
+        finished: conversationFinished,
       },
     };
-  }, [history, runId]);
+  }, [conversationFinished, history, runId]);
 
   useEffect(() => {
     if (!supportsManualAdvance || !setManualAdvanceHandler) {
       return;
     }
 
-    if (!conversationFinished) {
-      setManualAdvanceHandler(null);
-      setManualAdvanceDisabled?.(false);
-      return;
-    }
-
     setManualAdvanceHandler(manualAdvanceHandler);
-    setManualAdvanceDisabled?.(false);
+    setManualAdvanceDisabled?.(!conversationFinished);
 
     return () => {
       setManualAdvanceHandler(null);
       setManualAdvanceDisabled?.(false);
     };
   }, [
-    conversationFinished,
     manualAdvanceHandler,
+    conversationFinished,
     setManualAdvanceDisabled,
     setManualAdvanceHandler,
     supportsManualAdvance,

--- a/frontend/src/modules/step-sequence/modules/index.ts
+++ b/frontend/src/modules/step-sequence/modules/index.ts
@@ -29,9 +29,12 @@ import {
 } from "./FormStep";
 import type {
   SimulationChatConfig,
+  SimulationChatConversationMessage,
+  SimulationChatMode,
   SimulationChatPayload,
   SimulationChatStageConfig,
 } from "./SimulationChatStep";
+import { DEFAULT_SIMULATION_SYSTEM_MESSAGE } from "./SimulationChatStep";
 import "./workshop";
 import "./explorateur-world";
 import type {
@@ -82,7 +85,14 @@ export {
   sanitizeFormValues,
   validateFieldSpec,
 };
-export type { SimulationChatConfig, SimulationChatPayload, SimulationChatStageConfig };
+export type {
+  SimulationChatConfig,
+  SimulationChatConversationMessage,
+  SimulationChatMode,
+  SimulationChatPayload,
+  SimulationChatStageConfig,
+};
+export { DEFAULT_SIMULATION_SYSTEM_MESSAGE };
 export type { RichContentStepConfig, RichContentStepContent };
 export type { RichContentMediaItem };
 export type {

--- a/frontend/src/modules/step-sequence/tools.ts
+++ b/frontend/src/modules/step-sequence/tools.ts
@@ -757,6 +757,9 @@ interface CreateSimulationChatStepInput extends ToolBaseInput {
   mode?: SimulationChatMode;
   systemMessage?: string;
   stages?: SimulationChatStageInput[];
+  model?: string;
+  verbosity?: string;
+  thinking?: string;
 }
 
 const DEFAULT_SIMULATION_TITLE = "Simulation conversation";
@@ -823,6 +826,9 @@ const createSimulationChatStep: StepSequenceFunctionTool<
           enum: ["scripted", "live"],
         },
         systemMessage: { type: "string" },
+        model: { type: "string", enum: Array.from(MODEL_CHOICES) },
+        verbosity: { type: "string", enum: Array.from(VERBOSITY_CHOICES) },
+        thinking: { type: "string", enum: Array.from(THINKING_CHOICES) },
       },
     },
   },
@@ -841,6 +847,18 @@ const createSimulationChatStep: StepSequenceFunctionTool<
       DEFAULT_SIMULATION_SYSTEM_MESSAGE,
       { allowEmpty: false }
     );
+    const model: SimulationChatConfig["model"] =
+      typeof input.model === "string" && MODEL_CHOICES.has(input.model)
+        ? (input.model as SimulationChatConfig["model"])
+        : (DEFAULT_MODEL as SimulationChatConfig["model"]);
+    const verbosity: SimulationChatConfig["verbosity"] =
+      typeof input.verbosity === "string" && VERBOSITY_CHOICES.has(input.verbosity as VerbosityChoice)
+        ? (input.verbosity as SimulationChatConfig["verbosity"])
+        : (DEFAULT_VERBOSITY as SimulationChatConfig["verbosity"]);
+    const thinking: SimulationChatConfig["thinking"] =
+      typeof input.thinking === "string" && THINKING_CHOICES.has(input.thinking as ThinkingChoice)
+        ? (input.thinking as SimulationChatConfig["thinking"])
+        : (DEFAULT_THINKING as SimulationChatConfig["thinking"]);
     const roles = {
       ai: sanitizeString(input.roles?.ai, DEFAULT_SIMULATION_ROLE_AI, {
         allowEmpty: false,
@@ -890,6 +908,9 @@ const createSimulationChatStep: StepSequenceFunctionTool<
       stages,
       mode,
       systemMessage,
+      model,
+      verbosity,
+      thinking,
       ...(missionId ? { missionId } : {}),
     };
 

--- a/frontend/tests/step-sequence/SimulationChatStep.test.tsx
+++ b/frontend/tests/step-sequence/SimulationChatStep.test.tsx
@@ -1,10 +1,14 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { SimulationChatConfig } from "../../src/modules/step-sequence/modules";
 import { DEFAULT_SIMULATION_SYSTEM_MESSAGE } from "../../src/modules/step-sequence/modules";
 import SimulationChatStep from "../../src/modules/step-sequence/modules/SimulationChatStep";
-import type { StepComponentProps } from "../../src/modules/step-sequence/types";
+import { StepSequenceContext } from "../../src/modules/step-sequence/types";
+import type {
+  StepComponentProps,
+  StepSequenceContextValue,
+} from "../../src/modules/step-sequence/types";
 
 function renderSimulationChatStep(config: SimulationChatConfig) {
   const props: StepComponentProps = {
@@ -131,5 +135,80 @@ describe("SimulationChatStep", () => {
     const helpTextarea = within(settingsPanel as HTMLElement).getByLabelText("Aide contextuelle");
     fireEvent.change(helpTextarea, { target: { value: "" } });
     expect(helpTextarea).toHaveValue("");
+  });
+
+  it("registers a manual advance handler once the live conversation ends", async () => {
+    const setManualAdvanceHandler = vi.fn();
+    const setManualAdvanceDisabled = vi.fn();
+    const onAdvance = vi.fn();
+
+    const config: SimulationChatConfig = {
+      ...baseConfig,
+      mode: "live",
+      stages: [],
+    };
+
+    const props: StepComponentProps = {
+      definition: { id: "simulation", component: "simulation-chat", config },
+      config,
+      payload: {
+        history: [],
+        runId: "run-42",
+        conversation: {
+          messages: [
+            { id: "msg-user", role: "user", content: "Bonjour" },
+            { id: "msg-ai", role: "ai", content: "Salut" },
+          ],
+          finished: true,
+        },
+      },
+      isActive: true,
+      isEditMode: false,
+      onAdvance,
+      onUpdateConfig: vi.fn(),
+    };
+
+    const contextValue: StepSequenceContextValue = {
+      stepIndex: 0,
+      stepCount: 1,
+      steps: [],
+      payloads: {},
+      isEditMode: false,
+      onAdvance: vi.fn(),
+      onUpdateConfig: vi.fn(),
+      goToStep: vi.fn(),
+      setManualAdvanceHandler,
+      setManualAdvanceDisabled,
+      getManualAdvanceState: () => ({ handler: null, disabled: false }),
+    };
+
+    render(
+      <StepSequenceContext.Provider value={contextValue}>
+        <SimulationChatStep {...props} />
+      </StepSequenceContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(setManualAdvanceHandler).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    expect(onAdvance).not.toHaveBeenCalled();
+
+    const lastCallIndex = setManualAdvanceHandler.mock.calls.length - 1;
+    const handler = lastCallIndex >= 0 ? (setManualAdvanceHandler.mock.calls[lastCallIndex]?.[0] as (() => unknown)) : undefined;
+    expect(typeof handler).toBe("function");
+    expect(handler?.()).toEqual({
+      history: [],
+      runId: "run-42",
+      conversation: {
+        messages: [
+          { id: "msg-user", role: "user", content: "Bonjour" },
+          { id: "msg-ai", role: "ai", content: "Salut" },
+        ],
+        finished: true,
+      },
+    });
+
+    expect(setManualAdvanceDisabled).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/tests/step-sequence/SimulationChatStep.test.tsx
+++ b/frontend/tests/step-sequence/SimulationChatStep.test.tsx
@@ -27,6 +27,9 @@ describe("SimulationChatStep", () => {
     roles: { ai: "IA", user: "Participant" },
     mode: "scripted",
     systemMessage: DEFAULT_SIMULATION_SYSTEM_MESSAGE,
+    model: "gpt-5-mini",
+    verbosity: "medium",
+    thinking: "medium",
   };
 
   it("keeps fields whose labels are temporarily empty during normalization", async () => {

--- a/frontend/tests/step-sequence/SimulationChatStep.test.tsx
+++ b/frontend/tests/step-sequence/SimulationChatStep.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { SimulationChatConfig } from "../../src/modules/step-sequence/modules";
+import { DEFAULT_SIMULATION_SYSTEM_MESSAGE } from "../../src/modules/step-sequence/modules";
 import SimulationChatStep from "../../src/modules/step-sequence/modules/SimulationChatStep";
 import type { StepComponentProps } from "../../src/modules/step-sequence/types";
 
@@ -24,6 +25,8 @@ describe("SimulationChatStep", () => {
     title: "Simulation",
     help: "Aide",
     roles: { ai: "IA", user: "Participant" },
+    mode: "scripted",
+    systemMessage: DEFAULT_SIMULATION_SYSTEM_MESSAGE,
   };
 
   it("keeps fields whose labels are temporarily empty during normalization", async () => {


### PR DESCRIPTION
## Summary
- add simulation chat request/response models and SSE endpoint backed by the Response API with structured output
- propagate simulation chat mode and system message through step configuration utilities and toolkit tools
- update the simulation chat frontend workflow, exports, and tests to support live streaming and designer controls

## Testing
- pytest backend/tests/test_step_sequence_components.py
- npm --prefix frontend test -- --run *(fails: vitest missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da9642de788322a359bbbb53237bab