### PR TITLE
Fix form step defaults to preserve generated questions

### DIFF
--- a/backend/app/step_sequence_components.py
+++ b/backend/app/step_sequence_components.py
@@ -434,17 +434,14 @@ def _sanitize_choice_options(field_id: str, options: Any) -> list[dict[str, Any]
             if not value_text or not label_text:
                 continue
             description = option.get("description")
-            if isinstance(description, str):
-                description_text = description.strip() or None
-            else:
-                description_text = None
-            sanitized.append(
-                {
-                    "value": value_text,
-                    "label": label_text,
-                    "description": description_text,
-                }
-            )
+            description_text = description.strip() if isinstance(description, str) else None
+            payload = {
+                "value": value_text,
+                "label": label_text,
+            }
+            if description_text:
+                payload["description"] = description_text
+            sanitized.append(payload)
 
     if sanitized:
         return sanitized
@@ -580,7 +577,6 @@ def create_form_step(
             normalized_id = ""
         if not normalized_id:
             normalized_id = f"{resolved_step_id}-field-{index}"
-        normalized_field["id"] = normalized_id
 
         raw_label = normalized_field.get("label")
         if isinstance(raw_label, str):
@@ -591,7 +587,6 @@ def create_form_step(
             normalized_label = str(raw_label).strip()
         if not normalized_label:
             normalized_label = normalized_id
-        normalized_field["label"] = normalized_label
 
         raw_type = normalized_field.get("type")
         if isinstance(raw_type, str):
@@ -600,115 +595,47 @@ def create_form_step(
             normalized_type = ""
         if normalized_type not in GUIDED_FIELD_TYPES:
             normalized_type = "textarea_with_counter"
-        normalized_field["type"] = normalized_type
 
         field_type = normalized_type
+        clean_field: dict[str, Any] = {
+            "id": normalized_id,
+            "label": normalized_label,
+            "type": field_type,
+        }
 
+        option_values: list[str] = []
         if field_type in {"single_choice", "multiple_choice"}:
-            normalized_options = _sanitize_choice_options(normalized_id, normalized_field.get("options"))
-            normalized_field["options"] = normalized_options
-            option_values = [option["value"] for option in normalized_options]
-        else:
-            normalized_field["options"] = None
-            option_values = []
+            options = _sanitize_choice_options(normalized_id, normalized_field.get("options"))
+            clean_field["options"] = options
+            option_values = [option["value"] for option in options]
 
         if field_type == "single_choice":
-            correct_answer = normalized_field.get("correctAnswer")
-            if not isinstance(correct_answer, str) or correct_answer not in option_values:
-                normalized_field["correctAnswer"] = option_values[0] if option_values else None
-            normalized_field["correctAnswers"] = None
+            correct_answer_raw = normalized_field.get("correctAnswer")
+            candidate = (
+                correct_answer_raw.strip()
+                if isinstance(correct_answer_raw, str)
+                else ""
+            )
+            if candidate and candidate in option_values:
+                clean_field["correctAnswer"] = candidate
+            elif option_values:
+                clean_field["correctAnswer"] = option_values[0]
         elif field_type == "multiple_choice":
             raw_answers = normalized_field.get("correctAnswers")
             filtered: list[str] = []
-            if isinstance(raw_answers, Sequence):
+            if isinstance(raw_answers, Sequence) and not isinstance(raw_answers, (str, bytes)):
                 seen: set[str] = set()
                 for value in raw_answers:
                     if not isinstance(value, str):
                         continue
-                    if value not in option_values or value in seen:
+                    trimmed = value.strip()
+                    if not trimmed or trimmed not in option_values or trimmed in seen:
                         continue
-                    seen.add(value)
-                    filtered.append(value)
-            normalized_field["correctAnswers"] = filtered or None
-            normalized_field["correctAnswer"] = None
-        else:
-            normalized_field["correctAnswer"] = None
-            normalized_field["correctAnswers"] = None
+                    seen.add(trimmed)
+                    filtered.append(trimmed)
+            if filtered:
+                clean_field["correctAnswers"] = filtered
 
-        if field_type == "bulleted_list":
-            min_bullets = _coerce_int(
-                normalized_field.get("minBullets"),
-                minimum=1,
-                fallback=_DEFAULT_BULLETED_LIST_MIN_BULLETS,
-            )
-            max_bullets = _coerce_int(
-                normalized_field.get("maxBullets"),
-                minimum=min_bullets,
-                fallback=max(_DEFAULT_BULLETED_LIST_MAX_BULLETS, min_bullets),
-            )
-            max_words_per_bullet = _coerce_int(
-                normalized_field.get("maxWordsPerBullet"),
-                minimum=1,
-                fallback=_DEFAULT_BULLETED_LIST_MAX_WORDS_PER_BULLET,
-            )
-            normalized_field["minBullets"] = min_bullets
-            normalized_field["maxBullets"] = max_bullets
-            normalized_field["maxWordsPerBullet"] = max_words_per_bullet
-            raw_requirements = normalized_field.get("mustContainAny")
-            if isinstance(raw_requirements, Sequence) and not isinstance(raw_requirements, (str, bytes)):
-                sanitized_requirements = [
-                    item.strip()
-                    for item in raw_requirements
-                    if isinstance(item, str) and item.strip()
-                ]
-                normalized_field["mustContainAny"] = sanitized_requirements or None
-            else:
-                normalized_field["mustContainAny"] = None
-        elif field_type in {"table_menu_day", "table_menu_full"}:
-            meals = normalized_field.get("meals")
-            sanitized_meals: list[str] = []
-            if isinstance(meals, Sequence) and not isinstance(meals, (str, bytes)):
-                for meal in meals:
-                    if not isinstance(meal, str):
-                        continue
-                    trimmed = meal.strip()
-                    if trimmed and trimmed not in sanitized_meals:
-                        sanitized_meals.append(trimmed)
-            if not sanitized_meals:
-                sanitized_meals = list(_DEFAULT_TABLE_MEALS)
-            normalized_field["meals"] = sanitized_meals
-        elif field_type == "textarea_with_counter":
-            min_words = _coerce_int(
-                normalized_field.get("minWords"),
-                minimum=0,
-                fallback=_DEFAULT_TEXTAREA_MIN_WORDS,
-            )
-            max_words = _coerce_int(
-                normalized_field.get("maxWords"),
-                minimum=min_words,
-                fallback=max(_DEFAULT_TEXTAREA_MAX_WORDS, min_words),
-            )
-            normalized_field["minWords"] = min_words
-            normalized_field["maxWords"] = max_words
-            forbid_words = normalized_field.get("forbidWords")
-            if isinstance(forbid_words, Sequence) and not isinstance(forbid_words, (str, bytes)):
-                sanitized_forbidden = [
-                    word.strip()
-                    for word in forbid_words
-                    if isinstance(word, str) and word.strip()
-                ]
-                normalized_field["forbidWords"] = sanitized_forbidden or None
-            else:
-                normalized_field["forbidWords"] = None
-            tone = normalized_field.get("tone")
-            normalized_field["tone"] = tone.strip() if isinstance(tone, str) and tone.strip() else None
-        elif field_type == "two_bullets":
-            normalized_field["maxWordsPerBullet"] = _coerce_int(
-                normalized_field.get("maxWordsPerBullet"),
-                minimum=1,
-                fallback=_DEFAULT_TWO_BULLETS_MAX_WORDS_PER_BULLET,
-            )
-        elif field_type == "multiple_choice":
             min_selections_value = normalized_field.get("minSelections")
             max_selections_value = normalized_field.get("maxSelections")
             min_selections: int | None
@@ -734,47 +661,97 @@ def create_form_step(
                 max_selections = None
 
             option_count = len(option_values)
-            if min_selections is not None and min_selections > option_count:
-                min_selections = option_count if option_count > 0 else None
-            if max_selections is not None and max_selections > option_count:
-                max_selections = option_count if option_count > 0 else None
+            if min_selections is not None and option_count and min_selections > option_count:
+                min_selections = option_count
+            if max_selections is not None and option_count and max_selections > option_count:
+                max_selections = option_count
             if (
                 min_selections is not None
                 and max_selections is not None
                 and max_selections < min_selections
             ):
                 max_selections = min_selections if min_selections > 0 else None
-            normalized_field["minSelections"] = min_selections
-            normalized_field["maxSelections"] = max_selections
-        else:
-            normalized_field.setdefault("minBullets", None)
-            normalized_field.setdefault("maxBullets", None)
-            normalized_field.setdefault("maxWordsPerBullet", None)
-            normalized_field.setdefault("mustContainAny", None)
-            normalized_field.setdefault("meals", None)
-            normalized_field.setdefault("minWords", None)
-            normalized_field.setdefault("maxWords", None)
-            normalized_field.setdefault("forbidWords", None)
-            normalized_field.setdefault("tone", None)
-            normalized_field.setdefault("minSelections", None)
-            normalized_field.setdefault("maxSelections", None)
 
-        normalized_field.setdefault("minBullets", None)
-        normalized_field.setdefault("maxBullets", None)
-        normalized_field.setdefault("maxWordsPerBullet", None)
-        normalized_field.setdefault("mustContainAny", None)
-        normalized_field.setdefault("meals", None)
-        normalized_field.setdefault("minWords", None)
-        normalized_field.setdefault("maxWords", None)
-        normalized_field.setdefault("forbidWords", None)
-        normalized_field.setdefault("tone", None)
-        normalized_field.setdefault("options", None)
-        normalized_field.setdefault("minSelections", None)
-        normalized_field.setdefault("maxSelections", None)
-        normalized_field.setdefault("correctAnswer", None)
-        normalized_field.setdefault("correctAnswers", None)
+            if min_selections is not None:
+                clean_field["minSelections"] = min_selections
+            if max_selections is not None:
+                clean_field["maxSelections"] = max_selections
+        elif field_type == "bulleted_list":
+            min_bullets = _coerce_int(
+                normalized_field.get("minBullets"),
+                minimum=1,
+                fallback=_DEFAULT_BULLETED_LIST_MIN_BULLETS,
+            )
+            max_bullets = _coerce_int(
+                normalized_field.get("maxBullets"),
+                minimum=min_bullets,
+                fallback=max(_DEFAULT_BULLETED_LIST_MAX_BULLETS, min_bullets),
+            )
+            max_words_per_bullet = _coerce_int(
+                normalized_field.get("maxWordsPerBullet"),
+                minimum=1,
+                fallback=_DEFAULT_BULLETED_LIST_MAX_WORDS_PER_BULLET,
+            )
+            clean_field["minBullets"] = min_bullets
+            clean_field["maxBullets"] = max_bullets
+            clean_field["maxWordsPerBullet"] = max_words_per_bullet
+            raw_requirements = normalized_field.get("mustContainAny")
+            if isinstance(raw_requirements, Sequence) and not isinstance(raw_requirements, (str, bytes)):
+                sanitized_requirements = [
+                    item.strip()
+                    for item in raw_requirements
+                    if isinstance(item, str) and item.strip()
+                ]
+                if sanitized_requirements:
+                    clean_field["mustContainAny"] = sanitized_requirements
+        elif field_type in {"table_menu_day", "table_menu_full"}:
+            meals = normalized_field.get("meals")
+            sanitized_meals: list[str] = []
+            if isinstance(meals, Sequence) and not isinstance(meals, (str, bytes)):
+                for meal in meals:
+                    if not isinstance(meal, str):
+                        continue
+                    trimmed = meal.strip()
+                    if trimmed and trimmed not in sanitized_meals:
+                        sanitized_meals.append(trimmed)
+            if not sanitized_meals:
+                sanitized_meals = list(_DEFAULT_TABLE_MEALS)
+            clean_field["meals"] = sanitized_meals
+        elif field_type == "textarea_with_counter":
+            min_words = _coerce_int(
+                normalized_field.get("minWords"),
+                minimum=0,
+                fallback=_DEFAULT_TEXTAREA_MIN_WORDS,
+            )
+            max_words = _coerce_int(
+                normalized_field.get("maxWords"),
+                minimum=min_words,
+                fallback=max(_DEFAULT_TEXTAREA_MAX_WORDS, min_words),
+            )
+            clean_field["minWords"] = min_words
+            clean_field["maxWords"] = max_words
+            forbid_words = normalized_field.get("forbidWords")
+            if isinstance(forbid_words, Sequence) and not isinstance(forbid_words, (str, bytes)):
+                sanitized_forbidden = [
+                    word.strip()
+                    for word in forbid_words
+                    if isinstance(word, str) and word.strip()
+                ]
+                if sanitized_forbidden:
+                    clean_field["forbidWords"] = sanitized_forbidden
+            tone = normalized_field.get("tone")
+            if isinstance(tone, str):
+                stripped_tone = tone.strip()
+                if stripped_tone:
+                    clean_field["tone"] = stripped_tone
+        elif field_type == "two_bullets":
+            clean_field["maxWordsPerBullet"] = _coerce_int(
+                normalized_field.get("maxWordsPerBullet"),
+                minimum=1,
+                fallback=_DEFAULT_TWO_BULLETS_MAX_WORDS_PER_BULLET,
+            )
 
-        normalized_fields.append(normalized_field)
+        normalized_fields.append(clean_field)
 
     if not normalized_fields:
         raise ValueError("Au moins un champ est requis pour configurer create_form_step.")

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -105,6 +105,40 @@ def test_create_form_step_includes_all_fields() -> None:
     assert config["failureMessage"] == "Mauvaise réponse, réessaie."
 
 
+def test_create_form_step_provides_defaults_for_missing_configuration() -> None:
+    step = create_form_step(
+        step_id="formulaire",
+        fields=[
+            {"id": "texte", "label": "Texte", "type": "textarea_with_counter"},
+            {"id": "liste", "label": "Liste", "type": "bulleted_list"},
+            {"id": "menu", "label": "Menu", "type": "table_menu_day", "meals": []},
+            {"id": "choix", "label": "Choix", "type": "single_choice", "options": []},
+        ],
+    )
+
+    fields = step["config"]["fields"]
+    assert len(fields) == 4
+
+    textarea = fields[0]
+    assert textarea["minWords"] == 10
+    assert textarea["maxWords"] >= 10
+    assert textarea["forbidWords"] is None
+    assert textarea["tone"] is None
+
+    bulleted = fields[1]
+    assert bulleted["minBullets"] == 2
+    assert bulleted["maxBullets"] >= 2
+    assert bulleted["maxWordsPerBullet"] == 12
+    assert bulleted["mustContainAny"] is None
+
+    table = fields[2]
+    assert table["meals"] == ["Matin", "Midi", "Soir"]
+
+    single_choice = fields[3]
+    assert len(single_choice["options"]) >= 1
+    assert single_choice["correctAnswer"] == single_choice["options"][0]["value"]
+
+
 def test_create_form_step_accepts_id_alias() -> None:
     step = create_form_step(
         id="alias",
@@ -114,9 +148,9 @@ def test_create_form_step_accepts_id_alias() -> None:
     assert step["id"] == "alias"
     field = step["config"]["fields"][0]
     assert field["type"] == "single_choice"
-    assert field["options"] is None
+    assert field["options"]
     assert field["minSelections"] is None
-    assert field["correctAnswer"] is None
+    assert field["correctAnswer"] == field["options"][0]["value"]
     assert field["correctAnswers"] is None
 
 

--- a/backend/tests/test_step_sequence_components.py
+++ b/backend/tests/test_step_sequence_components.py
@@ -79,29 +79,10 @@ def test_create_form_step_includes_all_fields() -> None:
         "failureMessage",
     }
     field = config["fields"][0]
-    assert set(field) == {
-        "id",
-        "label",
-        "type",
-        "minBullets",
-        "maxBullets",
-        "maxWordsPerBullet",
-        "mustContainAny",
-        "meals",
-        "minWords",
-        "maxWords",
-        "forbidWords",
-        "tone",
-        "options",
-        "minSelections",
-        "maxSelections",
-        "correctAnswer",
-        "correctAnswers",
-    }
-    assert field["options"][0]["description"] is None
-    assert field["minBullets"] is None
+    assert set(field) == {"id", "label", "type", "options", "correctAnswer"}
+    assert "correctAnswers" not in field
+    assert field["options"][0] == {"value": "a", "label": "Option A"}
     assert field["correctAnswer"] == "a"
-    assert field["correctAnswers"] is None
     assert config["failureMessage"] == "Mauvaise réponse, réessaie."
 
 
@@ -122,14 +103,14 @@ def test_create_form_step_provides_defaults_for_missing_configuration() -> None:
     textarea = fields[0]
     assert textarea["minWords"] == 10
     assert textarea["maxWords"] >= 10
-    assert textarea["forbidWords"] is None
-    assert textarea["tone"] is None
+    assert textarea.get("forbidWords") is None
+    assert textarea.get("tone") is None
 
     bulleted = fields[1]
     assert bulleted["minBullets"] == 2
     assert bulleted["maxBullets"] >= 2
     assert bulleted["maxWordsPerBullet"] == 12
-    assert bulleted["mustContainAny"] is None
+    assert bulleted.get("mustContainAny") is None
 
     table = fields[2]
     assert table["meals"] == ["Matin", "Midi", "Soir"]
@@ -137,6 +118,7 @@ def test_create_form_step_provides_defaults_for_missing_configuration() -> None:
     single_choice = fields[3]
     assert len(single_choice["options"]) >= 1
     assert single_choice["correctAnswer"] == single_choice["options"][0]["value"]
+    assert "correctAnswers" not in single_choice
 
 
 def test_create_form_step_accepts_id_alias() -> None:
@@ -149,9 +131,9 @@ def test_create_form_step_accepts_id_alias() -> None:
     field = step["config"]["fields"][0]
     assert field["type"] == "single_choice"
     assert field["options"]
-    assert field["minSelections"] is None
+    assert field.get("minSelections") is None
     assert field["correctAnswer"] == field["options"][0]["value"]
-    assert field["correctAnswers"] is None
+    assert field.get("correctAnswers") is None
 
 
 def test_create_video_step_preserves_sources_and_captions() -> None:


### PR DESCRIPTION
## Summary
- ensure `create_form_step` normalizes guided field configs with sensible defaults when values are missing
- generate fallback choice options and sanitize numeric/text limits so all generated questions remain visible
- add regression tests covering default hydration and updated expectations

## Testing
- pytest backend/tests/test_step_sequence_components.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbfcc7b5483229dbe2ee4f2fe9878