### PR TITLE
Fix OpenAI responses serialization by removing timestamp field

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4629,7 +4629,7 @@ def _serialize_conversation_entry(message: Mapping[str, Any]) -> dict[str, Any]:
     fallback = {
         key: deepcopy(value)
         for key, value in message.items()
-        if key not in {"type", "summary", "id"}
+        if key not in {"type", "summary", "id", "timestamp"}
     }
     if "role" not in fallback:
         fallback["role"] = "assistant"


### PR DESCRIPTION
## Summary
- prevent serialized conversation messages from including timestamp fields that the Responses API rejects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3e21e0ac8322a93d459548256185