### PR TITLE
Scope LTI platform management to current admin user

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -281,6 +281,7 @@ export interface AdminPlatform {
   createdAt?: string | null;
   updatedAt?: string | null;
   readOnly?: boolean;
+  ownerUsername?: string | null;
 }
 
 export interface AdminPlatformPayload {


### PR DESCRIPTION
## Summary
- add an `ownerUsername` field to stored LTI platforms with helpers to query and persist entries per admin user
- update the FastAPI admin routes to filter LTI platforms by the authenticated user and persist ownership through the LTI service
- adjust the admin React page and API typings to only list the logged-in user's platforms and lock forms when the platform belongs to someone else

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68db2ae5dcbc832289ee901206e4e651