### PR TITLE
Scope invitation codes to activities

### DIFF
--- a/backend/tests/test_admin_lti_users.py
+++ b/backend/tests/test_admin_lti_users.py
@@ -186,7 +186,9 @@ def test_invitation_consumption_and_role_creation(tmp_path) -> None:
         store.create_user_with_role("etudfail", "StudentPwd1!", "student")
 
     invitation_creator = store.generate_invitation_code("creator", code="CREATOR-XYZ")
-    invitation_student = store.generate_invitation_code("student", code="STUDENT-ABC")
+    invitation_student = store.generate_invitation_code(
+        "student", code="STUDENT-ABC", activity_id="activity-xyz"
+    )
 
     with pytest.raises(AdminStoreError):
         store.create_user_with_role(
@@ -245,16 +247,21 @@ def test_admin_invitation_endpoints(tmp_path) -> None:
 
             created = client.post(
                 "/api/admin/invitations",
-                json={"role": "student"},
+                json={"role": "student", "activityId": "activity-demo"},
             )
             assert created.status_code == 201, created.text
             payload = created.json()
             assert payload["invitation"]["role"] == "student"
             assert payload["invitation"]["code"]
+            assert payload["invitation"]["activityId"] == "activity-demo"
 
             duplicate = client.post(
                 "/api/admin/invitations",
-                json={"role": "student", "code": payload["invitation"]["code"]},
+                json={
+                    "role": "student",
+                    "code": payload["invitation"]["code"],
+                    "activityId": "activity-demo",
+                },
             )
             assert duplicate.status_code == 400
 

--- a/backend/tests/test_auth_signup.py
+++ b/backend/tests/test_auth_signup.py
@@ -64,7 +64,7 @@ def test_student_signup_requires_invitation(tmp_path) -> None:
             )
             assert missing.status_code == 422
 
-    code = store.generate_invitation_code("student").code
+    code = store.generate_invitation_code("student", activity_id="activity-test").code
 
     with override_store(store):
         with TestClient(app) as client:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -215,6 +215,8 @@ export interface AdminUser {
   createdAt?: string | null;
   updatedAt?: string | null;
   fromEnv?: boolean;
+  invitationCode?: string | null;
+  allowedActivities?: string[];
 }
 
 export interface AdminSession {
@@ -243,6 +245,7 @@ export interface AdminInvitationCode {
   createdAt: string;
   consumedAt?: string | null;
   consumedBy?: string | null;
+  activityId?: string | null;
 }
 
 export interface AdminInvitationListResponse {
@@ -252,6 +255,7 @@ export interface AdminInvitationListResponse {
 export interface AdminInvitationCreatePayload {
   role: string;
   code?: string;
+  activityId?: string;
 }
 
 export interface AdminInvitationCreateResponse {
@@ -406,6 +410,7 @@ export interface ActivityConfig {
 
 export interface ActivityConfigResponse extends ActivityConfig {
   usesDefaultFallback?: boolean;
+  allowedActivities?: string[];
 }
 
 export interface ActivityImportPayload {
@@ -523,7 +528,27 @@ export interface ActivityGenerationJobOptions {
 
 export const activities = {
   getConfig: async (): Promise<ActivityConfigResponse> =>
-    fetchJson<ActivityConfigResponse>(`${API_BASE_URL}/activities-config`),
+    fetchJson<ActivityConfigResponse>(`${API_BASE_URL}/api/activities-config`, {
+      credentials: "include",
+    }),
+};
+
+export interface StudentActivityJoinResponse {
+  activityId: string;
+  allowedActivities: string[];
+  user: AdminUser;
+}
+
+export const studentActivities = {
+  join: async (invitationCode: string): Promise<StudentActivityJoinResponse> =>
+    fetchJson<StudentActivityJoinResponse>(`${API_BASE_URL}/api/activities/join`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ invitationCode }),
+      credentials: "include",
+    }),
 };
 
 export const landingPage = {


### PR DESCRIPTION
## Summary
- scope invitation codes to activities by tracking allowed activity ids on users, validating activity-specific codes, and exposing student join endpoint
- filter activity catalogs per authenticated role and surface invitation/allowed activity data throughout backend and frontend APIs
- update frontend admin flows to require activity selection for student codes and add student UI to join activities via invitation codes

## Testing
- pytest backend/tests/test_auth_signup.py backend/tests/test_admin_lti_users.py

------
https://chatgpt.com/codex/tasks/task_e_68db2ac1ad088322aea5e6772d71a14c