### PR TITLE
Fix SSE stream condition for activity generation page

### DIFF
--- a/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
@@ -423,9 +423,9 @@ export function ActivityGenerationConversationPage(): JSX.Element {
 
     const shouldStream = Boolean(
       !jobStatus ||
-        jobStatus.status === "running" ||
         jobStatus.awaitingUserAction ||
-        jobStatus.pendingToolCall
+        jobStatus.pendingToolCall ||
+        (jobStatus.status !== "complete" && jobStatus.status !== "error")
     );
 
     if (!shouldStream) {

--- a/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
+++ b/frontend/src/pages/admin/ActivityGenerationConversationPage.tsx
@@ -936,13 +936,19 @@ export function ActivityGenerationConversationPage(): JSX.Element {
         (Array.isArray(lastAssistantMessage.toolCalls) && lastAssistantMessage.toolCalls.length > 0))
   );
 
-  const conversationViewIsLoading = Boolean(
+  const awaitingFirstAssistantResponse = Boolean(
     jobId &&
-      conversation?.status === "running" &&
       !jobStatus?.awaitingUserAction &&
       !jobStatus?.pendingToolCall &&
       !lastAssistantMessageHasContent &&
-      (isStreaming || isJobLoading)
+      ((conversation && conversation.status === "running") ||
+        jobStatus?.status === "pending" ||
+        jobStatus?.status === "running")
+  );
+
+  const conversationViewIsLoading = Boolean(
+    awaitingFirstAssistantResponse &&
+      (isStreaming || isJobLoading || jobStatus?.status === "pending")
   );
 
   useEffect(() => {
@@ -1291,10 +1297,27 @@ export function ActivityGenerationConversationPage(): JSX.Element {
                 </div>
               </div>
             ) : (
-              <ConversationView
-                messages={messagesToDisplay}
-                isLoading={conversationViewIsLoading}
-              />
+              <div className="relative h-full">
+                <ConversationView
+                  messages={messagesToDisplay}
+                  isLoading={conversationViewIsLoading}
+                />
+                {awaitingFirstAssistantResponse ? (
+                  <div className="pointer-events-none absolute inset-x-0 top-6 flex justify-center px-4 sm:px-6">
+                    <div
+                      className="inline-flex items-center gap-3 rounded-full border border-sky-200/70 bg-white/95 px-4 py-2 text-xs font-medium text-sky-800 shadow-lg backdrop-blur"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <span className="relative inline-flex h-3 w-3">
+                        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400/70" />
+                        <span className="relative inline-flex h-3 w-3 rounded-full bg-sky-500" />
+                      </span>
+                      <span>L’IA prépare une première réponse...</span>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- ensure the activity generation conversation stream remains open for non-final statuses

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddc8f0a8b48322be565b861badf43f