### PR TITLE
Remove unused external Moodle network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - ./storage:/app/storage
     networks:
       - default
-      - moodle-network
 
   frontend:
     build:
@@ -33,8 +32,3 @@ services:
       - "4173:80"
     networks:
       - default
-
-networks:
-  moodle-network:
-    external: true
-    name: moodle-docker_default


### PR DESCRIPTION
## Summary
- remove the unused external `moodle-docker_default` network from docker-compose
- keep both services on the default network only

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc17b1d6548322bbe9998fe9a04b59