### PR TITLE
Fix mobile overflow in activity generation conversation

### DIFF
--- a/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
@@ -422,7 +422,7 @@ export function ActivityGenerationConversationPage(): JSX.Element {
             </span>
           </p>
           <div className="rounded-2xl border border-sky-100 bg-white/90 p-3 text-xs text-sky-900/80">
-            <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-xs">
+            <pre className="max-h-64 max-w-full overflow-y-auto whitespace-pre-wrap break-words text-xs">
               {JSON.stringify(toolCall.result, null, 2)}
             </pre>
           </div>
@@ -436,7 +436,7 @@ export function ActivityGenerationConversationPage(): JSX.Element {
           Appel d'outil en attente
         </h3>
         <div className="rounded-2xl border border-sky-100 bg-white/95 p-3 text-xs text-sky-900/80">
-          <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-xs">
+          <pre className="max-h-64 max-w-full overflow-y-auto whitespace-pre-wrap break-words text-xs">
             {JSON.stringify(toolCall.result ?? toolCall.arguments ?? {}, null, 2)}
           </pre>
         </div>


### PR DESCRIPTION
## Summary
- prevent JSON previews in the AI activity generation conversation from overflowing horizontally on small screens

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68dc2280ca9883228352e3f2237b5189