### PR TITLE
Remove custom Explorateur IA steps

### DIFF
--- a/frontend/src/pages/explorateurIA/designerUtils.ts
+++ b/frontend/src/pages/explorateurIA/designerUtils.ts
@@ -523,38 +523,6 @@ export const QUARTER_DESIGNER_STEP_LIBRARY: QuarterDesignerStepLibraryEntry[] = 
     create: (quarter, steps) =>
       createSequenceStepFromTemplate(quarter, "form", steps),
   },
-  {
-    type: "clarte-quiz",
-    label: "Quiz Clarté",
-    description: "Question à choix multiple avec score.",
-    icon: "❓",
-    create: (quarter, steps) =>
-      createSequenceStepFromTemplate(quarter, "clarte-quiz", steps),
-  },
-  {
-    type: "creation-builder",
-    label: "Atelier Création",
-    description: "Assembler une consigne créative étape par étape.",
-    icon: "🎨",
-    create: (quarter, steps) =>
-      createSequenceStepFromTemplate(quarter, "creation-builder", steps),
-  },
-  {
-    type: "decision-path",
-    label: "Parcours Décision",
-    description: "Comparer différentes stratégies décisionnelles.",
-    icon: "🧭",
-    create: (quarter, steps) =>
-      createSequenceStepFromTemplate(quarter, "decision-path", steps),
-  },
-  {
-    type: "ethics-dilemmas",
-    label: "Dilemmes Éthique",
-    description: "Scénarios à choix pour explorer les enjeux éthiques.",
-    icon: "⚖️",
-    create: (quarter, steps) =>
-      createSequenceStepFromTemplate(quarter, "ethics-dilemmas", steps),
-  },
 ];
 
 export function getDesignerStepMeta(type: string) {

--- a/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
+++ b/frontend/src/pages/explorateurIA/worlds/world1/steps.ts
@@ -4,12 +4,6 @@ import {
 } from "../../../../modules/step-sequence";
 
 import {
-  DEFAULT_CLARTE_QUIZ_CONFIG,
-  DEFAULT_CREATION_BUILDER_CONFIG,
-  DEFAULT_DECISION_PATH_CONFIG,
-  DEFAULT_ETHICS_DILEMMAS_CONFIG,
-} from "../../modules";
-import {
   DEFAULT_EXPLORATEUR_QUARTERS,
   deriveQuarterData,
 } from "../../config";
@@ -87,11 +81,6 @@ const CLARTE_STEPS: StepDefinition[] = [
         "https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=800&q=80",
     },
   },
-  {
-    id: "clarte:quiz",
-    component: "custom",
-    config: DEFAULT_CLARTE_QUIZ_CONFIG,
-  },
 ];
 
 const CREATION_STEPS: StepDefinition[] = [
@@ -112,11 +101,6 @@ const CREATION_STEPS: StepDefinition[] = [
         ],
       },
     },
-  },
-  {
-    id: "creation:builder",
-    component: "custom",
-    config: DEFAULT_CREATION_BUILDER_CONFIG,
   },
   {
     id: "creation:reflection",
@@ -153,11 +137,6 @@ const DECISION_STEPS: StepDefinition[] = [
       body: "Expérimentez différentes stratégies et observez leurs compromis pour mener votre projet.",
     },
   },
-  {
-    id: "decision:path",
-    component: "custom",
-    config: DEFAULT_DECISION_PATH_CONFIG,
-  },
 ];
 
 const ETHIQUE_STEPS: StepDefinition[] = [
@@ -168,11 +147,6 @@ const ETHIQUE_STEPS: StepDefinition[] = [
       title: "Quartier Éthique",
       body: "Chaque scénario illustre une dérive potentielle. Sélectionnez la réponse qui protège au mieux les usagers.",
     },
-  },
-  {
-    id: "ethique:dilemmas",
-    component: "custom",
-    config: DEFAULT_ETHICS_DILEMMAS_CONFIG,
   },
   {
     id: "ethique:commitment",

--- a/frontend/tests/pages/ExplorateurIA.spec.tsx
+++ b/frontend/tests/pages/ExplorateurIA.spec.tsx
@@ -152,19 +152,14 @@ describe("Explorateur IA", () => {
     continueButton = await screen.findByRole("button", { name: /Continuer/i });
     fireEvent.click(continueButton);
 
-    const bestOption = await screen.findByRole("button", {
-      name: /Donne un plan en 5 sections sur l'énergie solaire/i,
-    });
-    fireEvent.click(bestOption);
-
-    const validateButton = await screen.findByRole("button", { name: /Valider/i });
-    fireEvent.click(validateButton);
-
     vi.runAllTimers();
     vi.useRealTimers();
 
     await waitFor(() => {
-      expect(screen.queryByRole("button", { name: /Valider/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: /Quartier Clarté/i }) ??
+          screen.queryByText(/Quartier Clarté/i)
+      ).not.toBeInTheDocument();
     });
 
     const progressionPanel = screen.getByText("Progression").closest("div");
@@ -183,8 +178,9 @@ describe("Explorateur IA", () => {
     const exportText = await storedBlobs[0].text();
     const exportData = JSON.parse(exportText);
     expect(exportData.activity).toBe("Explorateur IA");
-    expect(exportData.quarters.clarte.details.score).toBe(100);
-    expect(exportData.quarters.clarte.details.selectedOptionId).toBe("B");
-    expect(exportData.quarters.clarte.payloads["clarte:quiz"]).toBeDefined();
+    expect(exportData.quarters.clarte.payloads).toEqual({});
+    expect(exportData.quarters.clarte.details.score).toBe(0);
+    expect(exportData.quarters.clarte.details.selectedOptionId).toBeNull();
+    expect(exportData.quarters.clarte.details.explanation).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- remove the Clarté quiz, Création builder, Décision path and Éthique dilemmas from the default Explorateur IA world
- hide the removed components from the quarter designer step library
- adapt the Explorateur IA integration test to the simplified Clarté export payload

## Testing
- npm --prefix frontend test -- --run --filter=ExplorateurIA *(fails: vitest is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da83c7a05c832283e495bf1cd8bf4f