### PR TITLE
Fix AI form generation and add step preview link

### DIFF
--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -492,11 +492,36 @@ def create_form_step(
         raise ValueError("Un identifiant d'étape est requis pour create_form_step.")
 
     normalized_fields: list[dict[str, Any]] = []
+    seen_field_ids: set[str] = set()
+    fallback_prefix = str(resolved_step_id)
+    fallback_counter = 1
     for field in fields:
         if not isinstance(field, Mapping):
             continue
 
         normalized_field = deepcopy(field)
+        raw_field_id = normalized_field.get("id")
+        normalized_id: str | None
+        if isinstance(raw_field_id, str):
+            normalized_id = raw_field_id.strip()
+        elif raw_field_id is not None:
+            normalized_id = str(raw_field_id).strip()
+        else:
+            normalized_id = None
+
+        if not normalized_id:
+            normalized_id = f"{fallback_prefix}-field-{fallback_counter}"
+            fallback_counter += 1
+
+        base_id = normalized_id
+        suffix = 2
+        while normalized_id in seen_field_ids:
+            normalized_id = f"{base_id}-{suffix}"
+            suffix += 1
+
+        normalized_field["id"] = normalized_id
+        seen_field_ids.add(normalized_id)
+
         normalized_field.setdefault("minBullets", None)
         normalized_field.setdefault("maxBullets", None)
         normalized_field.setdefault("maxWordsPerBullet", None)

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -121,6 +121,47 @@ def test_create_form_step_accepts_id_alias() -> None:
     assert field["correctAnswers"] is None
 
 
+def test_create_form_step_generates_unique_field_ids() -> None:
+    step = create_form_step(
+        step_id="formulaire",
+        fields=[
+            {
+                "label": "Choix A",
+                "type": "single_choice",
+                "options": [{"value": "a", "label": "Option A"}],
+            },
+            {
+                "id": None,
+                "label": "Choix B",
+                "type": "single_choice",
+                "options": [{"value": "b", "label": "Option B"}],
+            },
+            {
+                "id": " question ",
+                "label": "Choix C",
+                "type": "single_choice",
+                "options": [{"value": "c", "label": "Option C"}],
+            },
+            {
+                "id": "question",
+                "label": "Choix D",
+                "type": "single_choice",
+                "options": [{"value": "d", "label": "Option D"}],
+            },
+        ],
+    )
+
+    field_ids = [field["id"] for field in step["config"]["fields"]]
+
+    assert field_ids == [
+        "formulaire-field-1",
+        "formulaire-field-2",
+        "question",
+        "question-2",
+    ]
+    assert len(field_ids) == len(set(field_ids))
+
+
 def test_merge_step_definition_preserves_full_form_fields() -> None:
     cached = create_form_step(
         step_id="formulaire",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { AdminPlatformsPage } from "./pages/admin/AdminPlatformsPage";
 import { AdminActivityTrackingPage } from "./pages/admin/AdminActivityTrackingPage";
 import { AdminActivityGenerationPage } from "./pages/admin/AdminActivityGenerationPage";
 import { ActivityGenerationConversationPage } from "./pages/admin/ActivityGenerationConversationPage";
+import { ActivityGenerationStepPreviewPage } from "./pages/admin/ActivityGenerationStepPreviewPage";
 import { AdminInvitationCodesPage } from "./pages/admin/AdminInvitationCodesPage";
 import { activities as activitiesClient } from "./api";
 
@@ -140,6 +141,10 @@ function App(): JSX.Element {
         <Route
           path="/assistant-ia"
           element={<ActivityGenerationConversationPage />}
+        />
+        <Route
+          path="/assistant-ia/apercu/:jobId/:stepId"
+          element={<ActivityGenerationStepPreviewPage />}
         />
         <Route path="/admin" element={<AdminLayout />}>
           <Route index element={<Navigate to="platforms" replace />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import ActivitySelector from "./pages/ActivitySelector";
@@ -20,10 +20,32 @@ import { AdminLtiUsersPage } from "./pages/admin/AdminLtiUsersPage";
 import { AdminPlatformsPage } from "./pages/admin/AdminPlatformsPage";
 import { AdminActivityTrackingPage } from "./pages/admin/AdminActivityTrackingPage";
 import { AdminActivityGenerationPage } from "./pages/admin/AdminActivityGenerationPage";
-import { ActivityGenerationConversationPage } from "./pages/admin/ActivityGenerationConversationPage";
-import { ActivityGenerationStepPreviewPage } from "./pages/admin/ActivityGenerationStepPreviewPage";
 import { AdminInvitationCodesPage } from "./pages/admin/AdminInvitationCodesPage";
 import { activities as activitiesClient } from "./api";
+
+const ActivityGenerationConversationPage = lazy(() =>
+  import("./pages/admin/ActivityGenerationConversationPage").then(
+    (module) => ({ default: module.ActivityGenerationConversationPage })
+  )
+);
+
+const ActivityGenerationStepPreviewPage = lazy(() =>
+  import("./pages/admin/ActivityGenerationStepPreviewPage").then(
+    (module) => ({ default: module.ActivityGenerationStepPreviewPage })
+  )
+);
+
+function AdminAssistantFallback(): JSX.Element {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[color:var(--brand-sand)]/40 px-4">
+      <div className="rounded-3xl bg-white px-6 py-8 text-center shadow-sm">
+        <p className="text-sm font-medium text-[color:var(--brand-charcoal)]">
+          Chargement de l’assistant…
+        </p>
+      </div>
+    </div>
+  );
+}
 
 function AdminLoginRedirect(): JSX.Element {
   const location = useLocation();
@@ -140,11 +162,19 @@ function App(): JSX.Element {
       <Route element={<AdminGuard />}>
         <Route
           path="/assistant-ia"
-          element={<ActivityGenerationConversationPage />}
+          element={
+            <Suspense fallback={<AdminAssistantFallback />}>
+              <ActivityGenerationConversationPage />
+            </Suspense>
+          }
         />
         <Route
           path="/assistant-ia/apercu/:jobId/:stepId"
-          element={<ActivityGenerationStepPreviewPage />}
+          element={
+            <Suspense fallback={<AdminAssistantFallback />}>
+              <ActivityGenerationStepPreviewPage />
+            </Suspense>
+          }
         />
         <Route path="/admin" element={<AdminLayout />}>
           <Route index element={<Navigate to="platforms" replace />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,9 +1,7 @@
 import { API_BASE_URL, API_AUTH_KEY } from "./config";
 import type { ModelChoice, VerbosityChoice, ThinkingChoice } from "./config";
-import type {
-  StepDefinition,
-  StepSequenceToolDefinition,
-} from "./modules/step-sequence";
+import type { StepDefinition } from "./modules/step-sequence/types";
+import type { StepSequenceToolDefinition } from "./modules/step-sequence/tools";
 
 export type FieldType =
   | "bulleted_list"

--- a/frontend/src/modules/step-sequence/StepSequenceRenderer.tsx
+++ b/frontend/src/modules/step-sequence/StepSequenceRenderer.tsx
@@ -136,6 +136,16 @@ export function StepSequenceRenderer({
   }, []);
 
   const stepIdsKey = useMemo(() => steps.map((step) => step.id).join("|"), [steps]);
+  useEffect(() => {
+    const maxIndex = steps.length === 0 ? 0 : steps.length - 1;
+    const normalizedInitial = Number.isFinite(initialIndex)
+      ? Math.max(0, Math.min(initialIndex, maxIndex))
+      : 0;
+
+    setCurrentIndex((previousIndex) =>
+      previousIndex === normalizedInitial ? previousIndex : normalizedInitial
+    );
+  }, [initialIndex, stepIdsKey, steps.length]);
   const stepsSignature = useMemo(() => buildStepsSignature(steps), [steps]);
   const latestStepsRef = useRef(steps);
 

--- a/frontend/src/modules/step-sequence/index.tsx
+++ b/frontend/src/modules/step-sequence/index.tsx
@@ -1,5 +1,3 @@
-import { useContext } from "react";
-
 import { getStepComponent, registerStepComponent, STEP_COMPONENT_REGISTRY } from "./registry";
 import { StepSequenceRenderer } from "./StepSequenceRenderer";
 import type {
@@ -18,9 +16,10 @@ import {
   type StepDefinition,
   type StepRegistry,
   type StepSequenceActivityContextBridge,
-  type StepSequenceContextValue,
   type StepSequenceWrapperPreference,
 } from "./types";
+import type { StepSequenceContextValue } from "./types";
+import { useStepSequence } from "./useStepSequence";
 
 export function StepSequenceContainer(
   props: StepSequenceRendererProps
@@ -32,18 +31,11 @@ export function StepSequenceContainer(
   return <StepSequenceRenderer {...props} />;
 }
 
-export function useStepSequence(): StepSequenceContextValue {
-  const context = useContext(StepSequenceContext);
-  if (!context) {
-    throw new Error("useStepSequence must be used within a StepSequenceRenderer");
-  }
-  return context;
-}
-
 export {
   StepSequenceActivity,
   StepSequenceRenderer,
   StepSequenceContext,
+  useStepSequence,
   STEP_COMPONENT_REGISTRY,
   getStepComponent,
   registerStepComponent,

--- a/frontend/src/modules/step-sequence/modules/DualModelComparisonStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/DualModelComparisonStep.tsx
@@ -7,7 +7,7 @@ import {
   VERBOSITY_OPTIONS,
   type ModelConfig,
 } from "../../../config";
-import { useStepSequence } from "..";
+import { useStepSequence } from "../useStepSequence";
 import type { StepComponentProps } from "../types";
 import {
   runComparisonRequests,

--- a/frontend/src/modules/step-sequence/modules/explorateur-world/index.tsx
+++ b/frontend/src/modules/step-sequence/modules/explorateur-world/index.tsx
@@ -1,9 +1,14 @@
-import ExplorateurIA, {
+import { Suspense, lazy } from "react";
+
+import {
   createDefaultExplorateurIAConfig,
   sanitizeExplorateurIAConfig,
-  type ExplorateurIAConfig,
-  type ExplorateurIATerrainConfig,
-} from "../../../../pages/ExplorateurIA";
+} from "../../../../pages/explorateurIA/worldConfig";
+import type {
+  ExplorateurExperienceMode,
+  ExplorateurIAConfig,
+  ExplorateurIATerrainConfig,
+} from "../../../../pages/explorateurIA/worldConfig";
 import { registerStepComponent } from "../../registry";
 import type {
   StepComponentProps,
@@ -11,10 +16,28 @@ import type {
   StepSequenceLayoutOverrides,
 } from "../../types";
 
+const ExplorateurIALazy = lazy(() =>
+  import("../../../../pages/ExplorateurIA").then((module) => ({
+    default: module.default,
+  }))
+);
+
+function ExplorateurWorldFallback(): JSX.Element {
+  return (
+    <div className="flex h-full w-full items-center justify-center bg-slate-50 text-sm text-slate-500">
+      Chargement de l’Explorateur IA…
+    </div>
+  );
+}
+
 export function ExplorateurWorldStep(
   props: StepComponentProps
 ): JSX.Element {
-  return <ExplorateurIA {...props} />;
+  return (
+    <Suspense fallback={<ExplorateurWorldFallback />}>
+      <ExplorateurIALazy {...props} />
+    </Suspense>
+  );
 }
 
 const EXPLORATEUR_WORLD_LAYOUT_OVERRIDES: StepSequenceLayoutOverrides = Object.freeze({
@@ -42,7 +65,7 @@ export type {
   ExplorateurIAConfig as ExplorateurWorldConfig,
   ExplorateurIATerrainConfig as ExplorateurWorldTerrainConfig,
   ExplorateurExperienceMode as ExplorateurWorldExperienceMode,
-} from "../../../../pages/ExplorateurIA";
+} from "../../../../pages/explorateurIA/worldConfig";
 
 export const createDefaultExplorateurWorldConfig =
   createDefaultExplorateurIAConfig;

--- a/frontend/src/modules/step-sequence/modules/workshop/WorkshopComparisonStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/workshop/WorkshopComparisonStep.tsx
@@ -8,7 +8,7 @@ import {
   type ModelConfig,
 } from "../../../../config";
 import type { StepComponentProps } from "../../types";
-import { useStepSequence } from "../..";
+import { useStepSequence } from "../../useStepSequence";
 import type { WorkshopContextStepState } from "./WorkshopContextStep";
 import {
   runComparisonRequests,

--- a/frontend/src/modules/step-sequence/modules/workshop/WorkshopSynthesisStep.tsx
+++ b/frontend/src/modules/step-sequence/modules/workshop/WorkshopSynthesisStep.tsx
@@ -9,7 +9,7 @@ import {
 import { useActivityCompletion } from "../../../../hooks/useActivityCompletion";
 import type { Flashcard } from "../../../../types/flashcards";
 import type { StepComponentProps } from "../../types";
-import { useStepSequence } from "../..";
+import { useStepSequence } from "../../useStepSequence";
 import type { WorkshopComparisonStepState } from "./WorkshopComparisonStep";
 import type { WorkshopContextStepState } from "./WorkshopContextStep";
 

--- a/frontend/src/modules/step-sequence/useStepSequence.ts
+++ b/frontend/src/modules/step-sequence/useStepSequence.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { StepSequenceContext } from "./types";
+import type { StepSequenceContextValue } from "./types";
+
+export function useStepSequence(): StepSequenceContextValue {
+  const context = useContext(StepSequenceContext);
+  if (!context) {
+    throw new Error("useStepSequence must be used within a StepSequenceRenderer");
+  }
+  return context;
+}
+

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -38,7 +38,6 @@ import {
   type VerbosityChoice,
 } from "../config";
 import "../modules/step-sequence/modules";
-import { StepSequenceActivity } from "../modules/step-sequence/StepSequenceActivity";
 import { getStepComponent, STEP_COMPONENT_REGISTRY } from "../modules/step-sequence/registry";
 import {
   StepSequenceContext,
@@ -2676,7 +2675,8 @@ function ActivitySelector(): JSX.Element {
                 </li>
               ) : null}
             </ul>
-            {isEditMode && activity.component === StepSequenceActivity ? (
+            {isEditMode &&
+            activity.componentKey === STEP_SEQUENCE_COMPONENT_KEY ? (
               <button
                 type="button"
                 onClick={() => setStepSequenceEditorActivityId(activity.id)}

--- a/frontend/src/pages/ActivitySelector.tsx
+++ b/frontend/src/pages/ActivitySelector.tsx
@@ -37,17 +37,16 @@ import {
   type ThinkingChoice,
   type VerbosityChoice,
 } from "../config";
+import "../modules/step-sequence/modules";
+import { StepSequenceActivity } from "../modules/step-sequence/StepSequenceActivity";
+import { getStepComponent, STEP_COMPONENT_REGISTRY } from "../modules/step-sequence/registry";
 import {
-  StepSequenceActivity,
-  getStepComponent,
-  STEP_COMPONENT_REGISTRY,
   StepSequenceContext,
   isCompositeStepDefinition,
   resolveStepComponentKey,
   type CompositeStepConfig,
   type StepDefinition,
-} from "../modules/step-sequence";
-import "../modules/step-sequence/modules";
+} from "../modules/step-sequence/types";
 import { createDefaultExplorateurWorldConfig } from "../modules/step-sequence/modules/explorateur-world";
 import { useLTI } from "../hooks/useLTI";
 import { useAdminAuth } from "../providers/AdminAuthProvider";

--- a/frontend/src/pages/ExplorateurIA.tsx
+++ b/frontend/src/pages/ExplorateurIA.tsx
@@ -16,13 +16,15 @@ import mapPackAtlasDescription from "../assets/kenney_map-pack/Spritesheet/mapPa
 import { useAdminAuth } from "../providers/AdminAuthProvider";
 import {
   StepSequenceRenderer,
+  type StepSequenceRenderWrapperProps,
+} from "../modules/step-sequence/StepSequenceRenderer";
+import {
   StepSequenceContext,
   type StepComponentProps,
   type StepDefinition,
-  type StepSequenceRenderWrapperProps,
   type StepSequenceActivityContextBridge,
-} from "../modules/step-sequence";
-import { isCompositeStepDefinition } from "../modules/step-sequence/types";
+  isCompositeStepDefinition,
+} from "../modules/step-sequence/types";
 import { createExplorateurExport } from "./explorateurIA/export";
 import { classNames } from "./explorateurIA/utils";
 import {

--- a/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
@@ -9,10 +9,7 @@ import {
   type ConversationMessageToolCall,
   type GenerateActivityPayload,
 } from "../../api";
-import {
-  resolveStepComponentKey,
-  type StepDefinition,
-} from "../../modules/step-sequence";
+import { resolveStepComponentKey, type StepDefinition } from "../../modules/step-sequence/types";
 import { ConversationView } from "../../components/ConversationView";
 import { useAdminAuth } from "../../providers/AdminAuthProvider";
 import { MODEL_OPTIONS, VERBOSITY_OPTIONS, THINKING_OPTIONS } from "../../config";

--- a/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { admin, type ActivityGenerationJob } from "../../api";
+import { StepSequenceRenderer } from "../../modules/step-sequence";
+import type { StepDefinition } from "../../modules/step-sequence";
+import "../../modules/step-sequence/modules";
+import { useAdminAuth } from "../../providers/AdminAuthProvider";
+
+interface RouteParams {
+  jobId?: string;
+  stepId?: string;
+}
+
+function extractStepHighlight(step: StepDefinition | null): string | null {
+  if (!step) {
+    return null;
+  }
+
+  const directKeys: Array<keyof StepDefinition | string> = [
+    "title",
+    "label",
+    "name",
+    "heading",
+  ];
+
+  for (const key of directKeys) {
+    const value = (step as Record<string, unknown>)[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  const config = (step as { config?: unknown }).config;
+  if (config && typeof config === "object") {
+    const configMap = config as Record<string, unknown>;
+    for (const key of directKeys) {
+      const value = configMap[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+
+    const fields = configMap.fields;
+    if (Array.isArray(fields)) {
+      for (const field of fields) {
+        if (!field || typeof field !== "object") {
+          continue;
+        }
+        const label = (field as Record<string, unknown>).label;
+        if (typeof label === "string" && label.trim()) {
+          return label.trim();
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function ActivityGenerationStepPreviewPage(): JSX.Element {
+  const { jobId, stepId } = useParams<RouteParams>();
+  const navigate = useNavigate();
+  const { token } = useAdminAuth();
+  const [job, setJob] = useState<ActivityGenerationJob | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!jobId) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    const controller = new AbortController();
+
+    void admin.activities
+      .getGenerationJob(jobId, token, { signal: controller.signal })
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        setJob(result);
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        const detail =
+          err instanceof Error
+            ? err.message
+            : "Impossible de charger la tâche de génération.";
+        setError(detail);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [jobId, token]);
+
+  const steps = useMemo<StepDefinition[]>(() => {
+    if (!job?.cachedSteps) {
+      return [];
+    }
+    return Object.values(job.cachedSteps) as StepDefinition[];
+  }, [job?.cachedSteps]);
+
+  const initialIndex = useMemo(() => {
+    if (!stepId || steps.length === 0) {
+      return 0;
+    }
+    const index = steps.findIndex((step) => step.id === stepId);
+    return index >= 0 ? index : 0;
+  }, [stepId, steps]);
+
+  const activeStep = steps[initialIndex] ?? null;
+  const highlight = extractStepHighlight(activeStep);
+
+  if (!jobId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[color:var(--brand-sand)]/40 px-4">
+        <div className="max-w-md rounded-3xl border border-red-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-sm font-medium text-red-700">
+            Identifiant de tâche manquant.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate("/assistant-ia")}
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-[color:var(--brand-red)] px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-600"
+          >
+            Revenir à l’assistant
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[color:var(--brand-sand)]/40 py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <h1 className="text-xl font-semibold text-[color:var(--brand-black)]">
+              Aperçu de l’étape générée
+            </h1>
+            <p className="text-sm text-[color:var(--brand-charcoal)]/80">
+              Job {jobId}
+              {stepId ? ` · Étape ${stepId}` : ""}
+            </p>
+            {highlight ? (
+              <p className="text-xs text-[color:var(--brand-charcoal)]">
+                {highlight}
+              </p>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              to={`/assistant-ia?jobId=${encodeURIComponent(jobId)}`}
+              className="inline-flex items-center justify-center rounded-full border border-sky-300 px-4 py-2 text-xs font-semibold text-sky-700 transition hover:bg-sky-50"
+            >
+              Retour à la conversation
+            </Link>
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="inline-flex items-center justify-center rounded-full border border-gray-200 px-4 py-2 text-xs font-semibold text-gray-700 transition hover:bg-gray-50"
+            >
+              Précédent
+            </button>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="rounded-3xl border border-gray-200 bg-white/80 p-8 text-center text-sm text-gray-600 shadow-sm">
+            Chargement de l’étape en cours…
+          </div>
+        ) : error ? (
+          <div className="rounded-3xl border border-red-200 bg-red-50 p-6 text-sm text-red-700 shadow-sm">
+            {error}
+          </div>
+        ) : steps.length === 0 ? (
+          <div className="rounded-3xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-800 shadow-sm">
+            Aucune étape générée pour cette tâche pour le moment.
+          </div>
+        ) : (
+          <div className="rounded-3xl border border-white/70 bg-white/95 p-6 shadow-sm">
+            <StepSequenceRenderer
+              steps={steps}
+              initialIndex={initialIndex}
+              isEditMode={false}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
@@ -3,8 +3,8 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { admin, type ActivityGenerationJob } from "../../api";
 import {
-  STEP_COMPONENT_REGISTRY,
   StepSequenceRenderer,
+  getStepComponent,
   resolveStepComponentKey,
   type StepDefinition,
 } from "../../modules/step-sequence";
@@ -134,7 +134,7 @@ export function ActivityGenerationStepPreviewPage(): JSX.Element {
           continue;
         }
 
-        if (!STEP_COMPONENT_REGISTRY[componentKey]) {
+        if (!getStepComponent(componentKey)) {
           skipped += 1;
           continue;
         }

--- a/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationStepPreviewPage.tsx
@@ -2,13 +2,13 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import { admin, type ActivityGenerationJob } from "../../api";
+import "../../modules/step-sequence/modules";
+import { StepSequenceRenderer } from "../../modules/step-sequence/StepSequenceRenderer";
+import { getStepComponent } from "../../modules/step-sequence/registry";
 import {
-  StepSequenceRenderer,
-  getStepComponent,
   resolveStepComponentKey,
   type StepDefinition,
-} from "../../modules/step-sequence";
-import "../../modules/step-sequence/modules";
+} from "../../modules/step-sequence/types";
 import { useAdminAuth } from "../../providers/AdminAuthProvider";
 
 interface RouteParams {

--- a/frontend/src/pages/explorateurIA/configUtils.ts
+++ b/frontend/src/pages/explorateurIA/configUtils.ts
@@ -1,5 +1,5 @@
 import { isCompositeStepDefinition } from "../../modules/step-sequence/types";
-import type { StepDefinition } from "../../modules/step-sequence";
+import type { StepDefinition } from "../../modules/step-sequence/types";
 
 import type { QuarterId } from "./types";
 import type { QuarterSteps } from "./worlds/world1/steps";

--- a/frontend/src/pages/explorateurIA/designerUtils.ts
+++ b/frontend/src/pages/explorateurIA/designerUtils.ts
@@ -1,4 +1,4 @@
-import type { StepDefinition } from "../../modules/step-sequence";
+import type { StepDefinition } from "../../modules/step-sequence/types";
 
 import {
   cloneStepConfig,

--- a/frontend/src/pages/explorateurIA/modules/registry.tsx
+++ b/frontend/src/pages/explorateurIA/modules/registry.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 import type { ComponentType } from "react";
 
-import {
-  registerStepComponent,
-  type StepComponentProps,
-} from "../../../modules/step-sequence";
+import { registerStepComponent } from "../../../modules/step-sequence/registry";
+import type { StepComponentProps } from "../../../modules/step-sequence/types";
 
 export interface ExplorateurIAModuleConfig {
   type: string;

--- a/frontend/src/pages/explorateurIA/worldConfig.ts
+++ b/frontend/src/pages/explorateurIA/worldConfig.ts
@@ -1,0 +1,171 @@
+import { cloneStepDefinition, sanitizeSteps } from "./configUtils";
+import {
+  DEFAULT_DERIVED_QUARTERS,
+  DEFAULT_EXPLORATEUR_QUARTERS,
+  deriveQuarterData,
+  sanitizeQuarterConfigs,
+  type ExplorateurIAQuarterConfig,
+} from "./config";
+import {
+  createDefaultQuarterDesignerStepMap,
+  sanitizeQuarterDesignerSteps,
+  type QuarterDesignerStepMap,
+} from "./designerUtils";
+import {
+  expandQuarterSteps,
+  flattenQuarterSteps,
+  WORLD1_QUARTER_STEPS,
+  type QuarterSteps,
+} from "./worlds/world1/steps";
+import type { StepDefinition } from "../../modules/step-sequence/types";
+
+export type TerrainThemeId = "sand" | "grass" | "dirt" | "dirtGray" | "snow";
+
+const ALLOWED_TERRAIN_THEME_IDS: readonly TerrainThemeId[] = [
+  "sand",
+  "grass",
+  "dirt",
+  "dirtGray",
+  "snow",
+];
+
+export function isTerrainThemeId(value: unknown): value is TerrainThemeId {
+  return (
+    typeof value === "string" &&
+    (ALLOWED_TERRAIN_THEME_IDS as readonly string[]).includes(value)
+  );
+}
+
+export const DEFAULT_TERRAIN_THEME_ID: TerrainThemeId = "sand";
+export const WORLD_SEED = 1247;
+
+export interface ExplorateurIATerrainConfig {
+  themeId: TerrainThemeId;
+  seed: number;
+}
+
+export type ExplorateurExperienceMode = "guided" | "open-world";
+
+export const DEFAULT_EXPERIENCE_MODE: ExplorateurExperienceMode = "guided";
+
+export interface ExplorateurIAConfig {
+  terrain: ExplorateurIATerrainConfig;
+  steps: StepDefinition[];
+  quarterDesignerSteps: QuarterDesignerStepMap;
+  quarters: ExplorateurIAQuarterConfig[];
+  experienceMode: ExplorateurExperienceMode;
+}
+
+export function sanitizeTerrainConfig(
+  value: unknown
+): ExplorateurIATerrainConfig {
+  if (!value || typeof value !== "object") {
+    return { themeId: DEFAULT_TERRAIN_THEME_ID, seed: WORLD_SEED };
+  }
+
+  const base = value as Partial<ExplorateurIATerrainConfig> & {
+    theme?: unknown;
+    themeId?: unknown;
+    seed?: unknown;
+  };
+
+  const rawTheme = base.themeId ?? base.theme;
+  const themeId = isTerrainThemeId(rawTheme)
+    ? rawTheme
+    : DEFAULT_TERRAIN_THEME_ID;
+
+  const seed =
+    typeof base.seed === "number" && Number.isFinite(base.seed)
+      ? Math.trunc(base.seed)
+      : WORLD_SEED;
+
+  return { themeId, seed } satisfies ExplorateurIATerrainConfig;
+}
+
+export function sanitizeExperienceMode(
+  value: unknown
+): ExplorateurExperienceMode {
+  if (value === "open-world") {
+    return "open-world";
+  }
+  if (value === "guided") {
+    return "guided";
+  }
+  return DEFAULT_EXPERIENCE_MODE;
+}
+
+function getDefaultExplorateurSteps(): StepDefinition[] {
+  return flattenQuarterSteps(
+    WORLD1_QUARTER_STEPS,
+    DEFAULT_DERIVED_QUARTERS.quarterOrder
+  ).map(cloneStepDefinition);
+}
+
+export function createDefaultExplorateurIAConfig(): ExplorateurIAConfig {
+  const quarters = DEFAULT_EXPLORATEUR_QUARTERS.map((quarter) => ({
+    ...quarter,
+    inventory: quarter.inventory ? { ...quarter.inventory } : null,
+  }));
+  const derived = deriveQuarterData(quarters);
+  const quarterSteps = expandQuarterSteps(
+    getDefaultExplorateurSteps(),
+    WORLD1_QUARTER_STEPS,
+    derived.quarterOrder
+  );
+  const designerSteps = createDefaultQuarterDesignerStepMap(
+    quarters,
+    quarterSteps
+  );
+
+  return {
+    terrain: { themeId: DEFAULT_TERRAIN_THEME_ID, seed: WORLD_SEED },
+    steps: flattenQuarterSteps(quarterSteps, derived.quarterOrder),
+    quarterDesignerSteps: designerSteps,
+    quarters,
+    experienceMode: DEFAULT_EXPERIENCE_MODE,
+  } satisfies ExplorateurIAConfig;
+}
+
+export function sanitizeExplorateurIAConfig(
+  config: unknown
+): ExplorateurIAConfig {
+  if (!config || typeof config !== "object") {
+    return createDefaultExplorateurIAConfig();
+  }
+
+  const base = config as Partial<ExplorateurIAConfig> & {
+    terrain?: unknown;
+    steps?: unknown;
+    quarters?: unknown;
+    quarterDesignerSteps?: unknown;
+    experienceMode?: unknown;
+  };
+
+  const terrain = sanitizeTerrainConfig(base.terrain);
+  const steps = sanitizeSteps(base.steps);
+  const quarters = sanitizeQuarterConfigs(
+    base.quarters,
+    DEFAULT_EXPLORATEUR_QUARTERS
+  );
+  const experienceMode = sanitizeExperienceMode(base.experienceMode);
+  const derived = deriveQuarterData(quarters);
+  const expandedQuarterSteps = expandQuarterSteps(
+    steps.length > 0 ? steps : getDefaultExplorateurSteps(),
+    WORLD1_QUARTER_STEPS,
+    derived.quarterOrder
+  );
+  const { designerSteps, quarterSteps } = sanitizeQuarterDesignerSteps(
+    base.quarterDesignerSteps,
+    quarters,
+    expandedQuarterSteps
+  );
+
+  return {
+    terrain,
+    steps: flattenQuarterSteps(quarterSteps, derived.quarterOrder),
+    quarterDesignerSteps: designerSteps,
+    quarters,
+    experienceMode,
+  } satisfies ExplorateurIAConfig;
+}
+

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -1,7 +1,7 @@
 import {
   isCompositeStepDefinition,
   type StepDefinition,
-} from "../../../../modules/step-sequence";
+} from "../../../../modules/step-sequence/types";
 
 import {
   DEFAULT_CLARTE_QUIZ_CONFIG,


### PR DESCRIPTION
## Summary
- ensure backend keeps the full form step configuration when re-merging cached steps and surface cached steps in job status
- add regression tests covering the new merge logic
- surface step preview links during activity generation and add a dedicated StepSequence preview page

## Testing
- pytest backend/tests/test_step_sequence_components.py

------
https://chatgpt.com/codex/tasks/task_e_68dd86e1653c8322b8c9925bd8f210d0