### PR TITLE
Fix default component key for generated activities

### DIFF
--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -175,6 +175,12 @@ def create_step_sequence_activity(
             }
         )
 
+    component_key = normalized_metadata["componentKey"]
+    if not isinstance(component_key, str) or not component_key.strip():
+        normalized_metadata["componentKey"] = "step-sequence"
+    else:
+        normalized_metadata["componentKey"] = component_key.strip()
+
     return {
         "id": str(activity_id),
         "componentKey": normalized_metadata["componentKey"],

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -376,6 +376,15 @@ def test_create_step_sequence_activity_sets_defaults() -> None:
     assert activity["stepSequence"] == []
 
 
+def test_create_step_sequence_activity_recovers_missing_component_key() -> None:
+    activity = create_step_sequence_activity(
+        activity_id="atelier",
+        metadata={"componentKey": None},
+    )
+
+    assert activity["componentKey"] == "step-sequence"
+
+
 def test_create_step_sequence_activity_keeps_metadata_and_steps() -> None:
     steps = [create_rich_content_step(step_id="intro", title="Intro")]
     activity = create_step_sequence_activity(


### PR DESCRIPTION
## Summary
- normalize the generated activity metadata so componentKey always defaults to `step-sequence`
- add regression coverage ensuring a `None` componentKey falls back to the default value

## Testing
- pytest backend/tests/test_step_sequence_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dc382aa7888322bd23bec0fae4d4e9