### PR TITLE
Use SSE for activity generation updates

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -608,13 +608,13 @@ function normalizeActivityGenerationJobToolCall(
   };
 }
 
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: ActivityGenerationJob
 ): ActivityGenerationJob;
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: Record<string, unknown>
 ): ActivityGenerationJob;
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: Record<string, unknown> | ActivityGenerationJob
 ): ActivityGenerationJob {
   if (!raw || typeof raw !== "object") {


### PR DESCRIPTION
## Summary
- add a streaming admin endpoint to push activity generation job updates and synced conversations via SSE
- export the activity generation job normalizer and rework the admin conversation page to consume SSE instead of polling
- drive the conversation loader state from the live stream status for clearer progress feedback

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68dd322d21a08322b047f3399498fec9