### PR TITLE
Use SSE for activity generation updates

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -524,13 +524,15 @@ export interface ConversationMessage {
   timestamp: string;
 }
 
+export type ConversationStatus = "pending" | "running" | "complete" | "error";
+
 export interface Conversation {
   id: string;
   jobId: string;
   username: string;
   activityId?: string | null;
   activityTitle?: string | null;
-  status: "running" | "complete" | "error";
+  status: ConversationStatus;
   messages: ConversationMessage[];
   modelName: string;
   createdAt: string;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -608,13 +608,13 @@ function normalizeActivityGenerationJobToolCall(
   };
 }
 
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: ActivityGenerationJob
 ): ActivityGenerationJob;
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: Record<string, unknown>
 ): ActivityGenerationJob;
-function normalizeActivityGenerationJob(
+export function normalizeActivityGenerationJob(
   raw: Record<string, unknown> | ActivityGenerationJob
 ): ActivityGenerationJob {
   if (!raw || typeof raw !== "object") {

--- a/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
@@ -317,14 +317,14 @@ export function ActivityGenerationConversationPage(): JSX.Element {
           }
           buffer += decoder.decode(value, { stream: true });
 
-          let eventBoundary = buffer.indexOf("\n\n");
-          while (eventBoundary !== -1) {
-            const rawEvent = buffer.slice(0, eventBoundary);
-            buffer = buffer.slice(eventBoundary + 2);
+          let delimiterMatch = buffer.match(/\r?\n\r?\n/);
+          while (delimiterMatch && delimiterMatch.index !== undefined) {
+            const rawEvent = buffer.slice(0, delimiterMatch.index);
+            buffer = buffer.slice(delimiterMatch.index + delimiterMatch[0].length);
             if (rawEvent.trim()) {
               handleEvent(rawEvent);
             }
-            eventBoundary = buffer.indexOf("\n\n");
+            delimiterMatch = buffer.match(/\r?\n\r?\n/);
           }
         }
 


### PR DESCRIPTION
## Summary
- add a streaming admin endpoint to push activity generation job updates and synced conversations via SSE
- export the activity generation job normalizer and rework the admin conversation page to consume SSE instead of polling
- drive the conversation loader state from the live stream status for clearer progress feedback

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68dd322d21a08322b047f3399498fec9