### PR TITLE
Ensure frontend can resolve backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,14 @@ services:
       FRONTEND_ORIGIN: ${FRONTEND_ORIGIN:-http://localhost:4173,http://localhost:5173}
       API_AUTH_TOKEN: ${API_AUTH_TOKEN}
       PORT: "8001"
+    ports:
+      - "8001:8001"
     volumes:
       - ./lti-keys:/app/lti-keys
       - ./storage:/app/storage
-    network_mode: "host"
+    networks:
+      - default
+      - moodle-network
 
   frontend:
     build:
@@ -27,6 +31,8 @@ services:
       - backend
     ports:
       - "4173:80"
+    networks:
+      - default
 
 networks:
   moodle-network:


### PR DESCRIPTION
## Summary
- expose the backend API on port 8001 instead of relying on host networking
- attach the backend container to both the default and Moodle networks for name resolution
- ensure the frontend container shares the default network with the backend service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc14257e84832298b6ba02b0d9521d