### PR TITLE
Improve admin dashboard responsiveness on mobile

### DIFF
--- a/frontend/src/pages/admin/AdminActivityTrackingPage.tsx
+++ b/frontend/src/pages/admin/AdminActivityTrackingPage.tsx
@@ -220,8 +220,8 @@ export function AdminActivityTrackingPage(): JSX.Element {
       ) : (
         <>
           {/* Users Table */}
-          <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
-            <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+          <div className="w-full overflow-x-auto rounded-3xl border border-white/60 shadow-sm">
+            <table className="w-full min-w-full table-fixed divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
               <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
                 <tr>
                   <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Utilisateur</th>
@@ -240,17 +240,17 @@ export function AdminActivityTrackingPage(): JSX.Element {
                           {user.displayName}
                         </span>
                         {user.email && (
-                          <span className="text-xs text-[color:var(--brand-charcoal)]/70">
+                          <span className="break-words text-xs text-[color:var(--brand-charcoal)]/70">
                             {user.email}
                           </span>
                         )}
-                        <span className="text-xs text-[color:var(--brand-charcoal)]/50">
+                        <span className="break-words text-xs text-[color:var(--brand-charcoal)]/50">
                           ID: {user.subject}
                         </span>
                       </div>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="text-xs text-[color:var(--brand-charcoal)]">
+                      <span className="break-words text-xs text-[color:var(--brand-charcoal)]">
                         {user.issuer}
                       </span>
                     </td>

--- a/frontend/src/pages/admin/AdminInvitationCodesPage.tsx
+++ b/frontend/src/pages/admin/AdminInvitationCodesPage.tsx
@@ -185,8 +185,8 @@ export function AdminInvitationCodesPage(): JSX.Element {
           <AdminSkeleton lines={6} />
         </div>
       ) : hasInvitations ? (
-        <div className="overflow-hidden rounded-3xl border border-white/60 bg-white/95 shadow-lg">
-          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+        <div className="w-full overflow-x-auto rounded-3xl border border-white/60 bg-white/95 shadow-lg">
+          <table className="w-full min-w-full table-fixed divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
             <thead className="bg-[color:var(--brand-sand)]/30 text-left uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
               <tr>
                 <th scope="col" className="px-4 py-3 font-semibold">

--- a/frontend/src/pages/admin/AdminLayout.tsx
+++ b/frontend/src/pages/admin/AdminLayout.tsx
@@ -27,7 +27,7 @@ export function AdminLayout(): JSX.Element {
   }, [expiresAt]);
 
   return (
-    <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-10 px-4 py-10 text-[color:var(--brand-black)] sm:px-6">
+    <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-10 px-4 py-10 text-[color:var(--brand-black)] sm:px-6">
       <header className="space-y-6 rounded-3xl border border-white/60 bg-white/95 p-8 shadow-lg backdrop-blur">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 text-sm text-[color:var(--brand-charcoal)]/90 sm:text-base">
@@ -69,8 +69,8 @@ export function AdminLayout(): JSX.Element {
         </div>
       </header>
 
-      <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
-        <aside className="space-y-4 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-md backdrop-blur">
+      <div className="grid w-full gap-6 lg:grid-cols-[260px_1fr]">
+        <aside className="min-w-0 space-y-4 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-md backdrop-blur">
           <p className="text-xs font-semibold uppercase tracking-wide text-[color:var(--brand-charcoal)]/70">
             Navigation
           </p>
@@ -98,7 +98,7 @@ export function AdminLayout(): JSX.Element {
             </p>
           </div>
         </aside>
-        <section className="rounded-3xl border border-white/60 bg-white/95 p-6 shadow-lg backdrop-blur">
+        <section className="min-w-0 rounded-3xl border border-white/60 bg-white/95 p-6 shadow-lg backdrop-blur">
           <Outlet />
         </section>
       </div>

--- a/frontend/src/pages/admin/AdminLocalUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminLocalUsersPage.tsx
@@ -232,8 +232,8 @@ export function AdminLocalUsersPage(): JSX.Element {
           Aucun compte interne n’a encore été créé.
         </div>
       ) : (
-        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
-          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+        <div className="w-full overflow-x-auto rounded-3xl border border-white/60 shadow-sm">
+          <table className="w-full min-w-full table-fixed divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
             <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
               <tr>
                 <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Utilisateur</th>

--- a/frontend/src/pages/admin/AdminLtiUsersPage.tsx
+++ b/frontend/src/pages/admin/AdminLtiUsersPage.tsx
@@ -202,8 +202,8 @@ export function AdminLtiUsersPage(): JSX.Element {
           Aucun utilisateur à afficher pour ces filtres.
         </div>
       ) : (
-        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
-          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+        <div className="w-full overflow-x-auto rounded-3xl border border-white/60 shadow-sm">
+          <table className="w-full min-w-full table-fixed divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
             <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
               <tr>
                 <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Utilisateur</th>
@@ -250,9 +250,9 @@ export function AdminLtiUsersPage(): JSX.Element {
                       ) : null}
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.email ?? "—"}</td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.issuer}</td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{user.subject}</td>
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">{user.email ?? "—"}</td>
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">{user.issuer}</td>
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">{user.subject}</td>
                   <td className="px-4 py-3 text-[color:var(--brand-black)]">{user.loginCount}</td>
                   <td className="px-4 py-3 text-[color:var(--brand-black)]">{user.completedActivities}</td>
                   <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{formatDate(user.lastLoginAt)}</td>

--- a/frontend/src/pages/admin/AdminPlatformsPage.tsx
+++ b/frontend/src/pages/admin/AdminPlatformsPage.tsx
@@ -388,8 +388,8 @@ export function AdminPlatformsPage(): JSX.Element {
           Aucune plateforme configurée pour le moment.
         </div>
       ) : (
-        <div className="overflow-hidden rounded-3xl border border-white/60 shadow-sm">
-          <table className="min-w-full divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
+        <div className="w-full overflow-x-auto rounded-3xl border border-white/60 shadow-sm">
+          <table className="w-full min-w-full table-fixed divide-y divide-[color:var(--brand-charcoal)]/10 text-sm">
             <thead className="bg-[color:var(--brand-sand)]/60 text-[color:var(--brand-charcoal)]/80">
               <tr>
                 <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide">Issuer</th>
@@ -403,12 +403,12 @@ export function AdminPlatformsPage(): JSX.Element {
             <tbody className="divide-y divide-[color:var(--brand-charcoal)]/10 bg-white/95">
               {platforms.map((platform) => (
                 <tr key={`${platform.issuer}-${platform.clientId}`} className="transition hover:bg-[color:var(--brand-sand)]/40">
-                  <td className="px-4 py-3 font-medium text-[color:var(--brand-black)]">{platform.issuer}</td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">{platform.clientId}</td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">
+                  <td className="break-words px-4 py-3 font-medium text-[color:var(--brand-black)]">{platform.issuer}</td>
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">{platform.clientId}</td>
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">
                     {platform.audience ? platform.audience : <span className="text-xs italic text-[color:var(--brand-charcoal)]/60">(non défini)</span>}
                   </td>
-                  <td className="px-4 py-3 text-[color:var(--brand-charcoal)]">
+                  <td className="break-words px-4 py-3 text-[color:var(--brand-charcoal)]">
                     {platform.deploymentIds.length > 0 ? platform.deploymentIds.join(", ") : "—"}
                   </td>
                   <td className="px-4 py-3">


### PR DESCRIPTION
## Summary
- ensure the admin shell stretches to the viewport and allows content to shrink on small screens
- allow admin tables to scroll within their cards and wrap long identifiers instead of stretching the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc200cbd4c8322937a9f31130c7639